### PR TITLE
Dphan/build fixes

### DIFF
--- a/goldenmaster/apigear/monitor/CMakeLists.txt
+++ b/goldenmaster/apigear/monitor/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 include(FetchContent)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
+find_package(Qt5 REQUIRED COMPONENTS Core WebSockets)
 
 
 set (SOURCES
@@ -29,7 +29,7 @@ target_include_directories(monitor_qt
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(monitor_qt PUBLIC Qt5::Core Qt5::Qml Qt5::WebSockets)
+target_link_libraries(monitor_qt PUBLIC Qt5::Core Qt5::WebSockets)
 target_compile_definitions(monitor_qt PRIVATE COMPILING_MONITOR_QT)
 
 # install binary files

--- a/goldenmaster/apigear/monitor/CMakeLists.txt
+++ b/goldenmaster/apigear/monitor/CMakeLists.txt
@@ -21,9 +21,11 @@ add_library(apigear::monitor_qt ALIAS monitor_qt)
 
 
 target_include_directories(monitor_qt
-    PUBLIC
+    PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     $<INSTALL_INTERFACE:include>
 )
 

--- a/goldenmaster/apigear/olink/CMakeLists.txt
+++ b/goldenmaster/apigear/olink/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 include(FetchContent)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
+find_package(Qt5 REQUIRED COMPONENTS Core WebSockets)
 
 find_package(apigear QUIET COMPONENTS olink_core)
 if(NOT olink_core_FOUND)
@@ -42,7 +42,7 @@ target_include_directories(olink_qt
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(olink_qt PUBLIC olink_core Qt5::Core Qt5::Qml Qt5::WebSockets)
+target_link_libraries(olink_qt PUBLIC olink_core Qt5::Core Qt5::WebSockets)
 target_compile_definitions(olink_qt PRIVATE OLINK_QT)
 
 # install binary files

--- a/goldenmaster/apigear/tests/olink/CMakeLists.txt
+++ b/goldenmaster/apigear/tests/olink/CMakeLists.txt
@@ -39,19 +39,6 @@ FetchContent_MakeAvailable(Catch2 trompeloeil)
 
 find_package(Catch2 REQUIRED)
 
-find_package(olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
-
 set(CMAKE_CTEST_COMMAND ctest -V)
 if(NOT TARGET check)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
@@ -78,7 +65,6 @@ add_test(test_olink test_olink)
 add_dependencies(check test_olink)
 
 target_link_libraries(test_olink PRIVATE
-    olink_core
     olink_qt
     Catch2::Catch2
     trompeloeil::trompeloeil

--- a/goldenmaster/apigear/tests/olink/CMakeLists.txt
+++ b/goldenmaster/apigear/tests/olink/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(test_olink PRIVATE
     olink_qt
     Catch2::Catch2
     trompeloeil::trompeloeil
-    Qt::Test Qt5::Core Qt5::Qml Qt5::WebSockets)
+    Qt::Test)
 
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
 include(Catch)

--- a/goldenmaster/examples/olinkclient/CMakeLists.txt
+++ b/goldenmaster/examples/olinkclient/CMakeLists.txt
@@ -2,20 +2,6 @@ project(OLinkClient)
 cmake_minimum_required(VERSION 3.20)
 
 find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets Gui)
-find_package(apigear QUIET COMPONENTS olink_qt)
-
-find_package(apigear QUIET COMPONENTS olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
 
 # append local binary directory for conan packages to be found
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR} ${CMAKE_MODULE_PATH})
@@ -63,8 +49,6 @@ target_link_libraries(OLinkClient
     testbed1_olink
     testbed1_monitor
 Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui
-olink_qt
-olink_core
 monitor_qt
 )
 install(TARGETS OLinkClient

--- a/goldenmaster/examples/olinkclient/CMakeLists.txt
+++ b/goldenmaster/examples/olinkclient/CMakeLists.txt
@@ -65,6 +65,7 @@ target_link_libraries(OLinkClient
 Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui
 olink_qt
 olink_core
+monitor_qt
 )
 install(TARGETS OLinkClient
         RUNTIME DESTINATION bin COMPONENT Runtime)

--- a/goldenmaster/examples/olinkclient/CMakeLists.txt
+++ b/goldenmaster/examples/olinkclient/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(OLinkClient)
 cmake_minimum_required(VERSION 3.20)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets Gui)
+find_package(Qt5 REQUIRED COMPONENTS Gui)
 
 # append local binary directory for conan packages to be found
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR} ${CMAKE_MODULE_PATH})
@@ -48,7 +48,7 @@ target_link_libraries(OLinkClient
     testbed1_impl
     testbed1_olink
     testbed1_monitor
-Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui
+Qt5::Gui
 monitor_qt
 )
 install(TARGETS OLinkClient

--- a/goldenmaster/examples/olinkclient/CMakeLists.txt
+++ b/goldenmaster/examples/olinkclient/CMakeLists.txt
@@ -49,7 +49,6 @@ target_link_libraries(OLinkClient
     testbed1_olink
     testbed1_monitor
 Qt5::Gui
-monitor_qt
 )
 install(TARGETS OLinkClient
         RUNTIME DESTINATION bin COMPONENT Runtime)

--- a/goldenmaster/examples/olinkserver/CMakeLists.txt
+++ b/goldenmaster/examples/olinkserver/CMakeLists.txt
@@ -15,20 +15,6 @@ add_executable(OLinkServer
 )
 
 find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets Gui)
-find_package(apigear QUIET COMPONENTS olink_qt)
-
-find_package(apigear QUIET COMPONENTS olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
 
 
 find_package(testbed2 QUIET COMPONENTS testbed2_api testbed2_impl testbed2_olink testbed2_monitor)
@@ -63,11 +49,8 @@ target_link_libraries(OLinkServer
     testbed1_olink
     testbed1_monitor
 Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui
-olink_qt
-olink_core
 monitor_qt
 )
-
 
 install(TARGETS OLinkServer
         RUNTIME DESTINATION bin COMPONENT Runtime)

--- a/goldenmaster/examples/olinkserver/CMakeLists.txt
+++ b/goldenmaster/examples/olinkserver/CMakeLists.txt
@@ -42,7 +42,6 @@ target_link_libraries(OLinkServer
     testbed1_impl
     testbed1_olink
     testbed1_monitor
-monitor_qt
 )
 
 install(TARGETS OLinkServer

--- a/goldenmaster/examples/olinkserver/CMakeLists.txt
+++ b/goldenmaster/examples/olinkserver/CMakeLists.txt
@@ -17,34 +17,28 @@ add_executable(OLinkServer
 find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets Gui)
 
 
-find_package(testbed2 QUIET COMPONENTS testbed2_api testbed2_impl testbed2_olink testbed2_monitor)
-find_package(tb_enum QUIET COMPONENTS tb_enum_api tb_enum_impl tb_enum_olink tb_enum_monitor)
-find_package(tb_same1 QUIET COMPONENTS tb_same1_api tb_same1_impl tb_same1_olink tb_same1_monitor)
-find_package(tb_same2 QUIET COMPONENTS tb_same2_api tb_same2_impl tb_same2_olink tb_same2_monitor)
-find_package(tb_simple QUIET COMPONENTS tb_simple_api tb_simple_impl tb_simple_olink tb_simple_monitor)
-find_package(testbed1 QUIET COMPONENTS testbed1_api testbed1_impl testbed1_olink testbed1_monitor)
+find_package(testbed2 QUIET COMPONENTS testbed2_impl testbed2_olink testbed2_monitor)
+find_package(tb_enum QUIET COMPONENTS tb_enum_impl tb_enum_olink tb_enum_monitor)
+find_package(tb_same1 QUIET COMPONENTS tb_same1_impl tb_same1_olink tb_same1_monitor)
+find_package(tb_same2 QUIET COMPONENTS tb_same2_impl tb_same2_olink tb_same2_monitor)
+find_package(tb_simple QUIET COMPONENTS tb_simple_impl tb_simple_olink tb_simple_monitor)
+find_package(testbed1 QUIET COMPONENTS testbed1_impl testbed1_olink testbed1_monitor)
 target_link_libraries(OLinkServer
-    testbed2_api
     testbed2_impl
     testbed2_olink
     testbed2_monitor
-    tb_enum_api
     tb_enum_impl
     tb_enum_olink
     tb_enum_monitor
-    tb_same1_api
     tb_same1_impl
     tb_same1_olink
     tb_same1_monitor
-    tb_same2_api
     tb_same2_impl
     tb_same2_olink
     tb_same2_monitor
-    tb_simple_api
     tb_simple_impl
     tb_simple_olink
     tb_simple_monitor
-    testbed1_api
     testbed1_impl
     testbed1_olink
     testbed1_monitor

--- a/goldenmaster/examples/olinkserver/CMakeLists.txt
+++ b/goldenmaster/examples/olinkserver/CMakeLists.txt
@@ -48,7 +48,6 @@ target_link_libraries(OLinkServer
     testbed1_impl
     testbed1_olink
     testbed1_monitor
-Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui
 monitor_qt
 )
 

--- a/goldenmaster/examples/olinkserver/CMakeLists.txt
+++ b/goldenmaster/examples/olinkserver/CMakeLists.txt
@@ -65,6 +65,7 @@ target_link_libraries(OLinkServer
 Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui
 olink_qt
 olink_core
+monitor_qt
 )
 
 

--- a/goldenmaster/examples/qml/CMakeLists.txt
+++ b/goldenmaster/examples/qml/CMakeLists.txt
@@ -77,6 +77,7 @@ target_link_libraries(QmlExamlple
 Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui Qt5::Quick Qt5::QuickControls2 Qt5::QuickWidgets
 olink_qt
 olink_core
+monitor_qt
 )
 
 

--- a/goldenmaster/examples/qml/CMakeLists.txt
+++ b/goldenmaster/examples/qml/CMakeLists.txt
@@ -20,7 +20,7 @@ add_executable(QmlExamlple
     ${SOURCES}
 )
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets Gui Quick QuickControls2 QuickWidgets)
+find_package(Qt5 REQUIRED COMPONENTS Gui Quick QuickControls2 QuickWidgets)
 
 
 find_package(testbed2 QUIET COMPONENTS testbed2_api testbed2_impl testbed2_olink plugin_testbed2 testbed2_monitor)
@@ -60,7 +60,7 @@ target_link_libraries(QmlExamlple
     testbed1_olink
     plugin_testbed1
     testbed1_monitor
-Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui Qt5::Quick Qt5::QuickControls2 Qt5::QuickWidgets
+Qt5::Gui Qt5::Quick Qt5::QuickControls2 Qt5::QuickWidgets
 monitor_qt
 )
 

--- a/goldenmaster/examples/qml/CMakeLists.txt
+++ b/goldenmaster/examples/qml/CMakeLists.txt
@@ -21,20 +21,6 @@ add_executable(QmlExamlple
 )
 
 find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets Gui Quick QuickControls2 QuickWidgets)
-find_package(apigear QUIET COMPONENTS olink_qt)
-
-find_package(apigear QUIET COMPONENTS olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
 
 
 find_package(testbed2 QUIET COMPONENTS testbed2_api testbed2_impl testbed2_olink plugin_testbed2 testbed2_monitor)
@@ -75,8 +61,6 @@ target_link_libraries(QmlExamlple
     plugin_testbed1
     testbed1_monitor
 Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui Qt5::Quick Qt5::QuickControls2 Qt5::QuickWidgets
-olink_qt
-olink_core
 monitor_qt
 )
 

--- a/goldenmaster/examples/qml/CMakeLists.txt
+++ b/goldenmaster/examples/qml/CMakeLists.txt
@@ -55,7 +55,6 @@ target_link_libraries(QmlExamlple
     plugin_testbed1
     testbed1_monitor
 Qt5::Gui Qt5::Quick Qt5::QuickControls2 Qt5::QuickWidgets
-monitor_qt
 )
 
 

--- a/goldenmaster/examples/qml/CMakeLists.txt
+++ b/goldenmaster/examples/qml/CMakeLists.txt
@@ -23,39 +23,33 @@ add_executable(QmlExamlple
 find_package(Qt5 REQUIRED COMPONENTS Gui Quick QuickControls2 QuickWidgets)
 
 
-find_package(testbed2 QUIET COMPONENTS testbed2_api testbed2_impl testbed2_olink plugin_testbed2 testbed2_monitor)
-find_package(tb_enum QUIET COMPONENTS tb_enum_api tb_enum_impl tb_enum_olink plugin_tb_enum tb_enum_monitor)
-find_package(tb_same1 QUIET COMPONENTS tb_same1_api tb_same1_impl tb_same1_olink plugin_tb_same1 tb_same1_monitor)
-find_package(tb_same2 QUIET COMPONENTS tb_same2_api tb_same2_impl tb_same2_olink plugin_tb_same2 tb_same2_monitor)
-find_package(tb_simple QUIET COMPONENTS tb_simple_api tb_simple_impl tb_simple_olink plugin_tb_simple tb_simple_monitor)
-find_package(testbed1 QUIET COMPONENTS testbed1_api testbed1_impl testbed1_olink plugin_testbed1 testbed1_monitor)
+find_package(testbed2 QUIET COMPONENTS testbed2_impl testbed2_olink plugin_testbed2 testbed2_monitor)
+find_package(tb_enum QUIET COMPONENTS tb_enum_impl tb_enum_olink plugin_tb_enum tb_enum_monitor)
+find_package(tb_same1 QUIET COMPONENTS tb_same1_impl tb_same1_olink plugin_tb_same1 tb_same1_monitor)
+find_package(tb_same2 QUIET COMPONENTS tb_same2_impl tb_same2_olink plugin_tb_same2 tb_same2_monitor)
+find_package(tb_simple QUIET COMPONENTS tb_simple_impl tb_simple_olink plugin_tb_simple tb_simple_monitor)
+find_package(testbed1 QUIET COMPONENTS testbed1_impl testbed1_olink plugin_testbed1 testbed1_monitor)
 target_link_libraries(QmlExamlple
-    testbed2_api
     testbed2_impl
     testbed2_olink
     plugin_testbed2
     testbed2_monitor
-    tb_enum_api
     tb_enum_impl
     tb_enum_olink
     plugin_tb_enum
     tb_enum_monitor
-    tb_same1_api
     tb_same1_impl
     tb_same1_olink
     plugin_tb_same1
     tb_same1_monitor
-    tb_same2_api
     tb_same2_impl
     tb_same2_olink
     plugin_tb_same2
     tb_same2_monitor
-    tb_simple_api
     tb_simple_impl
     tb_simple_olink
     plugin_tb_simple
     tb_simple_monitor
-    testbed1_api
     testbed1_impl
     testbed1_olink
     plugin_testbed1

--- a/goldenmaster/tb_enum/api/CMakeLists.txt
+++ b/goldenmaster/tb_enum/api/CMakeLists.txt
@@ -4,7 +4,7 @@ project(tb_enum_api LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml WebSockets)
+find_package(Qt5 REQUIRED COMPONENTS Core Qml)
 
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
@@ -40,6 +40,9 @@ target_include_directories(tb_enum_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_enum_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets
-PUBLIC nlohmann_json::nlohmann_json)
+target_link_libraries(tb_enum_api PUBLIC
+Qt5::Core
+Qt5::Qml
+nlohmann_json::nlohmann_json)
+
 target_compile_definitions(tb_enum_api PRIVATE TB_ENUM_API_LIBRARY)

--- a/goldenmaster/tb_enum/api/CMakeLists.txt
+++ b/goldenmaster/tb_enum/api/CMakeLists.txt
@@ -40,5 +40,6 @@ target_include_directories(tb_enum_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_enum_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets nlohmann_json::nlohmann_json)
+target_link_libraries(tb_enum_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets
+PUBLIC nlohmann_json::nlohmann_json)
 target_compile_definitions(tb_enum_api PRIVATE TB_ENUM_API_LIBRARY)

--- a/goldenmaster/tb_enum/http/CMakeLists.txt
+++ b/goldenmaster/tb_enum/http/CMakeLists.txt
@@ -4,7 +4,7 @@ project(tb_enum_http LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network)
+find_package(Qt5 REQUIRED COMPONENTS Network)
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set (TB_ENUM_HTTP_SOURCES
@@ -16,4 +16,4 @@ set (TB_ENUM_HTTP_SOURCES
 
 add_library(tb_enum_http STATIC ${TB_ENUM_HTTP_SOURCES})
 target_include_directories(tb_enum_http PRIVATE ../tb_enum)
-target_link_libraries(tb_enum_http PRIVATE Qt5::Core Qt5::Qml Qt5::Network tb_enum_api)
+target_link_libraries(tb_enum_http PRIVATE Qt5::Network tb_enum_api)

--- a/goldenmaster/tb_enum/http/CMakeLists.txt
+++ b/goldenmaster/tb_enum/http/CMakeLists.txt
@@ -16,4 +16,4 @@ set (TB_ENUM_HTTP_SOURCES
 
 add_library(tb_enum_http STATIC ${TB_ENUM_HTTP_SOURCES})
 target_include_directories(tb_enum_http PRIVATE ../tb_enum)
-target_link_libraries(tb_enum_http PRIVATE Qt5::Network tb_enum_api)
+target_link_libraries(tb_enum_http PUBLIC Qt5::Network tb_enum_api)

--- a/goldenmaster/tb_enum/implementation/CMakeLists.txt
+++ b/goldenmaster/tb_enum/implementation/CMakeLists.txt
@@ -4,7 +4,6 @@ project(tb_enum_impl LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml WebSockets)
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set (TB_ENUM_IMPL_SOURCES
@@ -25,7 +24,7 @@ target_include_directories(tb_enum_impl
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_enum_impl PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_enum::tb_enum_api)
+target_link_libraries(tb_enum_impl PRIVATE tb_enum::tb_enum_api)
 target_compile_definitions(tb_enum_impl PRIVATE TB_ENUM_IMPL_LIBRARY)
 
 add_subdirectory(tests)

--- a/goldenmaster/tb_enum/implementation/CMakeLists.txt
+++ b/goldenmaster/tb_enum/implementation/CMakeLists.txt
@@ -24,7 +24,7 @@ target_include_directories(tb_enum_impl
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_enum_impl PRIVATE tb_enum::tb_enum_api)
+target_link_libraries(tb_enum_impl PUBLIC tb_enum::tb_enum_api)
 target_compile_definitions(tb_enum_impl PRIVATE TB_ENUM_IMPL_LIBRARY)
 
 add_subdirectory(tests)

--- a/goldenmaster/tb_enum/implementation/tests/CMakeLists.txt
+++ b/goldenmaster/tb_enum/implementation/tests/CMakeLists.txt
@@ -17,5 +17,5 @@ set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR} ${CMAKE_MODULE_PATH})
 add_executable(test_tb_enum_enuminterface test_enuminterface.cpp)
 
 
-find_package(tb_enum QUIET COMPONENTS tb_enum_api tb_enum_impl )
-target_link_libraries(test_tb_enum_enuminterface  tb_enum_api tb_enum_impl Qt5::Core Qt5::Test)
+find_package(tb_enum QUIET COMPONENTS tb_enum_impl )
+target_link_libraries(test_tb_enum_enuminterface tb_enum_impl Qt5::Test)

--- a/goldenmaster/tb_enum/monitor/CMakeLists.txt
+++ b/goldenmaster/tb_enum/monitor/CMakeLists.txt
@@ -4,7 +4,6 @@ project(tb_enum_monitor)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core WebSockets)
 find_package(apigear QUIET COMPONENTS monitor_qt )
 
 set (TB_ENUM_MONITOR_SOURCES
@@ -23,5 +22,5 @@ target_include_directories(tb_enum_monitor
     $<INSTALL_INTERFACE:include/tb_enum>
 )
 
-target_link_libraries(tb_enum_monitor PRIVATE tb_enum::tb_enum_api Qt5::Core Qt5::WebSockets apigear::monitor_qt)
+target_link_libraries(tb_enum_monitor PRIVATE tb_enum::tb_enum_api apigear::monitor_qt)
 target_compile_definitions(tb_enum_monitor PRIVATE TB_ENUM_MONITOR_LIBRARY)

--- a/goldenmaster/tb_enum/monitor/CMakeLists.txt
+++ b/goldenmaster/tb_enum/monitor/CMakeLists.txt
@@ -22,5 +22,5 @@ target_include_directories(tb_enum_monitor
     $<INSTALL_INTERFACE:include/tb_enum>
 )
 
-target_link_libraries(tb_enum_monitor PRIVATE tb_enum::tb_enum_api apigear::monitor_qt)
+target_link_libraries(tb_enum_monitor PUBLIC tb_enum::tb_enum_api apigear::monitor_qt)
 target_compile_definitions(tb_enum_monitor PRIVATE TB_ENUM_MONITOR_LIBRARY)

--- a/goldenmaster/tb_enum/olink/CMakeLists.txt
+++ b/goldenmaster/tb_enum/olink/CMakeLists.txt
@@ -16,6 +16,4 @@ target_include_directories(tb_enum_olink
     $<INSTALL_INTERFACE:include/tb_enum>
 )
 
-target_link_libraries(tb_enum_olink 
-PRIVATE tb_enum::tb_enum_api 
-PUBLIC olink_qt qtpromise)
+target_link_libraries(tb_enum_olink PUBLIC tb_enum::tb_enum_api olink_qt qtpromise)

--- a/goldenmaster/tb_enum/olink/CMakeLists.txt
+++ b/goldenmaster/tb_enum/olink/CMakeLists.txt
@@ -2,18 +2,6 @@ project(tb_enum_olink)
 
 find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
 
-find_package(nlohmann_json QUIET)
-if(NOT nlohmann_json_FOUND)
-  # pull nlohmann json as dependency
-  message(STATUS "nlohmann_json NOT FOUND, fetching the release package")
-  include(FetchContent)
-  set(JSON_Install ON)
-  FetchContent_Declare(json
-  GIT_REPOSITORY https://github.com/nlohmann/json
-  GIT_TAG v3.7.3)
-  FetchContent_MakeAvailable(json)
-endif()
-
 set (TB_ENUM_OLINK_SOURCES
     olinkfactory.cpp
     olinkenuminterface.cpp
@@ -32,4 +20,4 @@ target_include_directories(tb_enum_olink
 
 target_link_libraries(tb_enum_olink 
 PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_enum::tb_enum_api 
-PUBLIC olink_qt nlohmann_json::nlohmann_json qtpromise)
+PUBLIC olink_qt qtpromise)

--- a/goldenmaster/tb_enum/olink/CMakeLists.txt
+++ b/goldenmaster/tb_enum/olink/CMakeLists.txt
@@ -14,19 +14,6 @@ if(NOT nlohmann_json_FOUND)
   FetchContent_MakeAvailable(json)
 endif()
 
-find_package(olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
-
 set (TB_ENUM_OLINK_SOURCES
     olinkfactory.cpp
     olinkenuminterface.cpp
@@ -43,4 +30,6 @@ target_include_directories(tb_enum_olink
     $<INSTALL_INTERFACE:include/tb_enum>
 )
 
-target_link_libraries(tb_enum_olink PRIVATE olink_core Qt5::Core Qt5::Qml Qt5::WebSockets tb_enum::tb_enum_api PUBLIC nlohmann_json::nlohmann_json qtpromise)
+target_link_libraries(tb_enum_olink 
+PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_enum::tb_enum_api 
+PUBLIC olink_qt nlohmann_json::nlohmann_json qtpromise)

--- a/goldenmaster/tb_enum/olink/CMakeLists.txt
+++ b/goldenmaster/tb_enum/olink/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(tb_enum_olink)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
-
 set (TB_ENUM_OLINK_SOURCES
     olinkfactory.cpp
     olinkenuminterface.cpp
@@ -19,5 +17,5 @@ target_include_directories(tb_enum_olink
 )
 
 target_link_libraries(tb_enum_olink 
-PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_enum::tb_enum_api 
+PRIVATE tb_enum::tb_enum_api 
 PUBLIC olink_qt qtpromise)

--- a/goldenmaster/tb_enum/plugin/CMakeLists.txt
+++ b/goldenmaster/tb_enum/plugin/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(plugin_tb_enum PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_PATH}
 )
 
-target_link_libraries(plugin_tb_enum PRIVATE tb_enum::tb_enum_api)
+target_link_libraries(plugin_tb_enum PUBLIC tb_enum::tb_enum_api)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${OUTPUT_PATH}/qmldir COPYONLY)
 

--- a/goldenmaster/tb_enum/plugin/CMakeLists.txt
+++ b/goldenmaster/tb_enum/plugin/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(plugin_tb_enum PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_PATH}
 )
 
-target_link_libraries(plugin_tb_enum PRIVATE Qt5::Core Qt5::Qml tb_enum::tb_enum_api)
+target_link_libraries(plugin_tb_enum PRIVATE tb_enum::tb_enum_api)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${OUTPUT_PATH}/qmldir COPYONLY)
 

--- a/goldenmaster/tb_same1/api/CMakeLists.txt
+++ b/goldenmaster/tb_same1/api/CMakeLists.txt
@@ -43,5 +43,6 @@ target_include_directories(tb_same1_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same1_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets nlohmann_json::nlohmann_json)
+target_link_libraries(tb_same1_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets
+PUBLIC nlohmann_json::nlohmann_json)
 target_compile_definitions(tb_same1_api PRIVATE TB_SAME1_API_LIBRARY)

--- a/goldenmaster/tb_same1/api/CMakeLists.txt
+++ b/goldenmaster/tb_same1/api/CMakeLists.txt
@@ -4,7 +4,7 @@ project(tb_same1_api LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml WebSockets)
+find_package(Qt5 REQUIRED COMPONENTS Core Qml)
 
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
@@ -43,6 +43,9 @@ target_include_directories(tb_same1_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same1_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets
-PUBLIC nlohmann_json::nlohmann_json)
+target_link_libraries(tb_same1_api PUBLIC
+Qt5::Core
+Qt5::Qml
+nlohmann_json::nlohmann_json)
+
 target_compile_definitions(tb_same1_api PRIVATE TB_SAME1_API_LIBRARY)

--- a/goldenmaster/tb_same1/http/CMakeLists.txt
+++ b/goldenmaster/tb_same1/http/CMakeLists.txt
@@ -19,4 +19,4 @@ set (TB_SAME1_HTTP_SOURCES
 
 add_library(tb_same1_http STATIC ${TB_SAME1_HTTP_SOURCES})
 target_include_directories(tb_same1_http PRIVATE ../tb_same1)
-target_link_libraries(tb_same1_http PRIVATE Qt5::Network tb_same1_api)
+target_link_libraries(tb_same1_http PUBLIC Qt5::Network tb_same1_api)

--- a/goldenmaster/tb_same1/http/CMakeLists.txt
+++ b/goldenmaster/tb_same1/http/CMakeLists.txt
@@ -4,7 +4,7 @@ project(tb_same1_http LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network)
+find_package(Qt5 REQUIRED COMPONENTS Network)
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set (TB_SAME1_HTTP_SOURCES
@@ -19,4 +19,4 @@ set (TB_SAME1_HTTP_SOURCES
 
 add_library(tb_same1_http STATIC ${TB_SAME1_HTTP_SOURCES})
 target_include_directories(tb_same1_http PRIVATE ../tb_same1)
-target_link_libraries(tb_same1_http PRIVATE Qt5::Core Qt5::Qml Qt5::Network tb_same1_api)
+target_link_libraries(tb_same1_http PRIVATE Qt5::Network tb_same1_api)

--- a/goldenmaster/tb_same1/implementation/CMakeLists.txt
+++ b/goldenmaster/tb_same1/implementation/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(tb_same1_impl
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same1_impl PRIVATE tb_same1::tb_same1_api)
+target_link_libraries(tb_same1_impl PUBLIC tb_same1::tb_same1_api)
 target_compile_definitions(tb_same1_impl PRIVATE TB_SAME1_IMPL_LIBRARY)
 
 add_subdirectory(tests)

--- a/goldenmaster/tb_same1/implementation/CMakeLists.txt
+++ b/goldenmaster/tb_same1/implementation/CMakeLists.txt
@@ -4,7 +4,6 @@ project(tb_same1_impl LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml WebSockets)
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set (TB_SAME1_IMPL_SOURCES
@@ -28,7 +27,7 @@ target_include_directories(tb_same1_impl
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same1_impl PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_same1::tb_same1_api)
+target_link_libraries(tb_same1_impl PRIVATE tb_same1::tb_same1_api)
 target_compile_definitions(tb_same1_impl PRIVATE TB_SAME1_IMPL_LIBRARY)
 
 add_subdirectory(tests)

--- a/goldenmaster/tb_same1/implementation/tests/CMakeLists.txt
+++ b/goldenmaster/tb_same1/implementation/tests/CMakeLists.txt
@@ -20,8 +20,8 @@ add_executable(test_tb_same1_sameenum1interface test_sameenum1interface.cpp)
 add_executable(test_tb_same1_sameenum2interface test_sameenum2interface.cpp)
 
 
-find_package(tb_same1 QUIET COMPONENTS tb_same1_api tb_same1_impl )
-target_link_libraries(test_tb_same1_samestruct1interface  tb_same1_api tb_same1_impl Qt5::Core Qt5::Test)
-target_link_libraries(test_tb_same1_samestruct2interface  tb_same1_api tb_same1_impl Qt5::Core Qt5::Test)
-target_link_libraries(test_tb_same1_sameenum1interface  tb_same1_api tb_same1_impl Qt5::Core Qt5::Test)
-target_link_libraries(test_tb_same1_sameenum2interface  tb_same1_api tb_same1_impl Qt5::Core Qt5::Test)
+find_package(tb_same1 QUIET COMPONENTS tb_same1_impl )
+target_link_libraries(test_tb_same1_samestruct1interface tb_same1_impl Qt5::Test)
+target_link_libraries(test_tb_same1_samestruct2interface tb_same1_impl Qt5::Test)
+target_link_libraries(test_tb_same1_sameenum1interface tb_same1_impl Qt5::Test)
+target_link_libraries(test_tb_same1_sameenum2interface tb_same1_impl Qt5::Test)

--- a/goldenmaster/tb_same1/monitor/CMakeLists.txt
+++ b/goldenmaster/tb_same1/monitor/CMakeLists.txt
@@ -4,7 +4,6 @@ project(tb_same1_monitor)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core WebSockets)
 find_package(apigear QUIET COMPONENTS monitor_qt )
 
 set (TB_SAME1_MONITOR_SOURCES
@@ -26,5 +25,5 @@ target_include_directories(tb_same1_monitor
     $<INSTALL_INTERFACE:include/tb_same1>
 )
 
-target_link_libraries(tb_same1_monitor PRIVATE tb_same1::tb_same1_api Qt5::Core Qt5::WebSockets apigear::monitor_qt)
+target_link_libraries(tb_same1_monitor PRIVATE tb_same1::tb_same1_api apigear::monitor_qt)
 target_compile_definitions(tb_same1_monitor PRIVATE TB_SAME1_MONITOR_LIBRARY)

--- a/goldenmaster/tb_same1/monitor/CMakeLists.txt
+++ b/goldenmaster/tb_same1/monitor/CMakeLists.txt
@@ -25,5 +25,5 @@ target_include_directories(tb_same1_monitor
     $<INSTALL_INTERFACE:include/tb_same1>
 )
 
-target_link_libraries(tb_same1_monitor PRIVATE tb_same1::tb_same1_api apigear::monitor_qt)
+target_link_libraries(tb_same1_monitor PUBLIC tb_same1::tb_same1_api apigear::monitor_qt)
 target_compile_definitions(tb_same1_monitor PRIVATE TB_SAME1_MONITOR_LIBRARY)

--- a/goldenmaster/tb_same1/olink/CMakeLists.txt
+++ b/goldenmaster/tb_same1/olink/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(tb_same1_olink)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
-
 set (TB_SAME1_OLINK_SOURCES
     olinkfactory.cpp
     olinksamestruct1interface.cpp
@@ -25,5 +23,5 @@ target_include_directories(tb_same1_olink
 )
 
 target_link_libraries(tb_same1_olink 
-PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_same1::tb_same1_api 
+PRIVATE tb_same1::tb_same1_api 
 PUBLIC olink_qt qtpromise)

--- a/goldenmaster/tb_same1/olink/CMakeLists.txt
+++ b/goldenmaster/tb_same1/olink/CMakeLists.txt
@@ -22,6 +22,4 @@ target_include_directories(tb_same1_olink
     $<INSTALL_INTERFACE:include/tb_same1>
 )
 
-target_link_libraries(tb_same1_olink 
-PRIVATE tb_same1::tb_same1_api 
-PUBLIC olink_qt qtpromise)
+target_link_libraries(tb_same1_olink PUBLIC tb_same1::tb_same1_api olink_qt qtpromise)

--- a/goldenmaster/tb_same1/olink/CMakeLists.txt
+++ b/goldenmaster/tb_same1/olink/CMakeLists.txt
@@ -14,19 +14,6 @@ if(NOT nlohmann_json_FOUND)
   FetchContent_MakeAvailable(json)
 endif()
 
-find_package(olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
-
 set (TB_SAME1_OLINK_SOURCES
     olinkfactory.cpp
     olinksamestruct1interface.cpp
@@ -49,4 +36,6 @@ target_include_directories(tb_same1_olink
     $<INSTALL_INTERFACE:include/tb_same1>
 )
 
-target_link_libraries(tb_same1_olink PRIVATE olink_core Qt5::Core Qt5::Qml Qt5::WebSockets tb_same1::tb_same1_api PUBLIC nlohmann_json::nlohmann_json qtpromise)
+target_link_libraries(tb_same1_olink 
+PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_same1::tb_same1_api 
+PUBLIC olink_qt nlohmann_json::nlohmann_json qtpromise)

--- a/goldenmaster/tb_same1/olink/CMakeLists.txt
+++ b/goldenmaster/tb_same1/olink/CMakeLists.txt
@@ -2,18 +2,6 @@ project(tb_same1_olink)
 
 find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
 
-find_package(nlohmann_json QUIET)
-if(NOT nlohmann_json_FOUND)
-  # pull nlohmann json as dependency
-  message(STATUS "nlohmann_json NOT FOUND, fetching the release package")
-  include(FetchContent)
-  set(JSON_Install ON)
-  FetchContent_Declare(json
-  GIT_REPOSITORY https://github.com/nlohmann/json
-  GIT_TAG v3.7.3)
-  FetchContent_MakeAvailable(json)
-endif()
-
 set (TB_SAME1_OLINK_SOURCES
     olinkfactory.cpp
     olinksamestruct1interface.cpp
@@ -38,4 +26,4 @@ target_include_directories(tb_same1_olink
 
 target_link_libraries(tb_same1_olink 
 PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_same1::tb_same1_api 
-PUBLIC olink_qt nlohmann_json::nlohmann_json qtpromise)
+PUBLIC olink_qt qtpromise)

--- a/goldenmaster/tb_same1/plugin/CMakeLists.txt
+++ b/goldenmaster/tb_same1/plugin/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(plugin_tb_same1 PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_PATH}
 )
 
-target_link_libraries(plugin_tb_same1 PRIVATE Qt5::Core Qt5::Qml tb_same1::tb_same1_api)
+target_link_libraries(plugin_tb_same1 PRIVATE tb_same1::tb_same1_api)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${OUTPUT_PATH}/qmldir COPYONLY)
 

--- a/goldenmaster/tb_same1/plugin/CMakeLists.txt
+++ b/goldenmaster/tb_same1/plugin/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(plugin_tb_same1 PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_PATH}
 )
 
-target_link_libraries(plugin_tb_same1 PRIVATE tb_same1::tb_same1_api)
+target_link_libraries(plugin_tb_same1 PUBLIC tb_same1::tb_same1_api)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${OUTPUT_PATH}/qmldir COPYONLY)
 

--- a/goldenmaster/tb_same2/api/CMakeLists.txt
+++ b/goldenmaster/tb_same2/api/CMakeLists.txt
@@ -4,7 +4,7 @@ project(tb_same2_api LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml WebSockets)
+find_package(Qt5 REQUIRED COMPONENTS Core Qml)
 
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
@@ -43,6 +43,9 @@ target_include_directories(tb_same2_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same2_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets
-PUBLIC nlohmann_json::nlohmann_json)
+target_link_libraries(tb_same2_api PUBLIC
+Qt5::Core
+Qt5::Qml
+nlohmann_json::nlohmann_json)
+
 target_compile_definitions(tb_same2_api PRIVATE TB_SAME2_API_LIBRARY)

--- a/goldenmaster/tb_same2/api/CMakeLists.txt
+++ b/goldenmaster/tb_same2/api/CMakeLists.txt
@@ -43,5 +43,6 @@ target_include_directories(tb_same2_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same2_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets nlohmann_json::nlohmann_json)
+target_link_libraries(tb_same2_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets
+PUBLIC nlohmann_json::nlohmann_json)
 target_compile_definitions(tb_same2_api PRIVATE TB_SAME2_API_LIBRARY)

--- a/goldenmaster/tb_same2/http/CMakeLists.txt
+++ b/goldenmaster/tb_same2/http/CMakeLists.txt
@@ -19,4 +19,4 @@ set (TB_SAME2_HTTP_SOURCES
 
 add_library(tb_same2_http STATIC ${TB_SAME2_HTTP_SOURCES})
 target_include_directories(tb_same2_http PRIVATE ../tb_same2)
-target_link_libraries(tb_same2_http PRIVATE Qt5::Network tb_same2_api)
+target_link_libraries(tb_same2_http PUBLIC Qt5::Network tb_same2_api)

--- a/goldenmaster/tb_same2/http/CMakeLists.txt
+++ b/goldenmaster/tb_same2/http/CMakeLists.txt
@@ -4,7 +4,7 @@ project(tb_same2_http LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network)
+find_package(Qt5 REQUIRED COMPONENTS Network)
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set (TB_SAME2_HTTP_SOURCES
@@ -19,4 +19,4 @@ set (TB_SAME2_HTTP_SOURCES
 
 add_library(tb_same2_http STATIC ${TB_SAME2_HTTP_SOURCES})
 target_include_directories(tb_same2_http PRIVATE ../tb_same2)
-target_link_libraries(tb_same2_http PRIVATE Qt5::Core Qt5::Qml Qt5::Network tb_same2_api)
+target_link_libraries(tb_same2_http PRIVATE Qt5::Network tb_same2_api)

--- a/goldenmaster/tb_same2/implementation/CMakeLists.txt
+++ b/goldenmaster/tb_same2/implementation/CMakeLists.txt
@@ -4,7 +4,6 @@ project(tb_same2_impl LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml WebSockets)
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set (TB_SAME2_IMPL_SOURCES
@@ -28,7 +27,7 @@ target_include_directories(tb_same2_impl
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same2_impl PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_same2::tb_same2_api)
+target_link_libraries(tb_same2_impl PRIVATE tb_same2::tb_same2_api)
 target_compile_definitions(tb_same2_impl PRIVATE TB_SAME2_IMPL_LIBRARY)
 
 add_subdirectory(tests)

--- a/goldenmaster/tb_same2/implementation/CMakeLists.txt
+++ b/goldenmaster/tb_same2/implementation/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(tb_same2_impl
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same2_impl PRIVATE tb_same2::tb_same2_api)
+target_link_libraries(tb_same2_impl PUBLIC tb_same2::tb_same2_api)
 target_compile_definitions(tb_same2_impl PRIVATE TB_SAME2_IMPL_LIBRARY)
 
 add_subdirectory(tests)

--- a/goldenmaster/tb_same2/implementation/tests/CMakeLists.txt
+++ b/goldenmaster/tb_same2/implementation/tests/CMakeLists.txt
@@ -20,8 +20,8 @@ add_executable(test_tb_same2_sameenum1interface test_sameenum1interface.cpp)
 add_executable(test_tb_same2_sameenum2interface test_sameenum2interface.cpp)
 
 
-find_package(tb_same2 QUIET COMPONENTS tb_same2_api tb_same2_impl )
-target_link_libraries(test_tb_same2_samestruct1interface  tb_same2_api tb_same2_impl Qt5::Core Qt5::Test)
-target_link_libraries(test_tb_same2_samestruct2interface  tb_same2_api tb_same2_impl Qt5::Core Qt5::Test)
-target_link_libraries(test_tb_same2_sameenum1interface  tb_same2_api tb_same2_impl Qt5::Core Qt5::Test)
-target_link_libraries(test_tb_same2_sameenum2interface  tb_same2_api tb_same2_impl Qt5::Core Qt5::Test)
+find_package(tb_same2 QUIET COMPONENTS tb_same2_impl )
+target_link_libraries(test_tb_same2_samestruct1interface tb_same2_impl Qt5::Test)
+target_link_libraries(test_tb_same2_samestruct2interface tb_same2_impl Qt5::Test)
+target_link_libraries(test_tb_same2_sameenum1interface tb_same2_impl Qt5::Test)
+target_link_libraries(test_tb_same2_sameenum2interface tb_same2_impl Qt5::Test)

--- a/goldenmaster/tb_same2/monitor/CMakeLists.txt
+++ b/goldenmaster/tb_same2/monitor/CMakeLists.txt
@@ -4,7 +4,6 @@ project(tb_same2_monitor)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core WebSockets)
 find_package(apigear QUIET COMPONENTS monitor_qt )
 
 set (TB_SAME2_MONITOR_SOURCES
@@ -26,5 +25,5 @@ target_include_directories(tb_same2_monitor
     $<INSTALL_INTERFACE:include/tb_same2>
 )
 
-target_link_libraries(tb_same2_monitor PRIVATE tb_same2::tb_same2_api Qt5::Core Qt5::WebSockets apigear::monitor_qt)
+target_link_libraries(tb_same2_monitor PRIVATE tb_same2::tb_same2_api apigear::monitor_qt)
 target_compile_definitions(tb_same2_monitor PRIVATE TB_SAME2_MONITOR_LIBRARY)

--- a/goldenmaster/tb_same2/monitor/CMakeLists.txt
+++ b/goldenmaster/tb_same2/monitor/CMakeLists.txt
@@ -25,5 +25,5 @@ target_include_directories(tb_same2_monitor
     $<INSTALL_INTERFACE:include/tb_same2>
 )
 
-target_link_libraries(tb_same2_monitor PRIVATE tb_same2::tb_same2_api apigear::monitor_qt)
+target_link_libraries(tb_same2_monitor PUBLIC tb_same2::tb_same2_api apigear::monitor_qt)
 target_compile_definitions(tb_same2_monitor PRIVATE TB_SAME2_MONITOR_LIBRARY)

--- a/goldenmaster/tb_same2/olink/CMakeLists.txt
+++ b/goldenmaster/tb_same2/olink/CMakeLists.txt
@@ -14,19 +14,6 @@ if(NOT nlohmann_json_FOUND)
   FetchContent_MakeAvailable(json)
 endif()
 
-find_package(olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
-
 set (TB_SAME2_OLINK_SOURCES
     olinkfactory.cpp
     olinksamestruct1interface.cpp
@@ -49,4 +36,6 @@ target_include_directories(tb_same2_olink
     $<INSTALL_INTERFACE:include/tb_same2>
 )
 
-target_link_libraries(tb_same2_olink PRIVATE olink_core Qt5::Core Qt5::Qml Qt5::WebSockets tb_same2::tb_same2_api PUBLIC nlohmann_json::nlohmann_json qtpromise)
+target_link_libraries(tb_same2_olink 
+PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_same2::tb_same2_api 
+PUBLIC olink_qt nlohmann_json::nlohmann_json qtpromise)

--- a/goldenmaster/tb_same2/olink/CMakeLists.txt
+++ b/goldenmaster/tb_same2/olink/CMakeLists.txt
@@ -2,18 +2,6 @@ project(tb_same2_olink)
 
 find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
 
-find_package(nlohmann_json QUIET)
-if(NOT nlohmann_json_FOUND)
-  # pull nlohmann json as dependency
-  message(STATUS "nlohmann_json NOT FOUND, fetching the release package")
-  include(FetchContent)
-  set(JSON_Install ON)
-  FetchContent_Declare(json
-  GIT_REPOSITORY https://github.com/nlohmann/json
-  GIT_TAG v3.7.3)
-  FetchContent_MakeAvailable(json)
-endif()
-
 set (TB_SAME2_OLINK_SOURCES
     olinkfactory.cpp
     olinksamestruct1interface.cpp
@@ -38,4 +26,4 @@ target_include_directories(tb_same2_olink
 
 target_link_libraries(tb_same2_olink 
 PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_same2::tb_same2_api 
-PUBLIC olink_qt nlohmann_json::nlohmann_json qtpromise)
+PUBLIC olink_qt qtpromise)

--- a/goldenmaster/tb_same2/olink/CMakeLists.txt
+++ b/goldenmaster/tb_same2/olink/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(tb_same2_olink)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
-
 set (TB_SAME2_OLINK_SOURCES
     olinkfactory.cpp
     olinksamestruct1interface.cpp
@@ -25,5 +23,5 @@ target_include_directories(tb_same2_olink
 )
 
 target_link_libraries(tb_same2_olink 
-PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_same2::tb_same2_api 
+PRIVATE tb_same2::tb_same2_api 
 PUBLIC olink_qt qtpromise)

--- a/goldenmaster/tb_same2/olink/CMakeLists.txt
+++ b/goldenmaster/tb_same2/olink/CMakeLists.txt
@@ -22,6 +22,4 @@ target_include_directories(tb_same2_olink
     $<INSTALL_INTERFACE:include/tb_same2>
 )
 
-target_link_libraries(tb_same2_olink 
-PRIVATE tb_same2::tb_same2_api 
-PUBLIC olink_qt qtpromise)
+target_link_libraries(tb_same2_olink PUBLIC tb_same2::tb_same2_api olink_qt qtpromise)

--- a/goldenmaster/tb_same2/plugin/CMakeLists.txt
+++ b/goldenmaster/tb_same2/plugin/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(plugin_tb_same2 PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_PATH}
 )
 
-target_link_libraries(plugin_tb_same2 PRIVATE tb_same2::tb_same2_api)
+target_link_libraries(plugin_tb_same2 PUBLIC tb_same2::tb_same2_api)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${OUTPUT_PATH}/qmldir COPYONLY)
 

--- a/goldenmaster/tb_same2/plugin/CMakeLists.txt
+++ b/goldenmaster/tb_same2/plugin/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(plugin_tb_same2 PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_PATH}
 )
 
-target_link_libraries(plugin_tb_same2 PRIVATE Qt5::Core Qt5::Qml tb_same2::tb_same2_api)
+target_link_libraries(plugin_tb_same2 PRIVATE tb_same2::tb_same2_api)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${OUTPUT_PATH}/qmldir COPYONLY)
 

--- a/goldenmaster/tb_simple/api/CMakeLists.txt
+++ b/goldenmaster/tb_simple/api/CMakeLists.txt
@@ -4,7 +4,7 @@ project(tb_simple_api LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml WebSockets)
+find_package(Qt5 REQUIRED COMPONENTS Core Qml)
 
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
@@ -41,6 +41,9 @@ target_include_directories(tb_simple_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_simple_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets
-PUBLIC nlohmann_json::nlohmann_json)
+target_link_libraries(tb_simple_api PUBLIC
+Qt5::Core
+Qt5::Qml
+nlohmann_json::nlohmann_json)
+
 target_compile_definitions(tb_simple_api PRIVATE TB_SIMPLE_API_LIBRARY)

--- a/goldenmaster/tb_simple/api/CMakeLists.txt
+++ b/goldenmaster/tb_simple/api/CMakeLists.txt
@@ -41,5 +41,6 @@ target_include_directories(tb_simple_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_simple_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets nlohmann_json::nlohmann_json)
+target_link_libraries(tb_simple_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets
+PUBLIC nlohmann_json::nlohmann_json)
 target_compile_definitions(tb_simple_api PRIVATE TB_SIMPLE_API_LIBRARY)

--- a/goldenmaster/tb_simple/http/CMakeLists.txt
+++ b/goldenmaster/tb_simple/http/CMakeLists.txt
@@ -17,4 +17,4 @@ set (TB_SIMPLE_HTTP_SOURCES
 
 add_library(tb_simple_http STATIC ${TB_SIMPLE_HTTP_SOURCES})
 target_include_directories(tb_simple_http PRIVATE ../tb_simple)
-target_link_libraries(tb_simple_http PRIVATE Qt5::Network tb_simple_api)
+target_link_libraries(tb_simple_http PUBLIC Qt5::Network tb_simple_api)

--- a/goldenmaster/tb_simple/http/CMakeLists.txt
+++ b/goldenmaster/tb_simple/http/CMakeLists.txt
@@ -4,7 +4,7 @@ project(tb_simple_http LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network)
+find_package(Qt5 REQUIRED COMPONENTS Network)
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set (TB_SIMPLE_HTTP_SOURCES
@@ -17,4 +17,4 @@ set (TB_SIMPLE_HTTP_SOURCES
 
 add_library(tb_simple_http STATIC ${TB_SIMPLE_HTTP_SOURCES})
 target_include_directories(tb_simple_http PRIVATE ../tb_simple)
-target_link_libraries(tb_simple_http PRIVATE Qt5::Core Qt5::Qml Qt5::Network tb_simple_api)
+target_link_libraries(tb_simple_http PRIVATE Qt5::Network tb_simple_api)

--- a/goldenmaster/tb_simple/implementation/CMakeLists.txt
+++ b/goldenmaster/tb_simple/implementation/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(tb_simple_impl
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_simple_impl PRIVATE tb_simple::tb_simple_api)
+target_link_libraries(tb_simple_impl PUBLIC tb_simple::tb_simple_api)
 target_compile_definitions(tb_simple_impl PRIVATE TB_SIMPLE_IMPL_LIBRARY)
 
 add_subdirectory(tests)

--- a/goldenmaster/tb_simple/implementation/CMakeLists.txt
+++ b/goldenmaster/tb_simple/implementation/CMakeLists.txt
@@ -4,7 +4,6 @@ project(tb_simple_impl LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml WebSockets)
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set (TB_SIMPLE_IMPL_SOURCES
@@ -26,7 +25,7 @@ target_include_directories(tb_simple_impl
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_simple_impl PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_simple::tb_simple_api)
+target_link_libraries(tb_simple_impl PRIVATE tb_simple::tb_simple_api)
 target_compile_definitions(tb_simple_impl PRIVATE TB_SIMPLE_IMPL_LIBRARY)
 
 add_subdirectory(tests)

--- a/goldenmaster/tb_simple/implementation/tests/CMakeLists.txt
+++ b/goldenmaster/tb_simple/implementation/tests/CMakeLists.txt
@@ -18,6 +18,6 @@ add_executable(test_tb_simple_simpleinterface test_simpleinterface.cpp)
 add_executable(test_tb_simple_simplearrayinterface test_simplearrayinterface.cpp)
 
 
-find_package(tb_simple QUIET COMPONENTS tb_simple_api tb_simple_impl )
-target_link_libraries(test_tb_simple_simpleinterface  tb_simple_api tb_simple_impl Qt5::Core Qt5::Test)
-target_link_libraries(test_tb_simple_simplearrayinterface  tb_simple_api tb_simple_impl Qt5::Core Qt5::Test)
+find_package(tb_simple QUIET COMPONENTS tb_simple_impl )
+target_link_libraries(test_tb_simple_simpleinterface tb_simple_impl Qt5::Test)
+target_link_libraries(test_tb_simple_simplearrayinterface tb_simple_impl Qt5::Test)

--- a/goldenmaster/tb_simple/monitor/CMakeLists.txt
+++ b/goldenmaster/tb_simple/monitor/CMakeLists.txt
@@ -4,7 +4,6 @@ project(tb_simple_monitor)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core WebSockets)
 find_package(apigear QUIET COMPONENTS monitor_qt )
 
 set (TB_SIMPLE_MONITOR_SOURCES
@@ -24,5 +23,5 @@ target_include_directories(tb_simple_monitor
     $<INSTALL_INTERFACE:include/tb_simple>
 )
 
-target_link_libraries(tb_simple_monitor PRIVATE tb_simple::tb_simple_api Qt5::Core Qt5::WebSockets apigear::monitor_qt)
+target_link_libraries(tb_simple_monitor PRIVATE tb_simple::tb_simple_api apigear::monitor_qt)
 target_compile_definitions(tb_simple_monitor PRIVATE TB_SIMPLE_MONITOR_LIBRARY)

--- a/goldenmaster/tb_simple/monitor/CMakeLists.txt
+++ b/goldenmaster/tb_simple/monitor/CMakeLists.txt
@@ -23,5 +23,5 @@ target_include_directories(tb_simple_monitor
     $<INSTALL_INTERFACE:include/tb_simple>
 )
 
-target_link_libraries(tb_simple_monitor PRIVATE tb_simple::tb_simple_api apigear::monitor_qt)
+target_link_libraries(tb_simple_monitor PUBLIC tb_simple::tb_simple_api apigear::monitor_qt)
 target_compile_definitions(tb_simple_monitor PRIVATE TB_SIMPLE_MONITOR_LIBRARY)

--- a/goldenmaster/tb_simple/olink/CMakeLists.txt
+++ b/goldenmaster/tb_simple/olink/CMakeLists.txt
@@ -14,19 +14,6 @@ if(NOT nlohmann_json_FOUND)
   FetchContent_MakeAvailable(json)
 endif()
 
-find_package(olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
-
 set (TB_SIMPLE_OLINK_SOURCES
     olinkfactory.cpp
     olinksimpleinterface.cpp
@@ -45,4 +32,6 @@ target_include_directories(tb_simple_olink
     $<INSTALL_INTERFACE:include/tb_simple>
 )
 
-target_link_libraries(tb_simple_olink PRIVATE olink_core Qt5::Core Qt5::Qml Qt5::WebSockets tb_simple::tb_simple_api PUBLIC nlohmann_json::nlohmann_json qtpromise)
+target_link_libraries(tb_simple_olink 
+PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_simple::tb_simple_api 
+PUBLIC olink_qt nlohmann_json::nlohmann_json qtpromise)

--- a/goldenmaster/tb_simple/olink/CMakeLists.txt
+++ b/goldenmaster/tb_simple/olink/CMakeLists.txt
@@ -18,6 +18,4 @@ target_include_directories(tb_simple_olink
     $<INSTALL_INTERFACE:include/tb_simple>
 )
 
-target_link_libraries(tb_simple_olink 
-PRIVATE tb_simple::tb_simple_api 
-PUBLIC olink_qt qtpromise)
+target_link_libraries(tb_simple_olink PUBLIC tb_simple::tb_simple_api olink_qt qtpromise)

--- a/goldenmaster/tb_simple/olink/CMakeLists.txt
+++ b/goldenmaster/tb_simple/olink/CMakeLists.txt
@@ -2,18 +2,6 @@ project(tb_simple_olink)
 
 find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
 
-find_package(nlohmann_json QUIET)
-if(NOT nlohmann_json_FOUND)
-  # pull nlohmann json as dependency
-  message(STATUS "nlohmann_json NOT FOUND, fetching the release package")
-  include(FetchContent)
-  set(JSON_Install ON)
-  FetchContent_Declare(json
-  GIT_REPOSITORY https://github.com/nlohmann/json
-  GIT_TAG v3.7.3)
-  FetchContent_MakeAvailable(json)
-endif()
-
 set (TB_SIMPLE_OLINK_SOURCES
     olinkfactory.cpp
     olinksimpleinterface.cpp
@@ -34,4 +22,4 @@ target_include_directories(tb_simple_olink
 
 target_link_libraries(tb_simple_olink 
 PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_simple::tb_simple_api 
-PUBLIC olink_qt nlohmann_json::nlohmann_json qtpromise)
+PUBLIC olink_qt qtpromise)

--- a/goldenmaster/tb_simple/olink/CMakeLists.txt
+++ b/goldenmaster/tb_simple/olink/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(tb_simple_olink)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
-
 set (TB_SIMPLE_OLINK_SOURCES
     olinkfactory.cpp
     olinksimpleinterface.cpp
@@ -21,5 +19,5 @@ target_include_directories(tb_simple_olink
 )
 
 target_link_libraries(tb_simple_olink 
-PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets tb_simple::tb_simple_api 
+PRIVATE tb_simple::tb_simple_api 
 PUBLIC olink_qt qtpromise)

--- a/goldenmaster/tb_simple/plugin/CMakeLists.txt
+++ b/goldenmaster/tb_simple/plugin/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(plugin_tb_simple PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_PATH}
 )
 
-target_link_libraries(plugin_tb_simple PRIVATE Qt5::Core Qt5::Qml tb_simple::tb_simple_api)
+target_link_libraries(plugin_tb_simple PRIVATE tb_simple::tb_simple_api)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${OUTPUT_PATH}/qmldir COPYONLY)
 

--- a/goldenmaster/tb_simple/plugin/CMakeLists.txt
+++ b/goldenmaster/tb_simple/plugin/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(plugin_tb_simple PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_PATH}
 )
 
-target_link_libraries(plugin_tb_simple PRIVATE tb_simple::tb_simple_api)
+target_link_libraries(plugin_tb_simple PUBLIC tb_simple::tb_simple_api)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${OUTPUT_PATH}/qmldir COPYONLY)
 

--- a/goldenmaster/testbed1/api/CMakeLists.txt
+++ b/goldenmaster/testbed1/api/CMakeLists.txt
@@ -41,5 +41,6 @@ target_include_directories(testbed1_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed1_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets nlohmann_json::nlohmann_json)
+target_link_libraries(testbed1_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets
+PUBLIC nlohmann_json::nlohmann_json)
 target_compile_definitions(testbed1_api PRIVATE TESTBED1_API_LIBRARY)

--- a/goldenmaster/testbed1/api/CMakeLists.txt
+++ b/goldenmaster/testbed1/api/CMakeLists.txt
@@ -4,7 +4,7 @@ project(testbed1_api LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml WebSockets)
+find_package(Qt5 REQUIRED COMPONENTS Core Qml)
 
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
@@ -41,6 +41,9 @@ target_include_directories(testbed1_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed1_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets
-PUBLIC nlohmann_json::nlohmann_json)
+target_link_libraries(testbed1_api PUBLIC
+Qt5::Core
+Qt5::Qml
+nlohmann_json::nlohmann_json)
+
 target_compile_definitions(testbed1_api PRIVATE TESTBED1_API_LIBRARY)

--- a/goldenmaster/testbed1/http/CMakeLists.txt
+++ b/goldenmaster/testbed1/http/CMakeLists.txt
@@ -4,7 +4,7 @@ project(testbed1_http LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network)
+find_package(Qt5 REQUIRED COMPONENTS Network)
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set (TESTBED1_HTTP_SOURCES
@@ -17,4 +17,4 @@ set (TESTBED1_HTTP_SOURCES
 
 add_library(testbed1_http STATIC ${TESTBED1_HTTP_SOURCES})
 target_include_directories(testbed1_http PRIVATE ../testbed1)
-target_link_libraries(testbed1_http PRIVATE Qt5::Core Qt5::Qml Qt5::Network testbed1_api)
+target_link_libraries(testbed1_http PRIVATE Qt5::Network testbed1_api)

--- a/goldenmaster/testbed1/http/CMakeLists.txt
+++ b/goldenmaster/testbed1/http/CMakeLists.txt
@@ -17,4 +17,4 @@ set (TESTBED1_HTTP_SOURCES
 
 add_library(testbed1_http STATIC ${TESTBED1_HTTP_SOURCES})
 target_include_directories(testbed1_http PRIVATE ../testbed1)
-target_link_libraries(testbed1_http PRIVATE Qt5::Network testbed1_api)
+target_link_libraries(testbed1_http PUBLIC Qt5::Network testbed1_api)

--- a/goldenmaster/testbed1/implementation/CMakeLists.txt
+++ b/goldenmaster/testbed1/implementation/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(testbed1_impl
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed1_impl PRIVATE testbed1::testbed1_api)
+target_link_libraries(testbed1_impl PUBLIC testbed1::testbed1_api)
 target_compile_definitions(testbed1_impl PRIVATE TESTBED1_IMPL_LIBRARY)
 
 add_subdirectory(tests)

--- a/goldenmaster/testbed1/implementation/CMakeLists.txt
+++ b/goldenmaster/testbed1/implementation/CMakeLists.txt
@@ -4,7 +4,6 @@ project(testbed1_impl LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml WebSockets)
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set (TESTBED1_IMPL_SOURCES
@@ -26,7 +25,7 @@ target_include_directories(testbed1_impl
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed1_impl PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets testbed1::testbed1_api)
+target_link_libraries(testbed1_impl PRIVATE testbed1::testbed1_api)
 target_compile_definitions(testbed1_impl PRIVATE TESTBED1_IMPL_LIBRARY)
 
 add_subdirectory(tests)

--- a/goldenmaster/testbed1/implementation/tests/CMakeLists.txt
+++ b/goldenmaster/testbed1/implementation/tests/CMakeLists.txt
@@ -18,6 +18,6 @@ add_executable(test_testbed1_structinterface test_structinterface.cpp)
 add_executable(test_testbed1_structarrayinterface test_structarrayinterface.cpp)
 
 
-find_package(testbed1 QUIET COMPONENTS testbed1_api testbed1_impl )
-target_link_libraries(test_testbed1_structinterface  testbed1_api testbed1_impl Qt5::Core Qt5::Test)
-target_link_libraries(test_testbed1_structarrayinterface  testbed1_api testbed1_impl Qt5::Core Qt5::Test)
+find_package(testbed1 QUIET COMPONENTS testbed1_impl )
+target_link_libraries(test_testbed1_structinterface testbed1_impl Qt5::Test)
+target_link_libraries(test_testbed1_structarrayinterface testbed1_impl Qt5::Test)

--- a/goldenmaster/testbed1/monitor/CMakeLists.txt
+++ b/goldenmaster/testbed1/monitor/CMakeLists.txt
@@ -4,7 +4,6 @@ project(testbed1_monitor)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core WebSockets)
 find_package(apigear QUIET COMPONENTS monitor_qt )
 
 set (TESTBED1_MONITOR_SOURCES
@@ -24,5 +23,5 @@ target_include_directories(testbed1_monitor
     $<INSTALL_INTERFACE:include/testbed1>
 )
 
-target_link_libraries(testbed1_monitor PRIVATE testbed1::testbed1_api Qt5::Core Qt5::WebSockets apigear::monitor_qt)
+target_link_libraries(testbed1_monitor PRIVATE testbed1::testbed1_api apigear::monitor_qt)
 target_compile_definitions(testbed1_monitor PRIVATE TESTBED1_MONITOR_LIBRARY)

--- a/goldenmaster/testbed1/monitor/CMakeLists.txt
+++ b/goldenmaster/testbed1/monitor/CMakeLists.txt
@@ -23,5 +23,5 @@ target_include_directories(testbed1_monitor
     $<INSTALL_INTERFACE:include/testbed1>
 )
 
-target_link_libraries(testbed1_monitor PRIVATE testbed1::testbed1_api apigear::monitor_qt)
+target_link_libraries(testbed1_monitor PUBLIC testbed1::testbed1_api apigear::monitor_qt)
 target_compile_definitions(testbed1_monitor PRIVATE TESTBED1_MONITOR_LIBRARY)

--- a/goldenmaster/testbed1/olink/CMakeLists.txt
+++ b/goldenmaster/testbed1/olink/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(testbed1_olink)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
-
 set (TESTBED1_OLINK_SOURCES
     olinkfactory.cpp
     olinkstructinterface.cpp
@@ -21,5 +19,5 @@ target_include_directories(testbed1_olink
 )
 
 target_link_libraries(testbed1_olink 
-PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets testbed1::testbed1_api 
+PRIVATE testbed1::testbed1_api 
 PUBLIC olink_qt qtpromise)

--- a/goldenmaster/testbed1/olink/CMakeLists.txt
+++ b/goldenmaster/testbed1/olink/CMakeLists.txt
@@ -2,18 +2,6 @@ project(testbed1_olink)
 
 find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
 
-find_package(nlohmann_json QUIET)
-if(NOT nlohmann_json_FOUND)
-  # pull nlohmann json as dependency
-  message(STATUS "nlohmann_json NOT FOUND, fetching the release package")
-  include(FetchContent)
-  set(JSON_Install ON)
-  FetchContent_Declare(json
-  GIT_REPOSITORY https://github.com/nlohmann/json
-  GIT_TAG v3.7.3)
-  FetchContent_MakeAvailable(json)
-endif()
-
 set (TESTBED1_OLINK_SOURCES
     olinkfactory.cpp
     olinkstructinterface.cpp
@@ -34,4 +22,4 @@ target_include_directories(testbed1_olink
 
 target_link_libraries(testbed1_olink 
 PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets testbed1::testbed1_api 
-PUBLIC olink_qt nlohmann_json::nlohmann_json qtpromise)
+PUBLIC olink_qt qtpromise)

--- a/goldenmaster/testbed1/olink/CMakeLists.txt
+++ b/goldenmaster/testbed1/olink/CMakeLists.txt
@@ -14,19 +14,6 @@ if(NOT nlohmann_json_FOUND)
   FetchContent_MakeAvailable(json)
 endif()
 
-find_package(olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
-
 set (TESTBED1_OLINK_SOURCES
     olinkfactory.cpp
     olinkstructinterface.cpp
@@ -45,4 +32,6 @@ target_include_directories(testbed1_olink
     $<INSTALL_INTERFACE:include/testbed1>
 )
 
-target_link_libraries(testbed1_olink PRIVATE olink_core Qt5::Core Qt5::Qml Qt5::WebSockets testbed1::testbed1_api PUBLIC nlohmann_json::nlohmann_json qtpromise)
+target_link_libraries(testbed1_olink 
+PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets testbed1::testbed1_api 
+PUBLIC olink_qt nlohmann_json::nlohmann_json qtpromise)

--- a/goldenmaster/testbed1/olink/CMakeLists.txt
+++ b/goldenmaster/testbed1/olink/CMakeLists.txt
@@ -18,6 +18,4 @@ target_include_directories(testbed1_olink
     $<INSTALL_INTERFACE:include/testbed1>
 )
 
-target_link_libraries(testbed1_olink 
-PRIVATE testbed1::testbed1_api 
-PUBLIC olink_qt qtpromise)
+target_link_libraries(testbed1_olink PUBLIC testbed1::testbed1_api olink_qt qtpromise)

--- a/goldenmaster/testbed1/plugin/CMakeLists.txt
+++ b/goldenmaster/testbed1/plugin/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(plugin_testbed1 PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_PATH}
 )
 
-target_link_libraries(plugin_testbed1 PRIVATE testbed1::testbed1_api)
+target_link_libraries(plugin_testbed1 PUBLIC testbed1::testbed1_api)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${OUTPUT_PATH}/qmldir COPYONLY)
 

--- a/goldenmaster/testbed1/plugin/CMakeLists.txt
+++ b/goldenmaster/testbed1/plugin/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(plugin_testbed1 PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_PATH}
 )
 
-target_link_libraries(plugin_testbed1 PRIVATE Qt5::Core Qt5::Qml testbed1::testbed1_api)
+target_link_libraries(plugin_testbed1 PRIVATE testbed1::testbed1_api)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${OUTPUT_PATH}/qmldir COPYONLY)
 

--- a/goldenmaster/testbed2/api/CMakeLists.txt
+++ b/goldenmaster/testbed2/api/CMakeLists.txt
@@ -4,7 +4,7 @@ project(testbed2_api LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml WebSockets)
+find_package(Qt5 REQUIRED COMPONENTS Core Qml)
 
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
@@ -43,6 +43,9 @@ target_include_directories(testbed2_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed2_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets
-PUBLIC nlohmann_json::nlohmann_json)
+target_link_libraries(testbed2_api PUBLIC
+Qt5::Core
+Qt5::Qml
+nlohmann_json::nlohmann_json)
+
 target_compile_definitions(testbed2_api PRIVATE TESTBED2_API_LIBRARY)

--- a/goldenmaster/testbed2/api/CMakeLists.txt
+++ b/goldenmaster/testbed2/api/CMakeLists.txt
@@ -43,5 +43,6 @@ target_include_directories(testbed2_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed2_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets nlohmann_json::nlohmann_json)
+target_link_libraries(testbed2_api PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets
+PUBLIC nlohmann_json::nlohmann_json)
 target_compile_definitions(testbed2_api PRIVATE TESTBED2_API_LIBRARY)

--- a/goldenmaster/testbed2/http/CMakeLists.txt
+++ b/goldenmaster/testbed2/http/CMakeLists.txt
@@ -19,4 +19,4 @@ set (TESTBED2_HTTP_SOURCES
 
 add_library(testbed2_http STATIC ${TESTBED2_HTTP_SOURCES})
 target_include_directories(testbed2_http PRIVATE ../testbed2)
-target_link_libraries(testbed2_http PRIVATE Qt5::Network testbed2_api)
+target_link_libraries(testbed2_http PUBLIC Qt5::Network testbed2_api)

--- a/goldenmaster/testbed2/http/CMakeLists.txt
+++ b/goldenmaster/testbed2/http/CMakeLists.txt
@@ -4,7 +4,7 @@ project(testbed2_http LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network)
+find_package(Qt5 REQUIRED COMPONENTS Network)
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set (TESTBED2_HTTP_SOURCES
@@ -19,4 +19,4 @@ set (TESTBED2_HTTP_SOURCES
 
 add_library(testbed2_http STATIC ${TESTBED2_HTTP_SOURCES})
 target_include_directories(testbed2_http PRIVATE ../testbed2)
-target_link_libraries(testbed2_http PRIVATE Qt5::Core Qt5::Qml Qt5::Network testbed2_api)
+target_link_libraries(testbed2_http PRIVATE Qt5::Network testbed2_api)

--- a/goldenmaster/testbed2/implementation/CMakeLists.txt
+++ b/goldenmaster/testbed2/implementation/CMakeLists.txt
@@ -4,7 +4,6 @@ project(testbed2_impl LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml WebSockets)
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set (TESTBED2_IMPL_SOURCES
@@ -28,7 +27,7 @@ target_include_directories(testbed2_impl
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed2_impl PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets testbed2::testbed2_api)
+target_link_libraries(testbed2_impl PRIVATE testbed2::testbed2_api)
 target_compile_definitions(testbed2_impl PRIVATE TESTBED2_IMPL_LIBRARY)
 
 add_subdirectory(tests)

--- a/goldenmaster/testbed2/implementation/CMakeLists.txt
+++ b/goldenmaster/testbed2/implementation/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(testbed2_impl
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed2_impl PRIVATE testbed2::testbed2_api)
+target_link_libraries(testbed2_impl PUBLIC testbed2::testbed2_api)
 target_compile_definitions(testbed2_impl PRIVATE TESTBED2_IMPL_LIBRARY)
 
 add_subdirectory(tests)

--- a/goldenmaster/testbed2/implementation/tests/CMakeLists.txt
+++ b/goldenmaster/testbed2/implementation/tests/CMakeLists.txt
@@ -20,8 +20,8 @@ add_executable(test_testbed2_nestedstruct2interface test_nestedstruct2interface.
 add_executable(test_testbed2_nestedstruct3interface test_nestedstruct3interface.cpp)
 
 
-find_package(testbed2 QUIET COMPONENTS testbed2_api testbed2_impl )
-target_link_libraries(test_testbed2_manyparaminterface  testbed2_api testbed2_impl Qt5::Core Qt5::Test)
-target_link_libraries(test_testbed2_nestedstruct1interface  testbed2_api testbed2_impl Qt5::Core Qt5::Test)
-target_link_libraries(test_testbed2_nestedstruct2interface  testbed2_api testbed2_impl Qt5::Core Qt5::Test)
-target_link_libraries(test_testbed2_nestedstruct3interface  testbed2_api testbed2_impl Qt5::Core Qt5::Test)
+find_package(testbed2 QUIET COMPONENTS testbed2_impl )
+target_link_libraries(test_testbed2_manyparaminterface testbed2_impl Qt5::Test)
+target_link_libraries(test_testbed2_nestedstruct1interface testbed2_impl Qt5::Test)
+target_link_libraries(test_testbed2_nestedstruct2interface testbed2_impl Qt5::Test)
+target_link_libraries(test_testbed2_nestedstruct3interface testbed2_impl Qt5::Test)

--- a/goldenmaster/testbed2/monitor/CMakeLists.txt
+++ b/goldenmaster/testbed2/monitor/CMakeLists.txt
@@ -4,7 +4,6 @@ project(testbed2_monitor)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core WebSockets)
 find_package(apigear QUIET COMPONENTS monitor_qt )
 
 set (TESTBED2_MONITOR_SOURCES
@@ -26,5 +25,5 @@ target_include_directories(testbed2_monitor
     $<INSTALL_INTERFACE:include/testbed2>
 )
 
-target_link_libraries(testbed2_monitor PRIVATE testbed2::testbed2_api Qt5::Core Qt5::WebSockets apigear::monitor_qt)
+target_link_libraries(testbed2_monitor PRIVATE testbed2::testbed2_api apigear::monitor_qt)
 target_compile_definitions(testbed2_monitor PRIVATE TESTBED2_MONITOR_LIBRARY)

--- a/goldenmaster/testbed2/monitor/CMakeLists.txt
+++ b/goldenmaster/testbed2/monitor/CMakeLists.txt
@@ -25,5 +25,5 @@ target_include_directories(testbed2_monitor
     $<INSTALL_INTERFACE:include/testbed2>
 )
 
-target_link_libraries(testbed2_monitor PRIVATE testbed2::testbed2_api apigear::monitor_qt)
+target_link_libraries(testbed2_monitor PUBLIC testbed2::testbed2_api apigear::monitor_qt)
 target_compile_definitions(testbed2_monitor PRIVATE TESTBED2_MONITOR_LIBRARY)

--- a/goldenmaster/testbed2/olink/CMakeLists.txt
+++ b/goldenmaster/testbed2/olink/CMakeLists.txt
@@ -14,19 +14,6 @@ if(NOT nlohmann_json_FOUND)
   FetchContent_MakeAvailable(json)
 endif()
 
-find_package(olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
-
 set (TESTBED2_OLINK_SOURCES
     olinkfactory.cpp
     olinkmanyparaminterface.cpp
@@ -49,4 +36,6 @@ target_include_directories(testbed2_olink
     $<INSTALL_INTERFACE:include/testbed2>
 )
 
-target_link_libraries(testbed2_olink PRIVATE olink_core Qt5::Core Qt5::Qml Qt5::WebSockets testbed2::testbed2_api PUBLIC nlohmann_json::nlohmann_json qtpromise)
+target_link_libraries(testbed2_olink 
+PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets testbed2::testbed2_api 
+PUBLIC olink_qt nlohmann_json::nlohmann_json qtpromise)

--- a/goldenmaster/testbed2/olink/CMakeLists.txt
+++ b/goldenmaster/testbed2/olink/CMakeLists.txt
@@ -22,6 +22,4 @@ target_include_directories(testbed2_olink
     $<INSTALL_INTERFACE:include/testbed2>
 )
 
-target_link_libraries(testbed2_olink 
-PRIVATE testbed2::testbed2_api 
-PUBLIC olink_qt qtpromise)
+target_link_libraries(testbed2_olink PUBLIC testbed2::testbed2_api olink_qt qtpromise)

--- a/goldenmaster/testbed2/olink/CMakeLists.txt
+++ b/goldenmaster/testbed2/olink/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(testbed2_olink)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
-
 set (TESTBED2_OLINK_SOURCES
     olinkfactory.cpp
     olinkmanyparaminterface.cpp
@@ -25,5 +23,5 @@ target_include_directories(testbed2_olink
 )
 
 target_link_libraries(testbed2_olink 
-PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets testbed2::testbed2_api 
+PRIVATE testbed2::testbed2_api 
 PUBLIC olink_qt qtpromise)

--- a/goldenmaster/testbed2/olink/CMakeLists.txt
+++ b/goldenmaster/testbed2/olink/CMakeLists.txt
@@ -2,18 +2,6 @@ project(testbed2_olink)
 
 find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
 
-find_package(nlohmann_json QUIET)
-if(NOT nlohmann_json_FOUND)
-  # pull nlohmann json as dependency
-  message(STATUS "nlohmann_json NOT FOUND, fetching the release package")
-  include(FetchContent)
-  set(JSON_Install ON)
-  FetchContent_Declare(json
-  GIT_REPOSITORY https://github.com/nlohmann/json
-  GIT_TAG v3.7.3)
-  FetchContent_MakeAvailable(json)
-endif()
-
 set (TESTBED2_OLINK_SOURCES
     olinkfactory.cpp
     olinkmanyparaminterface.cpp
@@ -38,4 +26,4 @@ target_include_directories(testbed2_olink
 
 target_link_libraries(testbed2_olink 
 PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets testbed2::testbed2_api 
-PUBLIC olink_qt nlohmann_json::nlohmann_json qtpromise)
+PUBLIC olink_qt qtpromise)

--- a/goldenmaster/testbed2/plugin/CMakeLists.txt
+++ b/goldenmaster/testbed2/plugin/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(plugin_testbed2 PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_PATH}
 )
 
-target_link_libraries(plugin_testbed2 PRIVATE Qt5::Core Qt5::Qml testbed2::testbed2_api)
+target_link_libraries(plugin_testbed2 PRIVATE testbed2::testbed2_api)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${OUTPUT_PATH}/qmldir COPYONLY)
 

--- a/goldenmaster/testbed2/plugin/CMakeLists.txt
+++ b/goldenmaster/testbed2/plugin/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(plugin_testbed2 PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_PATH}
 )
 
-target_link_libraries(plugin_testbed2 PRIVATE testbed2::testbed2_api)
+target_link_libraries(plugin_testbed2 PUBLIC testbed2::testbed2_api)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${OUTPUT_PATH}/qmldir COPYONLY)
 

--- a/templates/api/CMakeLists.txt.tpl
+++ b/templates/api/CMakeLists.txt.tpl
@@ -10,7 +10,7 @@ project({{ $lib_id }} LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml WebSockets)
+find_package(Qt5 REQUIRED COMPONENTS Core Qml)
 
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
@@ -48,6 +48,9 @@ target_include_directories({{$lib_id}}
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries({{$lib_id}} PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets
-PUBLIC nlohmann_json::nlohmann_json)
+target_link_libraries({{$lib_id}} PUBLIC
+Qt5::Core
+Qt5::Qml
+nlohmann_json::nlohmann_json)
+
 target_compile_definitions({{$lib_id}} PRIVATE {{ $MODULE_ID }}_LIBRARY)

--- a/templates/api/CMakeLists.txt.tpl
+++ b/templates/api/CMakeLists.txt.tpl
@@ -48,5 +48,6 @@ target_include_directories({{$lib_id}}
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries({{$lib_id}} PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets nlohmann_json::nlohmann_json)
+target_link_libraries({{$lib_id}} PRIVATE  Qt5::Core Qt5::Qml Qt5::WebSockets
+PUBLIC nlohmann_json::nlohmann_json)
 target_compile_definitions({{$lib_id}} PRIVATE {{ $MODULE_ID }}_LIBRARY)

--- a/templates/apigear/monitor/CMakeLists.txt
+++ b/templates/apigear/monitor/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 include(FetchContent)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
+find_package(Qt5 REQUIRED COMPONENTS Core WebSockets)
 
 
 set (SOURCES
@@ -29,7 +29,7 @@ target_include_directories(monitor_qt
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(monitor_qt PUBLIC Qt5::Core Qt5::Qml Qt5::WebSockets)
+target_link_libraries(monitor_qt PUBLIC Qt5::Core Qt5::WebSockets)
 target_compile_definitions(monitor_qt PRIVATE COMPILING_MONITOR_QT)
 
 # install binary files

--- a/templates/apigear/monitor/CMakeLists.txt
+++ b/templates/apigear/monitor/CMakeLists.txt
@@ -21,9 +21,11 @@ add_library(apigear::monitor_qt ALIAS monitor_qt)
 
 
 target_include_directories(monitor_qt
-    PUBLIC
+    PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     $<INSTALL_INTERFACE:include>
 )
 

--- a/templates/apigear/olink/CMakeLists.txt
+++ b/templates/apigear/olink/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 include(FetchContent)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
+find_package(Qt5 REQUIRED COMPONENTS Core WebSockets)
 
 find_package(apigear QUIET COMPONENTS olink_core)
 if(NOT olink_core_FOUND)
@@ -42,7 +42,7 @@ target_include_directories(olink_qt
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(olink_qt PUBLIC olink_core Qt5::Core Qt5::Qml Qt5::WebSockets)
+target_link_libraries(olink_qt PUBLIC olink_core Qt5::Core Qt5::WebSockets)
 target_compile_definitions(olink_qt PRIVATE OLINK_QT)
 
 # install binary files

--- a/templates/apigear/tests/olink/CMakeLists.txt
+++ b/templates/apigear/tests/olink/CMakeLists.txt
@@ -39,19 +39,6 @@ FetchContent_MakeAvailable(Catch2 trompeloeil)
 
 find_package(Catch2 REQUIRED)
 
-find_package(olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
-
 set(CMAKE_CTEST_COMMAND ctest -V)
 if(NOT TARGET check)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
@@ -78,7 +65,6 @@ add_test(test_olink test_olink)
 add_dependencies(check test_olink)
 
 target_link_libraries(test_olink PRIVATE
-    olink_core
     olink_qt
     Catch2::Catch2
     trompeloeil::trompeloeil

--- a/templates/apigear/tests/olink/CMakeLists.txt
+++ b/templates/apigear/tests/olink/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(test_olink PRIVATE
     olink_qt
     Catch2::Catch2
     trompeloeil::trompeloeil
-    Qt::Test Qt5::Core Qt5::Qml Qt5::WebSockets)
+    Qt::Test)
 
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
 include(Catch)

--- a/templates/examples/olinkclient/CMakeLists.txt.tpl
+++ b/templates/examples/olinkclient/CMakeLists.txt.tpl
@@ -4,20 +4,6 @@ project(OLinkClient)
 cmake_minimum_required(VERSION 3.20)
 
 find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets Gui)
-find_package(apigear QUIET COMPONENTS olink_qt)
-
-find_package(apigear QUIET COMPONENTS olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
 
 # append local binary directory for conan packages to be found
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR} ${CMAKE_MODULE_PATH})
@@ -45,8 +31,6 @@ target_link_libraries(OLinkClient
     {{$module_id}}_monitor{{ end -}}
 {{- end }}
 Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui
-olink_qt
-olink_core
 {{- if $features.monitor }}
 monitor_qt
 {{- end}}

--- a/templates/examples/olinkclient/CMakeLists.txt.tpl
+++ b/templates/examples/olinkclient/CMakeLists.txt.tpl
@@ -31,9 +31,6 @@ target_link_libraries(OLinkClient
     {{$module_id}}_monitor{{ end -}}
 {{- end }}
 Qt5::Gui
-{{- if $features.monitor }}
-monitor_qt
-{{- end}}
 )
 install(TARGETS OLinkClient
         RUNTIME DESTINATION bin COMPONENT Runtime)

--- a/templates/examples/olinkclient/CMakeLists.txt.tpl
+++ b/templates/examples/olinkclient/CMakeLists.txt.tpl
@@ -3,7 +3,7 @@
 project(OLinkClient)
 cmake_minimum_required(VERSION 3.20)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets Gui)
+find_package(Qt5 REQUIRED COMPONENTS Gui)
 
 # append local binary directory for conan packages to be found
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR} ${CMAKE_MODULE_PATH})
@@ -30,7 +30,7 @@ target_link_libraries(OLinkClient
     {{$module_id}}_olink{{ if $features.monitor }}
     {{$module_id}}_monitor{{ end -}}
 {{- end }}
-Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui
+Qt5::Gui
 {{- if $features.monitor }}
 monitor_qt
 {{- end}}

--- a/templates/examples/olinkclient/CMakeLists.txt.tpl
+++ b/templates/examples/olinkclient/CMakeLists.txt.tpl
@@ -47,6 +47,9 @@ target_link_libraries(OLinkClient
 Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui
 olink_qt
 olink_core
+{{- if $features.monitor }}
+monitor_qt
+{{- end}}
 )
 install(TARGETS OLinkClient
         RUNTIME DESTINATION bin COMPONENT Runtime)

--- a/templates/examples/olinkserver/CMakeLists.txt.tpl
+++ b/templates/examples/olinkserver/CMakeLists.txt.tpl
@@ -29,9 +29,6 @@ target_link_libraries(OLinkServer
     {{$module_id}}_olink{{ if $features.monitor }}
     {{$module_id}}_monitor{{ end -}}
 {{- end }}
-{{- if $features.monitor }}
-monitor_qt
-{{- end}}
 )
 
 install(TARGETS OLinkServer

--- a/templates/examples/olinkserver/CMakeLists.txt.tpl
+++ b/templates/examples/olinkserver/CMakeLists.txt.tpl
@@ -20,12 +20,11 @@ find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets Gui)
 
 {{ range .System.Modules }}
 {{- $module_id := snake .Name }}
-find_package({{$module_id}} QUIET COMPONENTS {{$module_id}}_api {{$module_id}}_impl {{$module_id}}_olink{{ if $features.monitor }} {{$module_id}}_monitor{{ end}})
+find_package({{$module_id}} QUIET COMPONENTS {{$module_id}}_impl {{$module_id}}_olink{{ if $features.monitor }} {{$module_id}}_monitor{{ end}})
 {{- end }}
 target_link_libraries(OLinkServer
 {{- range .System.Modules }}
 {{- $module_id := snake .Name }}
-    {{$module_id}}_api
     {{$module_id}}_impl
     {{$module_id}}_olink{{ if $features.monitor }}
     {{$module_id}}_monitor{{ end -}}

--- a/templates/examples/olinkserver/CMakeLists.txt.tpl
+++ b/templates/examples/olinkserver/CMakeLists.txt.tpl
@@ -17,20 +17,6 @@ add_executable(OLinkServer
 )
 
 find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets Gui)
-find_package(apigear QUIET COMPONENTS olink_qt)
-
-find_package(apigear QUIET COMPONENTS olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
 
 {{ range .System.Modules }}
 {{- $module_id := snake .Name }}
@@ -45,13 +31,10 @@ target_link_libraries(OLinkServer
     {{$module_id}}_monitor{{ end -}}
 {{- end }}
 Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui
-olink_qt
-olink_core
 {{- if $features.monitor }}
 monitor_qt
 {{- end}}
 )
-
 
 install(TARGETS OLinkServer
         RUNTIME DESTINATION bin COMPONENT Runtime)

--- a/templates/examples/olinkserver/CMakeLists.txt.tpl
+++ b/templates/examples/olinkserver/CMakeLists.txt.tpl
@@ -30,7 +30,6 @@ target_link_libraries(OLinkServer
     {{$module_id}}_olink{{ if $features.monitor }}
     {{$module_id}}_monitor{{ end -}}
 {{- end }}
-Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui
 {{- if $features.monitor }}
 monitor_qt
 {{- end}}

--- a/templates/examples/olinkserver/CMakeLists.txt.tpl
+++ b/templates/examples/olinkserver/CMakeLists.txt.tpl
@@ -47,6 +47,9 @@ target_link_libraries(OLinkServer
 Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui
 olink_qt
 olink_core
+{{- if $features.monitor }}
+monitor_qt
+{{- end}}
 )
 
 

--- a/templates/examples/qml/CMakeLists.txt.tpl
+++ b/templates/examples/qml/CMakeLists.txt.tpl
@@ -25,12 +25,11 @@ find_package(Qt5 REQUIRED COMPONENTS Gui Quick QuickControls2 QuickWidgets)
 
 {{ range .System.Modules }}
 {{- $module_id := snake .Name }}
-find_package({{$module_id}} QUIET COMPONENTS {{$module_id}}_api {{$module_id}}_impl {{$module_id}}_olink plugin_{{$module_id}}{{ if $features.monitor }} {{$module_id}}_monitor{{ end}})
+find_package({{$module_id}} QUIET COMPONENTS {{$module_id}}_impl {{$module_id}}_olink plugin_{{$module_id}}{{ if $features.monitor }} {{$module_id}}_monitor{{ end}})
 {{- end }}
 target_link_libraries(QmlExamlple
 {{- range .System.Modules }}
 {{- $module_id := snake .Name }}
-    {{$module_id}}_api
     {{$module_id}}_impl
     {{$module_id}}_olink
     plugin_{{$module_id}}{{ if $features.monitor }}

--- a/templates/examples/qml/CMakeLists.txt.tpl
+++ b/templates/examples/qml/CMakeLists.txt.tpl
@@ -36,9 +36,6 @@ target_link_libraries(QmlExamlple
     {{$module_id}}_monitor{{ end -}}
 {{- end }}
 Qt5::Gui Qt5::Quick Qt5::QuickControls2 Qt5::QuickWidgets
-{{- if $features.monitor }}
-monitor_qt
-{{- end}}
 )
 
 

--- a/templates/examples/qml/CMakeLists.txt.tpl
+++ b/templates/examples/qml/CMakeLists.txt.tpl
@@ -21,7 +21,7 @@ add_executable(QmlExamlple
     ${SOURCES}
 )
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets Gui Quick QuickControls2 QuickWidgets)
+find_package(Qt5 REQUIRED COMPONENTS Gui Quick QuickControls2 QuickWidgets)
 
 {{ range .System.Modules }}
 {{- $module_id := snake .Name }}
@@ -36,7 +36,7 @@ target_link_libraries(QmlExamlple
     plugin_{{$module_id}}{{ if $features.monitor }}
     {{$module_id}}_monitor{{ end -}}
 {{- end }}
-Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui Qt5::Quick Qt5::QuickControls2 Qt5::QuickWidgets
+Qt5::Gui Qt5::Quick Qt5::QuickControls2 Qt5::QuickWidgets
 {{- if $features.monitor }}
 monitor_qt
 {{- end}}

--- a/templates/examples/qml/CMakeLists.txt.tpl
+++ b/templates/examples/qml/CMakeLists.txt.tpl
@@ -22,20 +22,6 @@ add_executable(QmlExamlple
 )
 
 find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets Gui Quick QuickControls2 QuickWidgets)
-find_package(apigear QUIET COMPONENTS olink_qt)
-
-find_package(apigear QUIET COMPONENTS olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
 
 {{ range .System.Modules }}
 {{- $module_id := snake .Name }}
@@ -51,8 +37,6 @@ target_link_libraries(QmlExamlple
     {{$module_id}}_monitor{{ end -}}
 {{- end }}
 Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui Qt5::Quick Qt5::QuickControls2 Qt5::QuickWidgets
-olink_qt
-olink_core
 {{- if $features.monitor }}
 monitor_qt
 {{- end}}

--- a/templates/examples/qml/CMakeLists.txt.tpl
+++ b/templates/examples/qml/CMakeLists.txt.tpl
@@ -53,6 +53,9 @@ target_link_libraries(QmlExamlple
 Qt5::Core Qt5::Qml Qt5::WebSockets Qt5::Gui Qt5::Quick Qt5::QuickControls2 Qt5::QuickWidgets
 olink_qt
 olink_core
+{{- if $features.monitor }}
+monitor_qt
+{{- end}}
 )
 
 

--- a/templates/http/CMakeLists.txt.tpl
+++ b/templates/http/CMakeLists.txt.tpl
@@ -23,4 +23,4 @@ set ({{$SOURCES}}
 
 add_library({{$module_id}}_http STATIC ${ {{- $SOURCES -}} })
 target_include_directories({{$module_id}}_http PRIVATE ../{{$module_id}})
-target_link_libraries({{$module_id}}_http PRIVATE Qt5::Network {{$module_id}}_api)
+target_link_libraries({{$module_id}}_http PUBLIC Qt5::Network {{$module_id}}_api)

--- a/templates/http/CMakeLists.txt.tpl
+++ b/templates/http/CMakeLists.txt.tpl
@@ -9,7 +9,7 @@ project({{ $module_id }}_http LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network)
+find_package(Qt5 REQUIRED COMPONENTS Network)
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set ({{$SOURCES}}
@@ -23,4 +23,4 @@ set ({{$SOURCES}}
 
 add_library({{$module_id}}_http STATIC ${ {{- $SOURCES -}} })
 target_include_directories({{$module_id}}_http PRIVATE ../{{$module_id}})
-target_link_libraries({{$module_id}}_http PRIVATE Qt5::Core Qt5::Qml Qt5::Network {{$module_id}}_api)
+target_link_libraries({{$module_id}}_http PRIVATE Qt5::Network {{$module_id}}_api)

--- a/templates/library/CMakeLists.txt.tpl
+++ b/templates/library/CMakeLists.txt.tpl
@@ -32,7 +32,7 @@ target_include_directories({{$lib_id}}
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries({{$lib_id}} PRIVATE {{$module_id}}::{{snake .Module.Name}}_api)
+target_link_libraries({{$lib_id}} PUBLIC {{$module_id}}::{{snake .Module.Name}}_api)
 target_compile_definitions({{$lib_id}} PRIVATE {{ $LIB_ID }}_LIBRARY)
 
 add_subdirectory(tests)

--- a/templates/library/CMakeLists.txt.tpl
+++ b/templates/library/CMakeLists.txt.tpl
@@ -10,7 +10,6 @@ project({{ $lib_id }} LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml WebSockets)
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set ({{$LIB_ID}}_SOURCES
@@ -33,7 +32,7 @@ target_include_directories({{$lib_id}}
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries({{$lib_id}} PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets {{$module_id}}::{{snake .Module.Name}}_api)
+target_link_libraries({{$lib_id}} PRIVATE {{$module_id}}::{{snake .Module.Name}}_api)
 target_compile_definitions({{$lib_id}} PRIVATE {{ $LIB_ID }}_LIBRARY)
 
 add_subdirectory(tests)

--- a/templates/library/tests/CMakeLists.txt.tpl
+++ b/templates/library/tests/CMakeLists.txt.tpl
@@ -22,8 +22,8 @@ add_executable(test_{{$module_id}}_{{.Name|lower}} test_{{.Name|lower}}.cpp)
 {{- end }}
 
 
-find_package({{$module_id}} QUIET COMPONENTS {{$module_id}}_api {{$module_id}}_impl )
+find_package({{$module_id}} QUIET COMPONENTS {{$module_id}}_impl )
 
 {{- range .Module.Interfaces }}
-target_link_libraries(test_{{$module_id}}_{{.Name|lower}}  {{$module_id}}_api {{$module_id}}_impl Qt5::Core Qt5::Test)
+target_link_libraries(test_{{$module_id}}_{{.Name|lower}} {{$module_id}}_impl Qt5::Test)
 {{- end }}

--- a/templates/monitor/CMakeLists.txt.tpl
+++ b/templates/monitor/CMakeLists.txt.tpl
@@ -9,7 +9,6 @@ project({{$lib_id}})
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core WebSockets)
 find_package(apigear QUIET COMPONENTS monitor_qt )
 
 set ({{$SOURCES}}
@@ -30,5 +29,5 @@ target_include_directories({{$lib_id}}
     $<INSTALL_INTERFACE:include/{{$module_id}}>
 )
 
-target_link_libraries({{$lib_id}} PRIVATE {{$module_id}}::{{$module_id}}_api Qt5::Core Qt5::WebSockets apigear::monitor_qt)
+target_link_libraries({{$lib_id}} PRIVATE {{$module_id}}::{{$module_id}}_api apigear::monitor_qt)
 target_compile_definitions({{$lib_id}} PRIVATE {{ $MODULE_ID }}_LIBRARY)

--- a/templates/monitor/CMakeLists.txt.tpl
+++ b/templates/monitor/CMakeLists.txt.tpl
@@ -29,5 +29,5 @@ target_include_directories({{$lib_id}}
     $<INSTALL_INTERFACE:include/{{$module_id}}>
 )
 
-target_link_libraries({{$lib_id}} PRIVATE {{$module_id}}::{{$module_id}}_api apigear::monitor_qt)
+target_link_libraries({{$lib_id}} PUBLIC {{$module_id}}::{{$module_id}}_api apigear::monitor_qt)
 target_compile_definitions({{$lib_id}} PRIVATE {{ $MODULE_ID }}_LIBRARY)

--- a/templates/olink/CMakeLists.txt.tpl
+++ b/templates/olink/CMakeLists.txt.tpl
@@ -5,8 +5,6 @@
 {{- $SOURCES := printf "%s_OLINK_SOURCES" $MODULE_ID -}}
 project({{$lib_id}})
 
-find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
-
 set ({{$MODULE_ID}}_OLINK_SOURCES
     olinkfactory.cpp
 {{- range .Module.Interfaces }}
@@ -26,5 +24,5 @@ target_include_directories({{$lib_id}}
 )
 
 target_link_libraries({{$lib_id}} 
-PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets {{$module_id}}::{{$module_id}}_api 
+PRIVATE {{$module_id}}::{{$module_id}}_api 
 PUBLIC olink_qt qtpromise)

--- a/templates/olink/CMakeLists.txt.tpl
+++ b/templates/olink/CMakeLists.txt.tpl
@@ -23,6 +23,4 @@ target_include_directories({{$lib_id}}
     $<INSTALL_INTERFACE:include/{{$module_id}}>
 )
 
-target_link_libraries({{$lib_id}} 
-PRIVATE {{$module_id}}::{{$module_id}}_api 
-PUBLIC olink_qt qtpromise)
+target_link_libraries({{$lib_id}} PUBLIC {{$module_id}}::{{$module_id}}_api olink_qt qtpromise)

--- a/templates/olink/CMakeLists.txt.tpl
+++ b/templates/olink/CMakeLists.txt.tpl
@@ -7,18 +7,6 @@ project({{$lib_id}})
 
 find_package(Qt5 REQUIRED COMPONENTS Core Qml Network WebSockets)
 
-find_package(nlohmann_json QUIET)
-if(NOT nlohmann_json_FOUND)
-  # pull nlohmann json as dependency
-  message(STATUS "nlohmann_json NOT FOUND, fetching the release package")
-  include(FetchContent)
-  set(JSON_Install ON)
-  FetchContent_Declare(json
-  GIT_REPOSITORY https://github.com/nlohmann/json
-  GIT_TAG v3.7.3)
-  FetchContent_MakeAvailable(json)
-endif()
-
 set ({{$MODULE_ID}}_OLINK_SOURCES
     olinkfactory.cpp
 {{- range .Module.Interfaces }}
@@ -39,4 +27,4 @@ target_include_directories({{$lib_id}}
 
 target_link_libraries({{$lib_id}} 
 PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets {{$module_id}}::{{$module_id}}_api 
-PUBLIC olink_qt nlohmann_json::nlohmann_json qtpromise)
+PUBLIC olink_qt qtpromise)

--- a/templates/olink/CMakeLists.txt.tpl
+++ b/templates/olink/CMakeLists.txt.tpl
@@ -19,19 +19,6 @@ if(NOT nlohmann_json_FOUND)
   FetchContent_MakeAvailable(json)
 endif()
 
-find_package(olink_core)
-if(NOT olink_core_FOUND)
-  # pull objectlink-core-cpp as dependency
-  message(STATUS "objectlink-core-cpp NOT FOUND, fetching the git repository")
-  FetchContent_Declare(olink_core
-      GIT_REPOSITORY https://github.com/apigear-io/objectlink-core-cpp.git
-      GIT_TAG v0.2.4
-      GIT_SHALLOW TRUE
-      EXCLUDE_FROM_ALL FALSE
-  )
-  FetchContent_MakeAvailable(olink_core)
-endif()
-
 set ({{$MODULE_ID}}_OLINK_SOURCES
     olinkfactory.cpp
 {{- range .Module.Interfaces }}
@@ -50,4 +37,6 @@ target_include_directories({{$lib_id}}
     $<INSTALL_INTERFACE:include/{{$module_id}}>
 )
 
-target_link_libraries({{$lib_id}} PRIVATE olink_core Qt5::Core Qt5::Qml Qt5::WebSockets {{$module_id}}::{{$module_id}}_api PUBLIC nlohmann_json::nlohmann_json qtpromise)
+target_link_libraries({{$lib_id}} 
+PRIVATE Qt5::Core Qt5::Qml Qt5::WebSockets {{$module_id}}::{{$module_id}}_api 
+PUBLIC olink_qt nlohmann_json::nlohmann_json qtpromise)

--- a/templates/plugin/CMakeLists.txt.tpl
+++ b/templates/plugin/CMakeLists.txt.tpl
@@ -22,7 +22,7 @@ set_target_properties(plugin_{{$module_id}} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_PATH}
 )
 
-target_link_libraries(plugin_{{$module_id}} PRIVATE {{$module_id}}::{{$module_id}}_api)
+target_link_libraries(plugin_{{$module_id}} PUBLIC {{$module_id}}::{{$module_id}}_api)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${OUTPUT_PATH}/qmldir COPYONLY)
 

--- a/templates/plugin/CMakeLists.txt.tpl
+++ b/templates/plugin/CMakeLists.txt.tpl
@@ -22,7 +22,7 @@ set_target_properties(plugin_{{$module_id}} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_PATH}
 )
 
-target_link_libraries(plugin_{{$module_id}} PRIVATE Qt5::Core Qt5::Qml {{$module_id}}::{{$module_id}}_api)
+target_link_libraries(plugin_{{$module_id}} PRIVATE {{$module_id}}::{{$module_id}}_api)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmldir ${OUTPUT_PATH}/qmldir COPYONLY)
 


### PR DESCRIPTION
clean up cmakes
change linking libraries to PUBLIC where it make sense - whoever uses the lib doesn't need to include its dependencies to use it
remove unnecessary linking to libraries after the step above
applied to: olink core, olink_qt, monitor_qt, interface_api, qt core, qt qml, qt websocket, nlohmann