### PR TITLE
Dphan/fix examples

### DIFF
--- a/goldenmaster/apigear/olink/olinkclient.cpp
+++ b/goldenmaster/apigear/olink/olinkclient.cpp
@@ -42,7 +42,7 @@ void OLinkClient::connectToHost(QUrl url)
 {
     qDebug() << Q_FUNC_INFO << url;
     if (url.isEmpty()) {
-        QString serverUrl = qEnvironmentVariable("OLINK_SERVER", "ws://127.0.0.1:8182");
+        QString serverUrl = qEnvironmentVariable("OLINK_SERVER", "ws://127.0.0.1:8182/ws");
         m_serverUrl = QUrl(serverUrl);
     }
     else {

--- a/goldenmaster/apigear/tests/olink/olink_connection.test.cpp
+++ b/goldenmaster/apigear/tests/olink/olink_connection.test.cpp
@@ -41,7 +41,7 @@ bool checkMessageInContainer(const std::vector<QString>& container, const QStrin
 
 auto portNumber = 8000;
 QString localHostAddress =  "ws://127.0.0.1";
-QString localHostAddressWithPort = "ws://127.0.0.1:" + QString::fromStdString(std::to_string(portNumber));
+QString localHostAddressWithPort = "ws://127.0.0.1:" + QString::fromStdString(std::to_string(portNumber)) + QString("/ws");
 const std::string sink1Id = "tests.sink1";
 const std::string sink2Id = "tests.sink2";
 nlohmann::json initProperties = { {"property1", "some_string" }, { "property2",  9 }, { "property3", false } };

--- a/goldenmaster/apigear/tests/olink/olinkhost.test.cpp
+++ b/goldenmaster/apigear/tests/olink/olinkhost.test.cpp
@@ -43,7 +43,7 @@ void sendTenPropertyMessages (const std::string& propertyId, int startingPropert
 const std::string objectId = "tests.sink1";
 uint16_t portNumber = 7681;
 QString localHostAddress = "127.0.0.1";
-QUrl url("ws://127.0.0.1:7681");
+QUrl url("ws://127.0.0.1:7681/ws");
 
 nlohmann::json initProperties1 = { {"property1", "some_string1" }, { "property2",  92 }, { "property3", true } };
 nlohmann::json initProperties2 = { {"property1", "some_string2" }, { "property2",  29 }, { "property3", false } };

--- a/goldenmaster/examples/olinkclient/main.cpp
+++ b/goldenmaster/examples/olinkclient/main.cpp
@@ -39,62 +39,84 @@
 #include "testbed1/monitor/structarrayinterfacetraced.h"
 
 
+// You can run this client app together with the server side app - either also example, simulation,
+// or implemented olink server (may be in other technology) to play around with it.
+// Have in mind, that this example only instantiates the interfaces, you need to add some action to it by yourself, like:
+// changing properties or executing methods, also make sure you are subscribed for the changes and signals.
+// If you use a server example try out implementing some changes like: setting some properties or emitting signals to see any effects here.
+// Note that the server should be started first.
+// If you are running this example from qt creator make sure that the run project settings have "run in terminal" option selected.
 int main(int argc, char *argv[])
 {
-
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
     QGuiApplication app(argc, argv);
     ApiGear::ObjectLink::ClientRegistry registry;
     ApiGear::ObjectLink::OLinkClient client(registry);
-    client.connectToHost(QUrl("ws://127.0.0.1:8182"));
+    client.connectToHost(QUrl("ws://127.0.0.1:8182/ws"));
     auto testbed2ManyParamInterface = std::make_shared<testbed2::OLinkManyParamInterface>();
-    client.linkObjectSource(testbed2ManyParamInterface);testbed2::ManyParamInterfaceTraced testbed2ManyParamInterfaceTraced(testbed2ManyParamInterface );
+    client.linkObjectSource(testbed2ManyParamInterface);
+    testbed2::ManyParamInterfaceTraced testbed2ManyParamInterfaceTraced(testbed2ManyParamInterface );
     auto testbed2NestedStruct1Interface = std::make_shared<testbed2::OLinkNestedStruct1Interface>();
-    client.linkObjectSource(testbed2NestedStruct1Interface);testbed2::NestedStruct1InterfaceTraced testbed2NestedStruct1InterfaceTraced(testbed2NestedStruct1Interface );
+    client.linkObjectSource(testbed2NestedStruct1Interface);
+    testbed2::NestedStruct1InterfaceTraced testbed2NestedStruct1InterfaceTraced(testbed2NestedStruct1Interface );
     auto testbed2NestedStruct2Interface = std::make_shared<testbed2::OLinkNestedStruct2Interface>();
-    client.linkObjectSource(testbed2NestedStruct2Interface);testbed2::NestedStruct2InterfaceTraced testbed2NestedStruct2InterfaceTraced(testbed2NestedStruct2Interface );
+    client.linkObjectSource(testbed2NestedStruct2Interface);
+    testbed2::NestedStruct2InterfaceTraced testbed2NestedStruct2InterfaceTraced(testbed2NestedStruct2Interface );
     auto testbed2NestedStruct3Interface = std::make_shared<testbed2::OLinkNestedStruct3Interface>();
-    client.linkObjectSource(testbed2NestedStruct3Interface);testbed2::NestedStruct3InterfaceTraced testbed2NestedStruct3InterfaceTraced(testbed2NestedStruct3Interface );
+    client.linkObjectSource(testbed2NestedStruct3Interface);
+    testbed2::NestedStruct3InterfaceTraced testbed2NestedStruct3InterfaceTraced(testbed2NestedStruct3Interface );
     auto tbEnumEnumInterface = std::make_shared<tb_enum::OLinkEnumInterface>();
-    client.linkObjectSource(tbEnumEnumInterface);tb_enum::EnumInterfaceTraced tbEnumEnumInterfaceTraced(tbEnumEnumInterface );
+    client.linkObjectSource(tbEnumEnumInterface);
+    tb_enum::EnumInterfaceTraced tbEnumEnumInterfaceTraced(tbEnumEnumInterface );
     auto tbSame1SameStruct1Interface = std::make_shared<tb_same1::OLinkSameStruct1Interface>();
-    client.linkObjectSource(tbSame1SameStruct1Interface);tb_same1::SameStruct1InterfaceTraced tbSame1SameStruct1InterfaceTraced(tbSame1SameStruct1Interface );
+    client.linkObjectSource(tbSame1SameStruct1Interface);
+    tb_same1::SameStruct1InterfaceTraced tbSame1SameStruct1InterfaceTraced(tbSame1SameStruct1Interface );
     auto tbSame1SameStruct2Interface = std::make_shared<tb_same1::OLinkSameStruct2Interface>();
-    client.linkObjectSource(tbSame1SameStruct2Interface);tb_same1::SameStruct2InterfaceTraced tbSame1SameStruct2InterfaceTraced(tbSame1SameStruct2Interface );
+    client.linkObjectSource(tbSame1SameStruct2Interface);
+    tb_same1::SameStruct2InterfaceTraced tbSame1SameStruct2InterfaceTraced(tbSame1SameStruct2Interface );
     auto tbSame1SameEnum1Interface = std::make_shared<tb_same1::OLinkSameEnum1Interface>();
-    client.linkObjectSource(tbSame1SameEnum1Interface);tb_same1::SameEnum1InterfaceTraced tbSame1SameEnum1InterfaceTraced(tbSame1SameEnum1Interface );
+    client.linkObjectSource(tbSame1SameEnum1Interface);
+    tb_same1::SameEnum1InterfaceTraced tbSame1SameEnum1InterfaceTraced(tbSame1SameEnum1Interface );
     auto tbSame1SameEnum2Interface = std::make_shared<tb_same1::OLinkSameEnum2Interface>();
-    client.linkObjectSource(tbSame1SameEnum2Interface);tb_same1::SameEnum2InterfaceTraced tbSame1SameEnum2InterfaceTraced(tbSame1SameEnum2Interface );
+    client.linkObjectSource(tbSame1SameEnum2Interface);
+    tb_same1::SameEnum2InterfaceTraced tbSame1SameEnum2InterfaceTraced(tbSame1SameEnum2Interface );
     auto tbSame2SameStruct1Interface = std::make_shared<tb_same2::OLinkSameStruct1Interface>();
-    client.linkObjectSource(tbSame2SameStruct1Interface);tb_same2::SameStruct1InterfaceTraced tbSame2SameStruct1InterfaceTraced(tbSame2SameStruct1Interface );
+    client.linkObjectSource(tbSame2SameStruct1Interface);
+    tb_same2::SameStruct1InterfaceTraced tbSame2SameStruct1InterfaceTraced(tbSame2SameStruct1Interface );
     auto tbSame2SameStruct2Interface = std::make_shared<tb_same2::OLinkSameStruct2Interface>();
-    client.linkObjectSource(tbSame2SameStruct2Interface);tb_same2::SameStruct2InterfaceTraced tbSame2SameStruct2InterfaceTraced(tbSame2SameStruct2Interface );
+    client.linkObjectSource(tbSame2SameStruct2Interface);
+    tb_same2::SameStruct2InterfaceTraced tbSame2SameStruct2InterfaceTraced(tbSame2SameStruct2Interface );
     auto tbSame2SameEnum1Interface = std::make_shared<tb_same2::OLinkSameEnum1Interface>();
-    client.linkObjectSource(tbSame2SameEnum1Interface);tb_same2::SameEnum1InterfaceTraced tbSame2SameEnum1InterfaceTraced(tbSame2SameEnum1Interface );
+    client.linkObjectSource(tbSame2SameEnum1Interface);
+    tb_same2::SameEnum1InterfaceTraced tbSame2SameEnum1InterfaceTraced(tbSame2SameEnum1Interface );
     auto tbSame2SameEnum2Interface = std::make_shared<tb_same2::OLinkSameEnum2Interface>();
-    client.linkObjectSource(tbSame2SameEnum2Interface);tb_same2::SameEnum2InterfaceTraced tbSame2SameEnum2InterfaceTraced(tbSame2SameEnum2Interface );
+    client.linkObjectSource(tbSame2SameEnum2Interface);
+    tb_same2::SameEnum2InterfaceTraced tbSame2SameEnum2InterfaceTraced(tbSame2SameEnum2Interface );
     auto tbSimpleSimpleInterface = std::make_shared<tb_simple::OLinkSimpleInterface>();
-    client.linkObjectSource(tbSimpleSimpleInterface);tb_simple::SimpleInterfaceTraced tbSimpleSimpleInterfaceTraced(tbSimpleSimpleInterface );
+    client.linkObjectSource(tbSimpleSimpleInterface);
+    tb_simple::SimpleInterfaceTraced tbSimpleSimpleInterfaceTraced(tbSimpleSimpleInterface );
     auto tbSimpleSimpleArrayInterface = std::make_shared<tb_simple::OLinkSimpleArrayInterface>();
-    client.linkObjectSource(tbSimpleSimpleArrayInterface);tb_simple::SimpleArrayInterfaceTraced tbSimpleSimpleArrayInterfaceTraced(tbSimpleSimpleArrayInterface );
+    client.linkObjectSource(tbSimpleSimpleArrayInterface);
+    tb_simple::SimpleArrayInterfaceTraced tbSimpleSimpleArrayInterfaceTraced(tbSimpleSimpleArrayInterface );
     auto testbed1StructInterface = std::make_shared<testbed1::OLinkStructInterface>();
-    client.linkObjectSource(testbed1StructInterface);testbed1::StructInterfaceTraced testbed1StructInterfaceTraced(testbed1StructInterface );
+    client.linkObjectSource(testbed1StructInterface);
+    testbed1::StructInterfaceTraced testbed1StructInterfaceTraced(testbed1StructInterface );
     auto testbed1StructArrayInterface = std::make_shared<testbed1::OLinkStructArrayInterface>();
-    client.linkObjectSource(testbed1StructArrayInterface);testbed1::StructArrayInterfaceTraced testbed1StructArrayInterfaceTraced(testbed1StructArrayInterface );
+    client.linkObjectSource(testbed1StructArrayInterface);
+    testbed1::StructArrayInterfaceTraced testbed1StructArrayInterfaceTraced(testbed1StructArrayInterface );
 
-    QQmlApplicationEngine engine;
-    const QUrl url(QStringLiteral("qrc:/main.qml"));
-    QObject::connect(&engine,
-                     &QQmlApplicationEngine::objectCreated,
-                     &app,
-                     [url](QObject *obj, const QUrl &objUrl) {
-                       if (!obj && url == objUrl)
-                        QCoreApplication::exit(-1);
-                     },
-                     Qt::QueuedConnection);
-    engine.load(url);
+    
+    // Try out properties: subscribe for changes
+    testbed2ManyParamInterfaceTraced.connect(&testbed2ManyParamInterfaceTraced, &testbed2::AbstractManyParamInterface::prop1Changed, []( int prop1){ qDebug() << "prop1 property changed ";});
+    // or ask for change.
+    auto local_prop1 = 0;
+    testbed2ManyParamInterfaceTraced.setProp1(local_prop1);
+    
+    // Check the signals with subscribing for its change
+    testbed2ManyParamInterfaceTraced.connect(&testbed2ManyParamInterfaceTraced, &testbed2::AbstractManyParamInterface::sig1, [](int param1){ qDebug() << "sig1 signal emitted ";});
+    
+    // Play around executing your operations
+    auto method_result = testbed2ManyParamInterfaceTraced.func1(0);
+    
 
     auto result = app.exec();
     client.unlinkObjectSource(testbed2ManyParamInterface->olinkObjectName());

--- a/goldenmaster/examples/olinkserver/main.cpp
+++ b/goldenmaster/examples/olinkserver/main.cpp
@@ -58,9 +58,16 @@
 
 #include <iostream>
 
-int main(){
+// You can run this server app together with the client side app - either also example,
+// or implemented olink client (may be using other technology) to play around with it.
+// Have in mind, that this example only instantiates the interfaces and the services.
+// To see results make sure the clients are sending request to server or add some actions by yourself.
+// Note that the server should be started before the client apps.
+// If you are running this example from qt creator make sure that the run project settings have "run in terminal" option selected.
 
-    ApiGear::ObjectLink::RemoteRegistry registry;
+int main(int argc, char *argv[]){
+
+    QCoreApplication app(argc, argv);  ApiGear::ObjectLink::RemoteRegistry registry;
     ApiGear::ObjectLink::OLinkHost server(registry);
     server.listen("localhost", 8182);
     auto testbed2ManyParamInterface = std::make_shared<testbed2::ManyParamInterface>();
@@ -132,6 +139,7 @@ int main(){
     auto testbed1OlinkStructArrayInterfaceService = std::make_shared<testbed1::OLinkStructArrayInterfaceAdapter>(registry, &testbed1StructArrayInterfaceTraced);
     registry.addSource(testbed1OlinkStructArrayInterfaceService);
 
+    auto result = app.exec();
     // Use the server.
     registry.removeSource(testbed2OlinkManyParamInterfaceService->olinkObjectName());
     registry.removeSource(testbed2OlinkNestedStruct1InterfaceService->olinkObjectName());
@@ -150,5 +158,5 @@ int main(){
     registry.removeSource(tbSimpleOlinkSimpleArrayInterfaceService->olinkObjectName());
     registry.removeSource(testbed1OlinkStructInterfaceService->olinkObjectName());
     registry.removeSource(testbed1OlinkStructArrayInterfaceService->olinkObjectName());
-    return 0;
+    return result;
 }

--- a/goldenmaster/examples/qml/main.cpp
+++ b/goldenmaster/examples/qml/main.cpp
@@ -185,7 +185,7 @@ int main(int argc, char *argv[]){
     registry.addSource(testbed1OlinkStructArrayInterfaceService);
 
     // With services ready connect the client - all qml olink clients will be linked
-    client.connectToHost(QUrl("ws://127.0.0.1:8182"));
+    client.connectToHost(QUrl("ws://127.0.0.1:8182/ws"));
 
     /**
     * You may want to try out the bindings in qml for your interface

--- a/templates/apigear/olink/olinkclient.cpp
+++ b/templates/apigear/olink/olinkclient.cpp
@@ -42,7 +42,7 @@ void OLinkClient::connectToHost(QUrl url)
 {
     qDebug() << Q_FUNC_INFO << url;
     if (url.isEmpty()) {
-        QString serverUrl = qEnvironmentVariable("OLINK_SERVER", "ws://127.0.0.1:8182");
+        QString serverUrl = qEnvironmentVariable("OLINK_SERVER", "ws://127.0.0.1:8182/ws");
         m_serverUrl = QUrl(serverUrl);
     }
     else {

--- a/templates/apigear/tests/olink/olink_connection.test.cpp
+++ b/templates/apigear/tests/olink/olink_connection.test.cpp
@@ -41,7 +41,7 @@ bool checkMessageInContainer(const std::vector<QString>& container, const QStrin
 
 auto portNumber = 8000;
 QString localHostAddress =  "ws://127.0.0.1";
-QString localHostAddressWithPort = "ws://127.0.0.1:" + QString::fromStdString(std::to_string(portNumber));
+QString localHostAddressWithPort = "ws://127.0.0.1:" + QString::fromStdString(std::to_string(portNumber)) + QString("/ws");
 const std::string sink1Id = "tests.sink1";
 const std::string sink2Id = "tests.sink2";
 nlohmann::json initProperties = { {"property1", "some_string" }, { "property2",  9 }, { "property3", false } };

--- a/templates/apigear/tests/olink/olinkhost.test.cpp
+++ b/templates/apigear/tests/olink/olinkhost.test.cpp
@@ -43,7 +43,7 @@ void sendTenPropertyMessages (const std::string& propertyId, int startingPropert
 const std::string objectId = "tests.sink1";
 uint16_t portNumber = 7681;
 QString localHostAddress = "127.0.0.1";
-QUrl url("ws://127.0.0.1:7681");
+QUrl url("ws://127.0.0.1:7681/ws");
 
 nlohmann::json initProperties1 = { {"property1", "some_string1" }, { "property2",  92 }, { "property3", true } };
 nlohmann::json initProperties2 = { {"property1", "some_string2" }, { "property2",  29 }, { "property3", false } };

--- a/templates/examples/olinkclient/main.cpp.tpl
+++ b/templates/examples/olinkclient/main.cpp.tpl
@@ -16,16 +16,19 @@
 {{- end }}
 
 
+// You can run this client app together with the server side app - either also example, simulation,
+// or implemented olink server (may be in other technology) to play around with it.
+// Have in mind, that this example only instantiates the interfaces, you need to add some action to it by yourself, like:
+// changing properties or executing methods, also make sure you are subscribed for the changes and signals.
+// If you use a server example try out implementing some changes like: setting some properties or emitting signals to see any effects here.
+// Note that the server should be started first.
+// If you are running this example from qt creator make sure that the run project settings have "run in terminal" option selected.
 int main(int argc, char *argv[])
 {
-
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
     QGuiApplication app(argc, argv);
     ApiGear::ObjectLink::ClientRegistry registry;
     ApiGear::ObjectLink::OLinkClient client(registry);
-    client.connectToHost(QUrl("ws://127.0.0.1:8182"));
+    client.connectToHost(QUrl("ws://127.0.0.1:8182/ws"));
 
     {{- range.System.Modules }}
     {{- $module := . }}
@@ -37,22 +40,62 @@ int main(int argc, char *argv[])
     auto {{$clientClassName}} = std::make_shared< {{- snake $module.Name }}::OLink{{$interface.Name -}} >();
     client.linkObjectSource({{ $clientClassName }});
     {{- if $features.monitor }}
-    {{- snake $module.Name }}::{{$class}}Traced {{$clientClassName}}Traced({{$clientClassName}} );
+    {{ snake $module.Name }}::{{$class}}Traced {{$clientClassName}}Traced({{$clientClassName}} );
     {{- end }}
     {{- end }}
     {{- end }}
 
-    QQmlApplicationEngine engine;
-    const QUrl url(QStringLiteral("qrc:/main.qml"));
-    QObject::connect(&engine,
-                     &QQmlApplicationEngine::objectCreated,
-                     &app,
-                     [url](QObject *obj, const QUrl &objUrl) {
-                       if (!obj && url == objUrl)
-                        QCoreApplication::exit(-1);
-                     },
-                     Qt::QueuedConnection);
-    engine.load(url);
+    {{ $propertyExampleReady := 0 -}}
+    {{ $signalExampleReady := 0 -}}
+    {{ $operationExampleReady := 0 -}}
+    {{- range.System.Modules -}}
+    {{- $module := . -}}
+    {{- range $module.Interfaces -}}
+    {{- $interface := . -}}
+
+        {{- $class := printf "Abstract%s" (Camel .Name) -}}
+        {{- $modulePrefix := lower1 (Camel $module.Name) -}}
+        {{- $namespacePrefix := printf "%s::" (snake $module.Name) -}}
+        {{- $clientClassNameCall := printf "%s%s->"  $modulePrefix (Camel $interface.Name) -}}
+        {{- $clientClassNameGetPtr := printf "%s%s.get()"  $modulePrefix (Camel $interface.Name) -}}
+        {{- if $features.monitor -}}
+            {{- $clientClassNameCall = printf "%s%sTraced."  $modulePrefix (Camel $interface.Name) -}}
+            {{- $clientClassNameGetPtr = printf "&%s%sTraced"  $modulePrefix (Camel $interface.Name) -}}
+        {{- end -}}
+
+{{- if (and (eq $propertyExampleReady  0)  (len $interface.Properties) )}}
+    {{- $property := (index $interface.Properties 0) }}
+    // Try out properties: subscribe for changes
+    {{$clientClassNameCall}}connect({{$clientClassNameGetPtr}}, &{{ snake $module.Name }}::{{$class}}::{{$property.Name}}Changed, []( {{qtParam $namespacePrefix $property}}){ qDebug() << "{{$property.Name}} property changed ";});
+    // or ask for change.
+    auto local_{{$property.Name}} = {{qtDefault $namespacePrefix $property}};
+    {{$clientClassNameCall}}set{{Camel $property.Name}}(local_{{$property.Name}});
+    {{ $propertyExampleReady = 1}}
+{{- end }}
+{{- if (and (eq $signalExampleReady  0)  (len $interface.Signals))}}
+    // Check the signals with subscribing for its change
+    {{- $signal := (index $interface.Signals 0 ) }}
+    {{$clientClassNameCall}}connect({{$clientClassNameGetPtr}}, &{{ snake $module.Name }}::{{$class}}::{{camel $signal.Name}}, []({{qtParams $namespacePrefix $signal.Params}}){ qDebug() << "{{camel $signal.Name}} signal emitted ";});
+    {{ $signalExampleReady = 1}}
+{{- end }}
+
+{{- if ( and (eq $operationExampleReady  0) (len $interface.Operations))}}
+    {{- $operation := (index $interface.Operations 0) }}
+    // Play around executing your operations
+    {{ if (not $operation.Return.IsVoid) }}auto method_result = {{ end }}{{$clientClassNameCall}}{{camel $operation.Name}}(
+                {{- range $i, $e := $operation.Params }}
+                    {{- if $i }}, {{ end }}{{qtDefault $namespacePrefix $e}}
+                {{- end }}   {{- /* end range operation param*/ -}} );
+    {{ $operationExampleReady = 1}}
+{{- end }}
+{{- if (and (and $operationExampleReady  $signalExampleReady)  $propertyExampleReady)}}
+    {{- break}}
+{{- end }}
+{{- end}}{{/* end range over interfaces*/}}
+{{- if (and (and $operationExampleReady  $signalExampleReady)  $propertyExampleReady)}}
+    {{- break}}
+{{- end }}
+{{- end}}{{/* end range over modules*/}}
 
     auto result = app.exec();
 

--- a/templates/examples/olinkserver/main.cpp.tpl
+++ b/templates/examples/olinkserver/main.cpp.tpl
@@ -18,9 +18,16 @@
 
 #include <iostream>
 
-int main(){
+// You can run this server app together with the client side app - either also example,
+// or implemented olink client (may be using other technology) to play around with it.
+// Have in mind, that this example only instantiates the interfaces and the services.
+// To see results make sure the clients are sending request to server or add some actions by yourself.
+// Note that the server should be started before the client apps.
+// If you are running this example from qt creator make sure that the run project settings have "run in terminal" option selected.
 
-    ApiGear::ObjectLink::RemoteRegistry registry;
+int main(int argc, char *argv[]){
+
+    QCoreApplication app(argc, argv);  ApiGear::ObjectLink::RemoteRegistry registry;
     ApiGear::ObjectLink::OLinkHost server(registry);
     server.listen("localhost", 8182);
 
@@ -43,8 +50,8 @@ int main(){
     {{- end }}
     {{- end }}
 
+    auto result = app.exec();
     // Use the server.
-
 
     {{- range.System.Modules }}
     {{- $module := . }}
@@ -56,5 +63,5 @@ int main(){
     registry.removeSource( {{- $serviceInstanceName }}->olinkObjectName());
     {{- end }}
     {{- end }}
-    return 0;
+    return result;
 }

--- a/templates/examples/qml/main.cpp.tpl
+++ b/templates/examples/qml/main.cpp.tpl
@@ -85,7 +85,7 @@ int main(int argc, char *argv[]){
     {{- end }}
 
     // With services ready connect the client - all qml olink clients will be linked
-    client.connectToHost(QUrl("ws://127.0.0.1:8182"));
+    client.connectToHost(QUrl("ws://127.0.0.1:8182/ws"));
 
     /**
     * You may want to try out the bindings in qml for your interface


### PR DESCRIPTION
Cleanup examples:
client and server are now console applications - with use of qt engine, which is necessary for connections
add few words of documentation to main.cpp
align missing "ws" in connection address