### PR TITLE
perf: add logger and use across project

### DIFF
--- a/goldenmaster/apigear/CMakeLists.txt
+++ b/goldenmaster/apigear/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+add_subdirectory(utilities)
 add_subdirectory(olink)
 add_subdirectory(monitor)
 

--- a/goldenmaster/apigear/monitor/CMakeLists.txt
+++ b/goldenmaster/apigear/monitor/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(monitor_qt
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(monitor_qt PUBLIC Qt5::Core Qt5::WebSockets)
+target_link_libraries(monitor_qt PUBLIC apigear::utilities_qt Qt5::Core Qt5::WebSockets)
 target_compile_definitions(monitor_qt PRIVATE COMPILING_MONITOR_QT)
 
 # install binary files

--- a/goldenmaster/apigear/monitor/agentclient.cpp
+++ b/goldenmaster/apigear/monitor/agentclient.cpp
@@ -1,5 +1,5 @@
 #include "agentclient.h"
-
+#include "../utilities/logger.h"
 #include <QtNetwork>
 
 using namespace ApiGear::Monitor;
@@ -155,7 +155,7 @@ void AgentClient::doProcess()
     while (!m_queue.isEmpty()) {
         const QJsonObject &obj = m_queue.dequeue();
         const QByteArray &data = QJsonDocument(obj).toJson();
-        qDebug() << qPrintable(data);
+        AG_LOG_DEBUG(qPrintable(data));
         m_socket->sendBinaryMessage(data);
     }
 }
@@ -185,6 +185,6 @@ void AgentClient::doSendTrace()
         return;
     }
     const QByteArray& data = QJsonDocument(batch).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG(qPrintable(data));
     m_http->post(request, data);
 }

--- a/goldenmaster/apigear/olink/CMakeLists.txt
+++ b/goldenmaster/apigear/olink/CMakeLists.txt
@@ -44,7 +44,7 @@ target_include_directories(olink_qt
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(olink_qt PUBLIC olink_core Qt5::Core Qt5::WebSockets)
+target_link_libraries(olink_qt PUBLIC apigear::utilities_qt olink_core Qt5::Core Qt5::WebSockets)
 target_compile_definitions(olink_qt PRIVATE OLINK_QT)
 
 # install binary files

--- a/goldenmaster/apigear/olink/olinkhost.cpp
+++ b/goldenmaster/apigear/olink/olinkhost.cpp
@@ -25,6 +25,7 @@
 
 #include "olinkremote.h"
 #include "olink/remoteregistry.h"
+#include "../utilities/logger.h"
 
 using namespace ApiGear::ObjectLink;
 
@@ -44,16 +45,16 @@ OLinkHost::~OLinkHost()
 
 void OLinkHost::listen(const QString& host, int port)
 {
-    qDebug() << "wss.listen()";
+    AG_LOG_INFO("wss.listen ");
     m_wss->listen(QHostAddress(host), quint16(port));
-    qDebug() << m_wss->serverAddress() << m_wss->serverPort();
+    AG_LOG_INFO(m_wss->serverAddress().toString().toStdString() + ":" + std::to_string(m_wss->serverPort()));
     connect(m_wss, &QWebSocketServer::newConnection, this, &OLinkHost::onNewConnection);
     connect(m_wss, &QWebSocketServer::closed, this, &OLinkHost::onClosed);
 }
 
 void OLinkHost::onNewConnection()
 {
-    qDebug() << "wss.newConnection()";
+    AG_LOG_INFO("wss.newConnection");
     auto ws = m_wss->nextPendingConnection();
     OLinkRemote* connectionUser = new OLinkRemote(m_registry, ws);
     ws->setParent(connectionUser);
@@ -63,7 +64,7 @@ void OLinkHost::onNewConnection()
 
 void OLinkHost::onClosed()
 {
-    qDebug() << "wss.closed()";
+    AG_LOG_INFO("wss.closed");
 }
 
 RemoteRegistry &OLinkHost::registry()

--- a/goldenmaster/apigear/olink/olinkremote.cpp
+++ b/goldenmaster/apigear/olink/olinkremote.cpp
@@ -4,6 +4,8 @@
 #include "olink/remotenode.h"
 #include <memory>
 
+#include"../utilities/logger.h"
+
 using namespace ApiGear::ObjectLink;
 
 OLinkRemote::OLinkRemote(RemoteRegistry& registry, QWebSocket* socket)
@@ -21,7 +23,8 @@ OLinkRemote::OLinkRemote(RemoteRegistry& registry, QWebSocket* socket)
 
 void OLinkRemote::writeMessage(const QString &msg)
 {
-    qDebug() << Q_FUNC_INFO << msg;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(msg);
     if(m_socket) {
         m_socket->sendTextMessage(msg);
     }
@@ -29,13 +32,13 @@ void OLinkRemote::writeMessage(const QString &msg)
 
 void OLinkRemote::handleMessage(const QString &msg)
 {
-    qDebug() << Q_FUNC_INFO << msg;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(msg);
     m_node->handleMessage(msg.toStdString());
 }
 
 void OLinkRemote::socketDisconnected()
 {
-    qDebug() << "Client disconnected, connection closed";
+    AG_LOG_INFO("Client disconnected, connection closed");
     this->deleteLater();
 }

--- a/goldenmaster/apigear/utilities/CMakeLists.txt
+++ b/goldenmaster/apigear/utilities/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.20)
+project(utilities_qt)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+find_package(Qt5 REQUIRED COMPONENTS Core)
+
+set (SOURCES
+    logger.cpp
+)
+add_library(utilities_qt SHARED ${SOURCES})
+add_library(apigear::utilities_qt ALIAS utilities_qt)
+target_include_directories(utilities_qt
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(utilities_qt PUBLIC Qt5::Core)
+
+# install binary files
+install(TARGETS utilities_qt
+        EXPORT  utilities_qtTargets
+        RUNTIME DESTINATION bin           COMPONENT Runtime
+        LIBRARY DESTINATION lib           COMPONENT Runtime
+        ARCHIVE DESTINATION lib           COMPONENT Development)
+# install includes
+install(FILES ${INCLUDES}
+        DESTINATION include/apigear/utilities)
+
+export(EXPORT utilities_qtTargets
+  NAMESPACE apigear::
+)
+
+if(BUILD_TESTING)
+add_subdirectory (tests)
+endif() # BUILD_TESTING

--- a/goldenmaster/apigear/utilities/logger.cpp
+++ b/goldenmaster/apigear/utilities/logger.cpp
@@ -1,0 +1,156 @@
+/*
+* MIT License
+*
+* Copyright (c) 2021 ApiGear
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "logger.h"
+#include <iostream>
+
+
+
+namespace ApiGear {
+namespace Utilities {
+
+// static logging functions
+static WriteLogFuncStdString logFunc = getDefaultLogStdStringFunc(LogLevel::Warning);
+static WriteLogFuncQString logFuncQString = getDefaultQStringLogFunc(LogLevel::Warning);
+static WriteLogFuncCharPtr logFuncChar = getDefaultCharLogFunc(LogLevel::Warning);
+
+// Constant text messages to add to log.
+static const std::string levelTextDebug = "[debug  ] ";
+static const std::string levelTextError = "[error  ] ";
+static const std::string levelTextWarning = "[warning] ";
+static const std::string levelTextInfo = "[info   ] ";
+
+
+void emitLog(LogLevel level, const std::string& msg) {
+    if (logFunc) {
+        logFunc(level, msg);
+    }
+}
+
+void setLogger(WriteLogFuncStdString func) {
+    logFunc = func;
+}
+
+void emitLog(LogLevel level, const QString& msg) {
+    if (logFuncQString) {
+        logFuncQString(level, msg);
+    }
+}
+
+void setLogger(WriteLogFuncQString func) {
+    logFuncQString = func;
+}
+
+void emitLog(LogLevel level, const char* msg) {
+    if (logFuncChar) {
+        logFuncChar(level, msg);
+    }
+}
+
+void setLogger(WriteLogFuncCharPtr func) {
+    logFuncChar = func;
+}
+
+WriteLogFuncStdString getDefaultLogStdStringFunc(LogLevel minimumLevel) {
+    return [minimumLevel](LogLevel level, const std::string& msg)
+    {
+        if (level < minimumLevel) {
+            return;
+        }
+
+        switch (level)
+        {
+        case LogLevel::Debug:
+            std::clog << levelTextDebug << msg << std::endl;
+            break;
+        case LogLevel::Error:
+            std::cerr << levelTextError << msg << std::endl;
+            break;
+        case LogLevel::Warning:
+            std::cerr << levelTextWarning << msg << std::endl;
+            break;
+        case LogLevel::Info:
+            std::cout << levelTextInfo << msg << std::endl;
+            break;
+        default:
+            break;
+        }
+    };
+}
+
+WriteLogFuncQString getDefaultQStringLogFunc(LogLevel minimumLevel) {
+    return [minimumLevel](LogLevel level, const QString& msg)
+    {
+        if (level < minimumLevel) {
+            return;
+        }
+
+        switch (level)
+        {
+        case LogLevel::Debug:
+            std::clog << levelTextDebug << msg.toStdString() << std::endl;
+            break;
+        case LogLevel::Error:
+            std::cerr << levelTextError << msg.toStdString() << std::endl;
+            break;
+        case LogLevel::Warning:
+            std::cerr << levelTextWarning << msg.toStdString() << std::endl;
+            break;
+        case LogLevel::Info:
+            std::cout << levelTextInfo << msg.toStdString() << std::endl;
+            break;
+        default:
+            break;
+        }
+    };
+}
+
+WriteLogFuncCharPtr getDefaultCharLogFunc(LogLevel minimumLevel) {
+    return [minimumLevel](LogLevel level, const char* msg)
+    {
+        if (level < minimumLevel) {
+            return;
+        }
+
+        switch (level)
+        {
+        case LogLevel::Debug:
+            std::clog << levelTextDebug << msg << std::endl;
+            break;
+        case LogLevel::Error:
+            std::cerr << levelTextError << msg << std::endl;
+            break;
+        case LogLevel::Warning:
+            std::cerr << levelTextWarning << msg << std::endl;
+            break;
+        case LogLevel::Info:
+            std::cout << levelTextInfo << msg << std::endl;
+            break;
+        default:
+            break;
+        }
+    };
+}
+
+
+}} // ApiGear::Utilities

--- a/goldenmaster/apigear/utilities/logger.h
+++ b/goldenmaster/apigear/utilities/logger.h
@@ -1,0 +1,196 @@
+/*
+* MIT License
+*
+* Copyright (c) 2021 ApiGear
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#pragma once
+
+#include <functional>
+#include <string>
+#include <QString>
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define APIGEAR_LOGGER __attribute__ ((dllexport))
+#else
+#define APIGEAR_LOGGER __declspec(dllexport)
+#endif
+#else
+#if __GNUC__ >= 4
+#define APIGEAR_LOGGER __attribute__ ((visibility ("default")))
+#else
+#define APIGEAR_LOGGER
+#endif
+#endif
+
+/**
+* File defines functionality for logging used in apigear implementation.
+* To avoid conversions, loggers are defined for three types of message used in the project:
+* const std::string&
+* const QString&
+* const char*
+* Have that in mind if you'd like to set your own loggers instead of default one (logging to std::cout/cerr),
+* you may want to change all three of them. See setLogger functions.
+* For convenience of use below macros are defined.
+* Alternatively we recommend using logInfo, logDebug, logWarning, logError functions.
+*/
+
+#define AG_LOG_INFO(str) ApiGear::Utilities::logInfo(str)
+#define AG_LOG_DEBUG(str) ApiGear::Utilities::logDebug(str)
+#define AG_LOG_WARNING(str) ApiGear::Utilities::logWarning(str)
+#define AG_LOG_ERROR(str) ApiGear::Utilities::logError(str)
+
+namespace ApiGear { namespace Utilities {
+
+/**
+* Logging levels for logs across the application.
+*/
+enum APIGEAR_LOGGER LogLevel {
+    Debug = 0,      // Useful for debugging during development
+    Info = 1,       // Some event happened, usually not important
+    Warning = 2,    // Important to know
+    Error = 3       // Must know - something is wrong
+};
+
+/**
+* Used to log messages of type const std::string&.
+* @param level specify the LogLevel
+* @param msg content to be logged
+*/
+void APIGEAR_LOGGER emitLog(LogLevel level, const std::string& msg);
+
+/**
+* Used to log messages of type const QString&.
+* @param level specify the LogLevel
+* @param msg content to be logged
+*/
+void APIGEAR_LOGGER emitLog(LogLevel level, const QString& msg);
+
+/**
+* Used to log messages of type const char*.
+* @param level specify the LogLevel
+* @param msg content to be logged
+*/
+void APIGEAR_LOGGER emitLog(LogLevel level, const char* msg);
+
+
+/**
+* Use to log on LogLevel::Info
+* @param msg to be logged
+* msgType should be one of: std::string&, QString&, char*.
+* For other types user must define own emitLog function.
+*/
+template<typename msgType>
+void APIGEAR_LOGGER logInfo(const msgType msg)
+{
+    emitLog(LogLevel::Info, msg);
+}
+
+/**
+* Use to log on LogLevel::Debug
+* @param msg to be logged
+* msgType should be one of: std::string&, QString&, char*.
+* For other types user must define own emitLog function.
+*/
+template<typename msgType>
+void APIGEAR_LOGGER logDebug(const msgType msg)
+{
+    emitLog(LogLevel::Debug, msg);
+}
+
+/**
+* Use to log on LogLevel::Warning
+* @param msg to be logged
+* msgType should be one of: std::string&, QString&, char*.
+* For other types user must define own emitLog function.
+*/
+template<typename msgType>
+void APIGEAR_LOGGER logWarning(const msgType msg)
+{
+    emitLog(LogLevel::Warning, msg);
+}
+
+/*
+* Use to log on LogLevel::Error
+* @param msg to be logged
+* msgType should be one of: std::string&, QString&, char*.
+* For other types user must define own emitLog function.
+*/
+template<typename msgType>
+void APIGEAR_LOGGER logError(const msgType msg)
+{
+    emitLog(LogLevel::Error, msg);
+}
+
+
+/** A type of function to log messages of const std::string& type. */
+using WriteLogFuncStdString = std::function<void(LogLevel level, const std::string& msg)>;
+/** A type of function to log messages of const QString& type. */
+using WriteLogFuncQString = std::function<void(LogLevel level, const QString& msg)>;
+/** A type of function to log of const char* type. */
+using WriteLogFuncCharPtr = std::function<void(LogLevel level, const char* msg)>;
+
+/**
+* Use to set logger function for messages of const std::string& type.
+* @param func a functions which implements the WriteLogFuncStdString signature
+*/
+void APIGEAR_LOGGER setLogger(WriteLogFuncStdString func);
+/**
+* Use to set logger function for messages of const QString& type.
+* @param func a functions which implements the WriteLogFuncQString signature
+*/
+void APIGEAR_LOGGER setLogger(WriteLogFuncQString func);
+/**
+* Use to set logger function for messages of const char* type.
+* @param func a functions which implements the WriteLogFuncCharPtr signature
+*/
+void APIGEAR_LOGGER setLogger(WriteLogFuncCharPtr func);
+
+/**
+* A getter the default logger for const std::string& messages.
+* @param minimumLevel A log level below which all the logging is skipped.
+* @return A default WriteLogFuncStdString logger function. 
+* Logs info and debug level to std::cout (if log level allows).
+* Logs warnings and errors to std::error (if log level allows).
+*/
+WriteLogFuncStdString APIGEAR_LOGGER getDefaultLogStdStringFunc(LogLevel minimumLevel);
+
+/**
+* A getter the default logger for const QString& messages.
+* @param minimumLevel A log level below which all the logging is skipped.
+* @return A default WriteLogFuncQString logger function.
+* Logs info and debug level to std::cout (if log level allows).
+* Logs warnings and errors to std::error (if log level allows).
+*/
+WriteLogFuncQString APIGEAR_LOGGER getDefaultQStringLogFunc(LogLevel minimumLevel);
+
+/**
+* A getter the default logger for const char* messages.
+* @param minimumLevel A log level below which all the logging is skipped.
+* @return A default WriteLogFuncCharPtr logger function.
+* Logs info and debug level to std::cout (if log level allows).
+* Logs warnings and errors to std::error (if log level allows).
+*/
+WriteLogFuncCharPtr APIGEAR_LOGGER getDefaultCharLogFunc(LogLevel minimumLevel);
+
+
+} } // ApiGear::Utilities
+

--- a/goldenmaster/apigear/utilities/tests/CMakeLists.txt
+++ b/goldenmaster/apigear/utilities/tests/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 3.20)
+project(test_apigear_utilities)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(CTest)
+
+
+
+
+if(BUILD_TESTING)
+enable_testing()
+
+Include(FetchContent)
+
+FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG        v2.13.8
+    GIT_SHALLOW    TRUE
+    FIND_PACKAGE_ARGS)
+
+FetchContent_MakeAvailable(Catch2)
+
+
+set(CMAKE_CTEST_COMMAND ctest -V)
+if(NOT TARGET check)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+set(TEST_APIGEAR_UTILITIES_SOURCES
+    test_main.cpp
+    logger.test.cpp
+    )
+
+add_executable(test_apigear_utilities ${TEST_APIGEAR_UTILITIES_SOURCES})
+
+# do not automatically run this test on MacOS
+# see https://github.com/apigear-io/template-qtcpp/issues/38
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+add_test(NAME test_apigear_utilities COMMAND $<TARGET_FILE:test_apigear_utilities>)
+add_dependencies(check test_apigear_utilities)
+endif() # NOT Darwin
+
+target_link_libraries(test_apigear_utilities PRIVATE apigear::utilities_qt Catch2::Catch2 Qt::Test)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_apigear_utilities
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+
+
+endif() # BUILD_TESTING

--- a/goldenmaster/apigear/utilities/tests/logger.test.cpp
+++ b/goldenmaster/apigear/utilities/tests/logger.test.cpp
@@ -1,0 +1,131 @@
+#pragma warning (disable: 4251) 
+#pragma warning (disable: 4099) 
+
+#include <catch2/catch.hpp>
+#include <iostream>
+#include <sstream>
+
+#include "../logger.h"
+
+namespace {
+    struct strTuple {
+        std::string cout;
+        std::string clog;
+        std::string cerr;
+    };
+
+    // we need to capture the strings and restore the buffers
+    // otherwise catch2 REQUIRE etc. checks cause seg faults
+    strTuple captureStdStreams(std::function<void()> testFunction)
+    {
+        using namespace std;
+        strTuple output;
+
+        // redirect std streams to be read by us
+        streambuf* oldCoutBuffer = cout.rdbuf();
+        ostringstream newCout;
+        cout.rdbuf(newCout.rdbuf());
+
+        streambuf* oldClogBuffer = clog.rdbuf();
+        ostringstream newClog;
+        clog.rdbuf(newClog.rdbuf());
+
+        streambuf* oldCerrBuffer = cerr.rdbuf();
+        ostringstream newCerr;
+        cerr.rdbuf(newCerr.rdbuf());
+
+        // run function under test
+        testFunction();
+
+        // save stream content
+        output.cout = newCout.str();
+        output.clog = newClog.str();
+        output.cerr = newCerr.str();
+
+        // reset streams
+        cout.rdbuf(oldCoutBuffer);
+        clog.rdbuf(oldClogBuffer);
+        cerr.rdbuf(oldCerrBuffer);
+
+        return output;
+    };
+
+    auto logAll = [](){
+        ApiGear::Utilities::logDebug("test loglevel debug");
+        ApiGear::Utilities::logInfo("test loglevel info");
+        ApiGear::Utilities::logWarning("test loglevel warning");
+        ApiGear::Utilities::logError("test loglevel error");
+    };
+
+}
+
+SCENARIO("Test console log", "[console][log]")
+{
+    GIVEN("Default settings") {
+        THEN("Warning and Error should be logged") {
+            strTuple output = captureStdStreams(logAll);
+            REQUIRE(output.cout.empty());
+            REQUIRE(output.clog.empty());
+            REQUIRE(output.cerr == "[warning] test loglevel warning\n[error  ] test loglevel error\n");
+        }
+    }
+
+    GIVEN("Set minimum log level to debug") {
+        ApiGear::Utilities::setLogger(ApiGear::Utilities::getDefaultCharLogFunc(ApiGear::Utilities::LogLevel::Debug));
+
+        THEN("Everything should be logged") {
+            strTuple output = captureStdStreams(logAll);
+            REQUIRE(output.cout== "[info   ] test loglevel info\n");
+            REQUIRE(output.clog=="[debug  ] test loglevel debug\n");
+            REQUIRE(output.cerr=="[warning] test loglevel warning\n[error  ] test loglevel error\n");
+        }
+    }
+
+    GIVEN("Set minimum log level to info") {
+        ApiGear::Utilities::setLogger(ApiGear::Utilities::getDefaultCharLogFunc(ApiGear::Utilities::LogLevel::Info));
+
+        THEN("Info, Warning and Error should be logged") {
+            strTuple output = captureStdStreams(logAll);
+            REQUIRE(output.cout== "[info   ] test loglevel info\n");
+            REQUIRE(output.clog.empty());
+            REQUIRE(output.cerr=="[warning] test loglevel warning\n[error  ] test loglevel error\n");
+        }
+    }
+
+    GIVEN("Set minimum log level to warning") {
+        ApiGear::Utilities::setLogger(ApiGear::Utilities::getDefaultCharLogFunc(ApiGear::Utilities::LogLevel::Warning));
+
+        THEN("Warning and Error should be logged") {
+            strTuple output = captureStdStreams(logAll);
+            REQUIRE(output.cout.empty());
+            REQUIRE(output.clog.empty());
+            REQUIRE(output.cerr=="[warning] test loglevel warning\n[error  ] test loglevel error\n");
+        }
+    }
+
+    GIVEN("Set minimum log level to error") {
+        ApiGear::Utilities::setLogger(ApiGear::Utilities::getDefaultCharLogFunc(ApiGear::Utilities::LogLevel::Error));
+
+        THEN("Error should be logged") {
+            strTuple output = captureStdStreams(logAll);
+            REQUIRE(output.cout.empty());
+            REQUIRE(output.clog.empty());
+            REQUIRE(output.cerr=="[error  ] test loglevel error\n");
+        }
+    }
+}
+
+SCENARIO("Test disabled log", "[log]")
+{
+    GIVEN("No log function defined") {
+        ApiGear::Utilities::WriteLogFuncCharPtr noFunc = nullptr;
+        ApiGear::Utilities::setLogger(noFunc);
+
+        THEN("Nothing should be logged") {
+            strTuple output = captureStdStreams(logAll);
+            REQUIRE(output.cout.empty());
+            REQUIRE(output.clog.empty());
+            REQUIRE(output.cerr.empty());
+        }
+    }
+}

--- a/goldenmaster/apigear/utilities/tests/test_main.cpp
+++ b/goldenmaster/apigear/utilities/tests/test_main.cpp
@@ -1,0 +1,7 @@
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif // __clang__
+
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch.hpp>

--- a/goldenmaster/examples/olinkclient/main.cpp
+++ b/goldenmaster/examples/olinkclient/main.cpp
@@ -2,6 +2,7 @@
 #include <QGuiApplication>
 #include "apigear/olink/olinkclient.h"
 #include "olink/clientregistry.h"
+#include "utilities/logger.h"
 #include <memory>
 #include "testbed2/olink/olinkmanyparaminterface.h"
 #include "testbed2/monitor/manyparaminterfacetraced.h"
@@ -106,13 +107,21 @@ int main(int argc, char *argv[])
 
     
     // Try out properties: subscribe for changes
-    testbed2ManyParamInterfaceTraced.connect(&testbed2ManyParamInterfaceTraced, &testbed2::AbstractManyParamInterface::prop1Changed, []( int prop1){ qDebug() << "prop1 property changed ";});
+    testbed2ManyParamInterfaceTraced.connect(&testbed2ManyParamInterfaceTraced, &testbed2::AbstractManyParamInterface::prop1Changed, 
+            []( int prop1){ 
+                static const std::string message = "prop1 property changed ";
+                AG_LOG_DEBUG(message);
+            });
     // or ask for change.
     auto local_prop1 = 0;
     testbed2ManyParamInterfaceTraced.setProp1(local_prop1);
     
     // Check the signals with subscribing for its change
-    testbed2ManyParamInterfaceTraced.connect(&testbed2ManyParamInterfaceTraced, &testbed2::AbstractManyParamInterface::sig1, [](int param1){ qDebug() << "sig1 signal emitted ";});
+    testbed2ManyParamInterfaceTraced.connect(&testbed2ManyParamInterfaceTraced, &testbed2::AbstractManyParamInterface::sig1, 
+        [](int param1){
+                static const std::string message = "sig1 signal emitted ";
+                AG_LOG_DEBUG(message);
+        });
     
     // Play around executing your operations
     auto method_result = testbed2ManyParamInterfaceTraced.func1(0);

--- a/goldenmaster/tb_enum/http/CMakeLists.txt
+++ b/goldenmaster/tb_enum/http/CMakeLists.txt
@@ -16,4 +16,4 @@ set (TB_ENUM_HTTP_SOURCES
 
 add_library(tb_enum_http STATIC ${TB_ENUM_HTTP_SOURCES})
 target_include_directories(tb_enum_http PRIVATE ../tb_enum)
-target_link_libraries(tb_enum_http PUBLIC Qt5::Network tb_enum_api)
+target_link_libraries(tb_enum_http PUBLIC apigear::utilities_qt Qt5::Network tb_enum_api)

--- a/goldenmaster/tb_enum/http/httpenuminterface.cpp
+++ b/goldenmaster/tb_enum/http/httpenuminterface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpenuminterface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -89,45 +90,41 @@ Enum3::Enum3Enum HttpEnumInterface::prop3() const
 
 Enum0::Enum0Enum HttpEnumInterface::func0(Enum0::Enum0Enum param0)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param0"] = QJsonValue::fromVariant(QVariant::fromValue< Enum0::Enum0Enum >(param0));
     QJsonObject reply = post("tb.enum/EnumInterface/func0", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Enum0::value0;
 }
 
 Enum1::Enum1Enum HttpEnumInterface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< Enum1::Enum1Enum >(param1));
     QJsonObject reply = post("tb.enum/EnumInterface/func1", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Enum1::value1;
 }
 
 Enum2::Enum2Enum HttpEnumInterface::func2(Enum2::Enum2Enum param2)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param2"] = QJsonValue::fromVariant(QVariant::fromValue< Enum2::Enum2Enum >(param2));
     QJsonObject reply = post("tb.enum/EnumInterface/func2", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Enum2::value2;
 }
 
 Enum3::Enum3Enum HttpEnumInterface::func3(Enum3::Enum3Enum param3)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param3"] = QJsonValue::fromVariant(QVariant::fromValue< Enum3::Enum3Enum >(param3));
     QJsonObject reply = post("tb.enum/EnumInterface/func3", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Enum3::value3;
 }
 
@@ -138,14 +135,14 @@ QJsonObject HttpEnumInterface::post(const QString& path, const QJsonObject &payl
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/tb_enum/implementation/enuminterface.cpp
+++ b/goldenmaster/tb_enum/implementation/enuminterface.cpp
@@ -90,25 +90,21 @@ Enum3::Enum3Enum EnumInterface::prop3() const
 
 Enum0::Enum0Enum EnumInterface::func0(Enum0::Enum0Enum param0)
 {
-    qDebug() << Q_FUNC_INFO;
     return Enum0::value0;
 }
 
 Enum1::Enum1Enum EnumInterface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
     return Enum1::value1;
 }
 
 Enum2::Enum2Enum EnumInterface::func2(Enum2::Enum2Enum param2)
 {
-    qDebug() << Q_FUNC_INFO;
     return Enum2::value2;
 }
 
 Enum3::Enum3Enum EnumInterface::func3(Enum3::Enum3Enum param3)
 {
-    qDebug() << Q_FUNC_INFO;
     return Enum3::value3;
 }
 } //namespace tb_enum

--- a/goldenmaster/tb_enum/monitor/enuminterfacetraced.cpp
+++ b/goldenmaster/tb_enum/monitor/enuminterfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "enuminterfacetraced.h"
 #include "tb_enum/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace tb_enum {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 EnumInterfaceTraced::EnumInterfaceTraced(std::shared_ptr<AbstractEnumInterface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -35,7 +37,7 @@ EnumInterfaceTraced::EnumInterfaceTraced(std::shared_ptr<AbstractEnumInterface> 
 Enum0::Enum0Enum EnumInterfaceTraced::func0(Enum0::Enum0Enum param0) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     EnumInterfaceAgent::trace_func0(this, param0);
@@ -46,7 +48,7 @@ Enum0::Enum0Enum EnumInterfaceTraced::func0(Enum0::Enum0Enum param0)
 Enum1::Enum1Enum EnumInterfaceTraced::func1(Enum1::Enum1Enum param1) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     EnumInterfaceAgent::trace_func1(this, param1);
@@ -57,7 +59,7 @@ Enum1::Enum1Enum EnumInterfaceTraced::func1(Enum1::Enum1Enum param1)
 Enum2::Enum2Enum EnumInterfaceTraced::func2(Enum2::Enum2Enum param2) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     EnumInterfaceAgent::trace_func2(this, param2);
@@ -68,7 +70,7 @@ Enum2::Enum2Enum EnumInterfaceTraced::func2(Enum2::Enum2Enum param2)
 Enum3::Enum3Enum EnumInterfaceTraced::func3(Enum3::Enum3Enum param3) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     EnumInterfaceAgent::trace_func3(this, param3);
@@ -78,7 +80,7 @@ Enum3::Enum3Enum EnumInterfaceTraced::func3(Enum3::Enum3Enum param3)
 void EnumInterfaceTraced::setProp0(Enum0::Enum0Enum prop0)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     EnumInterfaceAgent::trace_state(this);
@@ -87,7 +89,7 @@ void EnumInterfaceTraced::setProp0(Enum0::Enum0Enum prop0)
 Enum0::Enum0Enum EnumInterfaceTraced::prop0() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop0();
@@ -96,7 +98,7 @@ Enum0::Enum0Enum EnumInterfaceTraced::prop0() const
 void EnumInterfaceTraced::setProp1(Enum1::Enum1Enum prop1)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     EnumInterfaceAgent::trace_state(this);
@@ -105,7 +107,7 @@ void EnumInterfaceTraced::setProp1(Enum1::Enum1Enum prop1)
 Enum1::Enum1Enum EnumInterfaceTraced::prop1() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop1();
@@ -114,7 +116,7 @@ Enum1::Enum1Enum EnumInterfaceTraced::prop1() const
 void EnumInterfaceTraced::setProp2(Enum2::Enum2Enum prop2)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     EnumInterfaceAgent::trace_state(this);
@@ -123,7 +125,7 @@ void EnumInterfaceTraced::setProp2(Enum2::Enum2Enum prop2)
 Enum2::Enum2Enum EnumInterfaceTraced::prop2() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop2();
@@ -132,7 +134,7 @@ Enum2::Enum2Enum EnumInterfaceTraced::prop2() const
 void EnumInterfaceTraced::setProp3(Enum3::Enum3Enum prop3)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     EnumInterfaceAgent::trace_state(this);
@@ -141,7 +143,7 @@ void EnumInterfaceTraced::setProp3(Enum3::Enum3Enum prop3)
 Enum3::Enum3Enum EnumInterfaceTraced::prop3() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop3();

--- a/goldenmaster/tb_enum/monitor/tracedapifactory.cpp
+++ b/goldenmaster/tb_enum/monitor/tracedapifactory.cpp
@@ -1,4 +1,5 @@
 #include "tracedapifactory.h"
+#include "utilities/logger.h"
 #include "enuminterfacetraced.h"
 
 namespace tb_enum {
@@ -7,12 +8,12 @@ TracedApiFactory::TracedApiFactory(IApiFactory& factory, QObject *parent)
     : QObject(parent),
       m_factory(factory)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 std::shared_ptr<AbstractEnumInterface> TracedApiFactory::createEnumInterface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto enumInterface = m_factory.createEnumInterface(parent);
     return std::make_shared<EnumInterfaceTraced>(enumInterface);
 }

--- a/goldenmaster/tb_enum/olink/olinkenuminterface.cpp
+++ b/goldenmaster/tb_enum/olink/olinkenuminterface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "tb_enum/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -37,12 +38,12 @@ OLinkEnumInterface::OLinkEnumInterface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkEnumInterface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("prop0")) {
         setProp0Local(fields["prop0"].get<Enum0::Enum0Enum>());
     }
@@ -59,7 +60,7 @@ void OLinkEnumInterface::applyState(const nlohmann::json& fields)
 
 void OLinkEnumInterface::setProp0(Enum0::Enum0Enum prop0)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -68,7 +69,7 @@ void OLinkEnumInterface::setProp0(Enum0::Enum0Enum prop0)
 
 void OLinkEnumInterface::setProp0Local(Enum0::Enum0Enum prop0)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop0 != prop0) {
         m_prop0 = prop0;
         emit prop0Changed(prop0);
@@ -82,7 +83,7 @@ Enum0::Enum0Enum OLinkEnumInterface::prop0() const
 
 void OLinkEnumInterface::setProp1(Enum1::Enum1Enum prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -91,7 +92,7 @@ void OLinkEnumInterface::setProp1(Enum1::Enum1Enum prop1)
 
 void OLinkEnumInterface::setProp1Local(Enum1::Enum1Enum prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop1 != prop1) {
         m_prop1 = prop1;
         emit prop1Changed(prop1);
@@ -105,7 +106,7 @@ Enum1::Enum1Enum OLinkEnumInterface::prop1() const
 
 void OLinkEnumInterface::setProp2(Enum2::Enum2Enum prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -114,7 +115,7 @@ void OLinkEnumInterface::setProp2(Enum2::Enum2Enum prop2)
 
 void OLinkEnumInterface::setProp2Local(Enum2::Enum2Enum prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop2 != prop2) {
         m_prop2 = prop2;
         emit prop2Changed(prop2);
@@ -128,7 +129,7 @@ Enum2::Enum2Enum OLinkEnumInterface::prop2() const
 
 void OLinkEnumInterface::setProp3(Enum3::Enum3Enum prop3)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -137,7 +138,7 @@ void OLinkEnumInterface::setProp3(Enum3::Enum3Enum prop3)
 
 void OLinkEnumInterface::setProp3Local(Enum3::Enum3Enum prop3)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop3 != prop3) {
         m_prop3 = prop3;
         emit prop3Changed(prop3);
@@ -151,7 +152,7 @@ Enum3::Enum3Enum OLinkEnumInterface::prop3() const
 
 Enum0::Enum0Enum OLinkEnumInterface::func0(Enum0::Enum0Enum param0)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Enum0::value0;
     }
@@ -166,7 +167,7 @@ Enum0::Enum0Enum OLinkEnumInterface::func0(Enum0::Enum0Enum param0)
 
 QtPromise::QPromise<Enum0::Enum0Enum> OLinkEnumInterface::func0Async(Enum0::Enum0Enum param0)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Enum0::Enum0Enum>::reject("not initialized");
     }
@@ -183,7 +184,7 @@ QtPromise::QPromise<Enum0::Enum0Enum> OLinkEnumInterface::func0Async(Enum0::Enum
 
 Enum1::Enum1Enum OLinkEnumInterface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Enum1::value1;
     }
@@ -198,7 +199,7 @@ Enum1::Enum1Enum OLinkEnumInterface::func1(Enum1::Enum1Enum param1)
 
 QtPromise::QPromise<Enum1::Enum1Enum> OLinkEnumInterface::func1Async(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Enum1::Enum1Enum>::reject("not initialized");
     }
@@ -215,7 +216,7 @@ QtPromise::QPromise<Enum1::Enum1Enum> OLinkEnumInterface::func1Async(Enum1::Enum
 
 Enum2::Enum2Enum OLinkEnumInterface::func2(Enum2::Enum2Enum param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Enum2::value2;
     }
@@ -230,7 +231,7 @@ Enum2::Enum2Enum OLinkEnumInterface::func2(Enum2::Enum2Enum param2)
 
 QtPromise::QPromise<Enum2::Enum2Enum> OLinkEnumInterface::func2Async(Enum2::Enum2Enum param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Enum2::Enum2Enum>::reject("not initialized");
     }
@@ -247,7 +248,7 @@ QtPromise::QPromise<Enum2::Enum2Enum> OLinkEnumInterface::func2Async(Enum2::Enum
 
 Enum3::Enum3Enum OLinkEnumInterface::func3(Enum3::Enum3Enum param3)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Enum3::value3;
     }
@@ -262,7 +263,7 @@ Enum3::Enum3Enum OLinkEnumInterface::func3(Enum3::Enum3Enum param3)
 
 QtPromise::QPromise<Enum3::Enum3Enum> OLinkEnumInterface::func3Async(Enum3::Enum3Enum param3)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Enum3::Enum3Enum>::reject("not initialized");
     }
@@ -285,7 +286,8 @@ std::string OLinkEnumInterface::olinkObjectName()
 
 void OLinkEnumInterface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sig0") {
         emit sig0(args[0].get<Enum0::Enum0Enum>());   
@@ -307,13 +309,15 @@ void OLinkEnumInterface::olinkOnSignal(const std::string& signalId, const nlohma
 
 void OLinkEnumInterface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkEnumInterface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -322,7 +326,7 @@ void OLinkEnumInterface::olinkOnInit(const std::string& objectId, const nlohmann
 
 void OLinkEnumInterface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/tb_enum/olink/olinkenuminterfaceadapter.cpp
+++ b/goldenmaster/tb_enum/olink/olinkenuminterfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -157,7 +158,8 @@ std::string OLinkEnumInterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkEnumInterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "func0") {
         const Enum0::Enum0Enum& param0 = args.at(0);
@@ -183,7 +185,8 @@ json OLinkEnumInterfaceAdapter::olinkInvoke(const std::string& methodId, const n
 }
 
 void OLinkEnumInterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "prop0") {
         Enum0::Enum0Enum prop0 = value.get<Enum0::Enum0Enum>();
@@ -204,12 +207,14 @@ void OLinkEnumInterfaceAdapter::olinkSetProperty(const std::string& propertyId, 
 }
 
 void OLinkEnumInterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkEnumInterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkEnumInterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/tb_enum/olink/olinkfactory.cpp
+++ b/goldenmaster/tb_enum/olink/olinkfactory.cpp
@@ -1,4 +1,5 @@
 #include "olinkfactory.h"
+#include "utilities/logger.h"
 #include "olink/olinkenuminterface.h"
 
 namespace tb_enum {
@@ -7,12 +8,12 @@ OLinkFactory::OLinkFactory(ApiGear::ObjectLink::OLinkClient& client, QObject *pa
     : QObject(parent),
       m_client(client)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 std::shared_ptr<AbstractEnumInterface> OLinkFactory::createEnumInterface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto enum_interface = std::make_shared<OLinkEnumInterface>();
     m_client.linkObjectSource(enum_interface);
     return enum_interface;

--- a/goldenmaster/tb_same1/http/CMakeLists.txt
+++ b/goldenmaster/tb_same1/http/CMakeLists.txt
@@ -19,4 +19,4 @@ set (TB_SAME1_HTTP_SOURCES
 
 add_library(tb_same1_http STATIC ${TB_SAME1_HTTP_SOURCES})
 target_include_directories(tb_same1_http PRIVATE ../tb_same1)
-target_link_libraries(tb_same1_http PUBLIC Qt5::Network tb_same1_api)
+target_link_libraries(tb_same1_http PUBLIC apigear::utilities_qt Qt5::Network tb_same1_api)

--- a/goldenmaster/tb_same1/http/httpsameenum1interface.cpp
+++ b/goldenmaster/tb_same1/http/httpsameenum1interface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpsameenum1interface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -47,12 +48,11 @@ Enum1::Enum1Enum HttpSameEnum1Interface::prop1() const
 
 Enum1::Enum1Enum HttpSameEnum1Interface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< Enum1::Enum1Enum >(param1));
     QJsonObject reply = post("tb.same1/SameEnum1Interface/func1", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Enum1::value1;
 }
 
@@ -63,14 +63,14 @@ QJsonObject HttpSameEnum1Interface::post(const QString& path, const QJsonObject 
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/tb_same1/http/httpsameenum2interface.cpp
+++ b/goldenmaster/tb_same1/http/httpsameenum2interface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpsameenum2interface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -61,24 +62,22 @@ Enum2::Enum2Enum HttpSameEnum2Interface::prop2() const
 
 Enum1::Enum1Enum HttpSameEnum2Interface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< Enum1::Enum1Enum >(param1));
     QJsonObject reply = post("tb.same1/SameEnum2Interface/func1", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Enum1::value1;
 }
 
 Enum1::Enum1Enum HttpSameEnum2Interface::func2(Enum1::Enum1Enum param1, Enum2::Enum2Enum param2)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< Enum1::Enum1Enum >(param1));
     payload["param2"] = QJsonValue::fromVariant(QVariant::fromValue< Enum2::Enum2Enum >(param2));
     QJsonObject reply = post("tb.same1/SameEnum2Interface/func2", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Enum1::value1;
 }
 
@@ -89,14 +88,14 @@ QJsonObject HttpSameEnum2Interface::post(const QString& path, const QJsonObject 
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/tb_same1/http/httpsamestruct1interface.cpp
+++ b/goldenmaster/tb_same1/http/httpsamestruct1interface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpsamestruct1interface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -47,12 +48,11 @@ Struct1 HttpSameStruct1Interface::prop1() const
 
 Struct1 HttpSameStruct1Interface::func1(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< Struct1 >(param1));
     QJsonObject reply = post("tb.same1/SameStruct1Interface/func1", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Struct1();
 }
 
@@ -63,14 +63,14 @@ QJsonObject HttpSameStruct1Interface::post(const QString& path, const QJsonObjec
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/tb_same1/http/httpsamestruct2interface.cpp
+++ b/goldenmaster/tb_same1/http/httpsamestruct2interface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpsamestruct2interface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -61,24 +62,22 @@ Struct2 HttpSameStruct2Interface::prop2() const
 
 Struct1 HttpSameStruct2Interface::func1(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< Struct1 >(param1));
     QJsonObject reply = post("tb.same1/SameStruct2Interface/func1", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Struct1();
 }
 
 Struct1 HttpSameStruct2Interface::func2(const Struct1& param1, const Struct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< Struct1 >(param1));
     payload["param2"] = QJsonValue::fromVariant(QVariant::fromValue< Struct2 >(param2));
     QJsonObject reply = post("tb.same1/SameStruct2Interface/func2", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Struct1();
 }
 
@@ -89,14 +88,14 @@ QJsonObject HttpSameStruct2Interface::post(const QString& path, const QJsonObjec
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/tb_same1/implementation/sameenum1interface.cpp
+++ b/goldenmaster/tb_same1/implementation/sameenum1interface.cpp
@@ -48,7 +48,6 @@ Enum1::Enum1Enum SameEnum1Interface::prop1() const
 
 Enum1::Enum1Enum SameEnum1Interface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
     return Enum1::value1;
 }
 } //namespace tb_same1

--- a/goldenmaster/tb_same1/implementation/sameenum2interface.cpp
+++ b/goldenmaster/tb_same1/implementation/sameenum2interface.cpp
@@ -62,13 +62,11 @@ Enum2::Enum2Enum SameEnum2Interface::prop2() const
 
 Enum1::Enum1Enum SameEnum2Interface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
     return Enum1::value1;
 }
 
 Enum1::Enum1Enum SameEnum2Interface::func2(Enum1::Enum1Enum param1, Enum2::Enum2Enum param2)
 {
-    qDebug() << Q_FUNC_INFO;
     return Enum1::value1;
 }
 } //namespace tb_same1

--- a/goldenmaster/tb_same1/implementation/samestruct1interface.cpp
+++ b/goldenmaster/tb_same1/implementation/samestruct1interface.cpp
@@ -48,7 +48,6 @@ Struct1 SameStruct1Interface::prop1() const
 
 Struct1 SameStruct1Interface::func1(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
     return Struct1();
 }
 } //namespace tb_same1

--- a/goldenmaster/tb_same1/implementation/samestruct2interface.cpp
+++ b/goldenmaster/tb_same1/implementation/samestruct2interface.cpp
@@ -62,13 +62,11 @@ Struct2 SameStruct2Interface::prop2() const
 
 Struct1 SameStruct2Interface::func1(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
     return Struct1();
 }
 
 Struct1 SameStruct2Interface::func2(const Struct1& param1, const Struct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
     return Struct1();
 }
 } //namespace tb_same1

--- a/goldenmaster/tb_same1/monitor/sameenum1interfacetraced.cpp
+++ b/goldenmaster/tb_same1/monitor/sameenum1interfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "sameenum1interfacetraced.h"
 #include "tb_same1/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace tb_same1 {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 SameEnum1InterfaceTraced::SameEnum1InterfaceTraced(std::shared_ptr<AbstractSameEnum1Interface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -26,7 +28,7 @@ SameEnum1InterfaceTraced::SameEnum1InterfaceTraced(std::shared_ptr<AbstractSameE
 Enum1::Enum1Enum SameEnum1InterfaceTraced::func1(Enum1::Enum1Enum param1) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SameEnum1InterfaceAgent::trace_func1(this, param1);
@@ -36,7 +38,7 @@ Enum1::Enum1Enum SameEnum1InterfaceTraced::func1(Enum1::Enum1Enum param1)
 void SameEnum1InterfaceTraced::setProp1(Enum1::Enum1Enum prop1)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SameEnum1InterfaceAgent::trace_state(this);
@@ -45,7 +47,7 @@ void SameEnum1InterfaceTraced::setProp1(Enum1::Enum1Enum prop1)
 Enum1::Enum1Enum SameEnum1InterfaceTraced::prop1() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop1();

--- a/goldenmaster/tb_same1/monitor/sameenum2interfacetraced.cpp
+++ b/goldenmaster/tb_same1/monitor/sameenum2interfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "sameenum2interfacetraced.h"
 #include "tb_same1/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace tb_same1 {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 SameEnum2InterfaceTraced::SameEnum2InterfaceTraced(std::shared_ptr<AbstractSameEnum2Interface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -29,7 +31,7 @@ SameEnum2InterfaceTraced::SameEnum2InterfaceTraced(std::shared_ptr<AbstractSameE
 Enum1::Enum1Enum SameEnum2InterfaceTraced::func1(Enum1::Enum1Enum param1) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SameEnum2InterfaceAgent::trace_func1(this, param1);
@@ -40,7 +42,7 @@ Enum1::Enum1Enum SameEnum2InterfaceTraced::func1(Enum1::Enum1Enum param1)
 Enum1::Enum1Enum SameEnum2InterfaceTraced::func2(Enum1::Enum1Enum param1, Enum2::Enum2Enum param2) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SameEnum2InterfaceAgent::trace_func2(this, param1, param2);
@@ -50,7 +52,7 @@ Enum1::Enum1Enum SameEnum2InterfaceTraced::func2(Enum1::Enum1Enum param1, Enum2:
 void SameEnum2InterfaceTraced::setProp1(Enum1::Enum1Enum prop1)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SameEnum2InterfaceAgent::trace_state(this);
@@ -59,7 +61,7 @@ void SameEnum2InterfaceTraced::setProp1(Enum1::Enum1Enum prop1)
 Enum1::Enum1Enum SameEnum2InterfaceTraced::prop1() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop1();
@@ -68,7 +70,7 @@ Enum1::Enum1Enum SameEnum2InterfaceTraced::prop1() const
 void SameEnum2InterfaceTraced::setProp2(Enum2::Enum2Enum prop2)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SameEnum2InterfaceAgent::trace_state(this);
@@ -77,7 +79,7 @@ void SameEnum2InterfaceTraced::setProp2(Enum2::Enum2Enum prop2)
 Enum2::Enum2Enum SameEnum2InterfaceTraced::prop2() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop2();

--- a/goldenmaster/tb_same1/monitor/samestruct1interfacetraced.cpp
+++ b/goldenmaster/tb_same1/monitor/samestruct1interfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "samestruct1interfacetraced.h"
 #include "tb_same1/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace tb_same1 {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 SameStruct1InterfaceTraced::SameStruct1InterfaceTraced(std::shared_ptr<AbstractSameStruct1Interface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -26,7 +28,7 @@ SameStruct1InterfaceTraced::SameStruct1InterfaceTraced(std::shared_ptr<AbstractS
 Struct1 SameStruct1InterfaceTraced::func1(const Struct1& param1) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SameStruct1InterfaceAgent::trace_func1(this, param1);
@@ -36,7 +38,7 @@ Struct1 SameStruct1InterfaceTraced::func1(const Struct1& param1)
 void SameStruct1InterfaceTraced::setProp1(const Struct1& prop1)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SameStruct1InterfaceAgent::trace_state(this);
@@ -45,7 +47,7 @@ void SameStruct1InterfaceTraced::setProp1(const Struct1& prop1)
 Struct1 SameStruct1InterfaceTraced::prop1() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop1();

--- a/goldenmaster/tb_same1/monitor/samestruct2interfacetraced.cpp
+++ b/goldenmaster/tb_same1/monitor/samestruct2interfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "samestruct2interfacetraced.h"
 #include "tb_same1/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace tb_same1 {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 SameStruct2InterfaceTraced::SameStruct2InterfaceTraced(std::shared_ptr<AbstractSameStruct2Interface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -29,7 +31,7 @@ SameStruct2InterfaceTraced::SameStruct2InterfaceTraced(std::shared_ptr<AbstractS
 Struct1 SameStruct2InterfaceTraced::func1(const Struct1& param1) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SameStruct2InterfaceAgent::trace_func1(this, param1);
@@ -40,7 +42,7 @@ Struct1 SameStruct2InterfaceTraced::func1(const Struct1& param1)
 Struct1 SameStruct2InterfaceTraced::func2(const Struct1& param1, const Struct2& param2) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SameStruct2InterfaceAgent::trace_func2(this, param1, param2);
@@ -50,7 +52,7 @@ Struct1 SameStruct2InterfaceTraced::func2(const Struct1& param1, const Struct2& 
 void SameStruct2InterfaceTraced::setProp1(const Struct2& prop1)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SameStruct2InterfaceAgent::trace_state(this);
@@ -59,7 +61,7 @@ void SameStruct2InterfaceTraced::setProp1(const Struct2& prop1)
 Struct2 SameStruct2InterfaceTraced::prop1() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop1();
@@ -68,7 +70,7 @@ Struct2 SameStruct2InterfaceTraced::prop1() const
 void SameStruct2InterfaceTraced::setProp2(const Struct2& prop2)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SameStruct2InterfaceAgent::trace_state(this);
@@ -77,7 +79,7 @@ void SameStruct2InterfaceTraced::setProp2(const Struct2& prop2)
 Struct2 SameStruct2InterfaceTraced::prop2() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop2();

--- a/goldenmaster/tb_same1/monitor/tracedapifactory.cpp
+++ b/goldenmaster/tb_same1/monitor/tracedapifactory.cpp
@@ -1,4 +1,5 @@
 #include "tracedapifactory.h"
+#include "utilities/logger.h"
 #include "samestruct1interfacetraced.h"
 #include "samestruct2interfacetraced.h"
 #include "sameenum1interfacetraced.h"
@@ -10,33 +11,33 @@ TracedApiFactory::TracedApiFactory(IApiFactory& factory, QObject *parent)
     : QObject(parent),
       m_factory(factory)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 std::shared_ptr<AbstractSameStruct1Interface> TracedApiFactory::createSameStruct1Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto sameStruct1Interface = m_factory.createSameStruct1Interface(parent);
     return std::make_shared<SameStruct1InterfaceTraced>(sameStruct1Interface);
 }
 
 std::shared_ptr<AbstractSameStruct2Interface> TracedApiFactory::createSameStruct2Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto sameStruct2Interface = m_factory.createSameStruct2Interface(parent);
     return std::make_shared<SameStruct2InterfaceTraced>(sameStruct2Interface);
 }
 
 std::shared_ptr<AbstractSameEnum1Interface> TracedApiFactory::createSameEnum1Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto sameEnum1Interface = m_factory.createSameEnum1Interface(parent);
     return std::make_shared<SameEnum1InterfaceTraced>(sameEnum1Interface);
 }
 
 std::shared_ptr<AbstractSameEnum2Interface> TracedApiFactory::createSameEnum2Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto sameEnum2Interface = m_factory.createSameEnum2Interface(parent);
     return std::make_shared<SameEnum2InterfaceTraced>(sameEnum2Interface);
 }

--- a/goldenmaster/tb_same1/olink/olinkfactory.cpp
+++ b/goldenmaster/tb_same1/olink/olinkfactory.cpp
@@ -1,4 +1,5 @@
 #include "olinkfactory.h"
+#include "utilities/logger.h"
 #include "olink/olinksamestruct1interface.h"
 #include "olink/olinksamestruct2interface.h"
 #include "olink/olinksameenum1interface.h"
@@ -10,12 +11,12 @@ OLinkFactory::OLinkFactory(ApiGear::ObjectLink::OLinkClient& client, QObject *pa
     : QObject(parent),
       m_client(client)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 std::shared_ptr<AbstractSameStruct1Interface> OLinkFactory::createSameStruct1Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto same_struct1_interface = std::make_shared<OLinkSameStruct1Interface>();
     m_client.linkObjectSource(same_struct1_interface);
     return same_struct1_interface;
@@ -23,7 +24,7 @@ std::shared_ptr<AbstractSameStruct1Interface> OLinkFactory::createSameStruct1Int
 
 std::shared_ptr<AbstractSameStruct2Interface> OLinkFactory::createSameStruct2Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto same_struct2_interface = std::make_shared<OLinkSameStruct2Interface>();
     m_client.linkObjectSource(same_struct2_interface);
     return same_struct2_interface;
@@ -31,7 +32,7 @@ std::shared_ptr<AbstractSameStruct2Interface> OLinkFactory::createSameStruct2Int
 
 std::shared_ptr<AbstractSameEnum1Interface> OLinkFactory::createSameEnum1Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto same_enum1_interface = std::make_shared<OLinkSameEnum1Interface>();
     m_client.linkObjectSource(same_enum1_interface);
     return same_enum1_interface;
@@ -39,7 +40,7 @@ std::shared_ptr<AbstractSameEnum1Interface> OLinkFactory::createSameEnum1Interfa
 
 std::shared_ptr<AbstractSameEnum2Interface> OLinkFactory::createSameEnum2Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto same_enum2_interface = std::make_shared<OLinkSameEnum2Interface>();
     m_client.linkObjectSource(same_enum2_interface);
     return same_enum2_interface;

--- a/goldenmaster/tb_same1/olink/olinksameenum1interface.cpp
+++ b/goldenmaster/tb_same1/olink/olinksameenum1interface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "tb_same1/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -34,12 +35,12 @@ OLinkSameEnum1Interface::OLinkSameEnum1Interface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkSameEnum1Interface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("prop1")) {
         setProp1Local(fields["prop1"].get<Enum1::Enum1Enum>());
     }
@@ -47,7 +48,7 @@ void OLinkSameEnum1Interface::applyState(const nlohmann::json& fields)
 
 void OLinkSameEnum1Interface::setProp1(Enum1::Enum1Enum prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -56,7 +57,7 @@ void OLinkSameEnum1Interface::setProp1(Enum1::Enum1Enum prop1)
 
 void OLinkSameEnum1Interface::setProp1Local(Enum1::Enum1Enum prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop1 != prop1) {
         m_prop1 = prop1;
         emit prop1Changed(prop1);
@@ -70,7 +71,7 @@ Enum1::Enum1Enum OLinkSameEnum1Interface::prop1() const
 
 Enum1::Enum1Enum OLinkSameEnum1Interface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Enum1::value1;
     }
@@ -85,7 +86,7 @@ Enum1::Enum1Enum OLinkSameEnum1Interface::func1(Enum1::Enum1Enum param1)
 
 QtPromise::QPromise<Enum1::Enum1Enum> OLinkSameEnum1Interface::func1Async(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Enum1::Enum1Enum>::reject("not initialized");
     }
@@ -108,7 +109,8 @@ std::string OLinkSameEnum1Interface::olinkObjectName()
 
 void OLinkSameEnum1Interface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sig1") {
         emit sig1(args[0].get<Enum1::Enum1Enum>());   
@@ -118,13 +120,15 @@ void OLinkSameEnum1Interface::olinkOnSignal(const std::string& signalId, const n
 
 void OLinkSameEnum1Interface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkSameEnum1Interface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -133,7 +137,7 @@ void OLinkSameEnum1Interface::olinkOnInit(const std::string& objectId, const nlo
 
 void OLinkSameEnum1Interface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/tb_same1/olink/olinksameenum1interfaceadapter.cpp
+++ b/goldenmaster/tb_same1/olink/olinksameenum1interfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -82,7 +83,8 @@ std::string OLinkSameEnum1InterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkSameEnum1InterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "func1") {
         const Enum1::Enum1Enum& param1 = args.at(0);
@@ -93,7 +95,8 @@ json OLinkSameEnum1InterfaceAdapter::olinkInvoke(const std::string& methodId, co
 }
 
 void OLinkSameEnum1InterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "prop1") {
         Enum1::Enum1Enum prop1 = value.get<Enum1::Enum1Enum>();
@@ -102,12 +105,14 @@ void OLinkSameEnum1InterfaceAdapter::olinkSetProperty(const std::string& propert
 }
 
 void OLinkSameEnum1InterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkSameEnum1InterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkSameEnum1InterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/tb_same1/olink/olinksameenum2interface.cpp
+++ b/goldenmaster/tb_same1/olink/olinksameenum2interface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "tb_same1/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -35,12 +36,12 @@ OLinkSameEnum2Interface::OLinkSameEnum2Interface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkSameEnum2Interface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("prop1")) {
         setProp1Local(fields["prop1"].get<Enum1::Enum1Enum>());
     }
@@ -51,7 +52,7 @@ void OLinkSameEnum2Interface::applyState(const nlohmann::json& fields)
 
 void OLinkSameEnum2Interface::setProp1(Enum1::Enum1Enum prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -60,7 +61,7 @@ void OLinkSameEnum2Interface::setProp1(Enum1::Enum1Enum prop1)
 
 void OLinkSameEnum2Interface::setProp1Local(Enum1::Enum1Enum prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop1 != prop1) {
         m_prop1 = prop1;
         emit prop1Changed(prop1);
@@ -74,7 +75,7 @@ Enum1::Enum1Enum OLinkSameEnum2Interface::prop1() const
 
 void OLinkSameEnum2Interface::setProp2(Enum2::Enum2Enum prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -83,7 +84,7 @@ void OLinkSameEnum2Interface::setProp2(Enum2::Enum2Enum prop2)
 
 void OLinkSameEnum2Interface::setProp2Local(Enum2::Enum2Enum prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop2 != prop2) {
         m_prop2 = prop2;
         emit prop2Changed(prop2);
@@ -97,7 +98,7 @@ Enum2::Enum2Enum OLinkSameEnum2Interface::prop2() const
 
 Enum1::Enum1Enum OLinkSameEnum2Interface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Enum1::value1;
     }
@@ -112,7 +113,7 @@ Enum1::Enum1Enum OLinkSameEnum2Interface::func1(Enum1::Enum1Enum param1)
 
 QtPromise::QPromise<Enum1::Enum1Enum> OLinkSameEnum2Interface::func1Async(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Enum1::Enum1Enum>::reject("not initialized");
     }
@@ -129,7 +130,7 @@ QtPromise::QPromise<Enum1::Enum1Enum> OLinkSameEnum2Interface::func1Async(Enum1:
 
 Enum1::Enum1Enum OLinkSameEnum2Interface::func2(Enum1::Enum1Enum param1, Enum2::Enum2Enum param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Enum1::value1;
     }
@@ -144,7 +145,7 @@ Enum1::Enum1Enum OLinkSameEnum2Interface::func2(Enum1::Enum1Enum param1, Enum2::
 
 QtPromise::QPromise<Enum1::Enum1Enum> OLinkSameEnum2Interface::func2Async(Enum1::Enum1Enum param1, Enum2::Enum2Enum param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Enum1::Enum1Enum>::reject("not initialized");
     }
@@ -167,7 +168,8 @@ std::string OLinkSameEnum2Interface::olinkObjectName()
 
 void OLinkSameEnum2Interface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sig1") {
         emit sig1(args[0].get<Enum1::Enum1Enum>());   
@@ -181,13 +183,15 @@ void OLinkSameEnum2Interface::olinkOnSignal(const std::string& signalId, const n
 
 void OLinkSameEnum2Interface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkSameEnum2Interface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -196,7 +200,7 @@ void OLinkSameEnum2Interface::olinkOnInit(const std::string& objectId, const nlo
 
 void OLinkSameEnum2Interface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/tb_same1/olink/olinksameenum2interfaceadapter.cpp
+++ b/goldenmaster/tb_same1/olink/olinksameenum2interfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -107,7 +108,8 @@ std::string OLinkSameEnum2InterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkSameEnum2InterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "func1") {
         const Enum1::Enum1Enum& param1 = args.at(0);
@@ -124,7 +126,8 @@ json OLinkSameEnum2InterfaceAdapter::olinkInvoke(const std::string& methodId, co
 }
 
 void OLinkSameEnum2InterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "prop1") {
         Enum1::Enum1Enum prop1 = value.get<Enum1::Enum1Enum>();
@@ -137,12 +140,14 @@ void OLinkSameEnum2InterfaceAdapter::olinkSetProperty(const std::string& propert
 }
 
 void OLinkSameEnum2InterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkSameEnum2InterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkSameEnum2InterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/tb_same1/olink/olinksamestruct1interface.cpp
+++ b/goldenmaster/tb_same1/olink/olinksamestruct1interface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "tb_same1/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -34,12 +35,12 @@ OLinkSameStruct1Interface::OLinkSameStruct1Interface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkSameStruct1Interface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("prop1")) {
         setProp1Local(fields["prop1"].get<Struct1>());
     }
@@ -47,7 +48,7 @@ void OLinkSameStruct1Interface::applyState(const nlohmann::json& fields)
 
 void OLinkSameStruct1Interface::setProp1(const Struct1& prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -56,7 +57,7 @@ void OLinkSameStruct1Interface::setProp1(const Struct1& prop1)
 
 void OLinkSameStruct1Interface::setProp1Local(const Struct1& prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop1 != prop1) {
         m_prop1 = prop1;
         emit prop1Changed(prop1);
@@ -70,7 +71,7 @@ Struct1 OLinkSameStruct1Interface::prop1() const
 
 Struct1 OLinkSameStruct1Interface::func1(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Struct1();
     }
@@ -85,7 +86,7 @@ Struct1 OLinkSameStruct1Interface::func1(const Struct1& param1)
 
 QtPromise::QPromise<Struct1> OLinkSameStruct1Interface::func1Async(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Struct1>::reject("not initialized");
     }
@@ -108,7 +109,8 @@ std::string OLinkSameStruct1Interface::olinkObjectName()
 
 void OLinkSameStruct1Interface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sig1") {
         emit sig1(args[0].get<Struct1>());   
@@ -118,13 +120,15 @@ void OLinkSameStruct1Interface::olinkOnSignal(const std::string& signalId, const
 
 void OLinkSameStruct1Interface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkSameStruct1Interface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -133,7 +137,7 @@ void OLinkSameStruct1Interface::olinkOnInit(const std::string& objectId, const n
 
 void OLinkSameStruct1Interface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/tb_same1/olink/olinksamestruct1interfaceadapter.cpp
+++ b/goldenmaster/tb_same1/olink/olinksamestruct1interfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -82,7 +83,8 @@ std::string OLinkSameStruct1InterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkSameStruct1InterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "func1") {
         const Struct1& param1 = args.at(0);
@@ -93,7 +95,8 @@ json OLinkSameStruct1InterfaceAdapter::olinkInvoke(const std::string& methodId, 
 }
 
 void OLinkSameStruct1InterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "prop1") {
         Struct1 prop1 = value.get<Struct1>();
@@ -102,12 +105,14 @@ void OLinkSameStruct1InterfaceAdapter::olinkSetProperty(const std::string& prope
 }
 
 void OLinkSameStruct1InterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkSameStruct1InterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkSameStruct1InterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/tb_same1/olink/olinksamestruct2interface.cpp
+++ b/goldenmaster/tb_same1/olink/olinksamestruct2interface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "tb_same1/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -35,12 +36,12 @@ OLinkSameStruct2Interface::OLinkSameStruct2Interface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkSameStruct2Interface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("prop1")) {
         setProp1Local(fields["prop1"].get<Struct2>());
     }
@@ -51,7 +52,7 @@ void OLinkSameStruct2Interface::applyState(const nlohmann::json& fields)
 
 void OLinkSameStruct2Interface::setProp1(const Struct2& prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -60,7 +61,7 @@ void OLinkSameStruct2Interface::setProp1(const Struct2& prop1)
 
 void OLinkSameStruct2Interface::setProp1Local(const Struct2& prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop1 != prop1) {
         m_prop1 = prop1;
         emit prop1Changed(prop1);
@@ -74,7 +75,7 @@ Struct2 OLinkSameStruct2Interface::prop1() const
 
 void OLinkSameStruct2Interface::setProp2(const Struct2& prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -83,7 +84,7 @@ void OLinkSameStruct2Interface::setProp2(const Struct2& prop2)
 
 void OLinkSameStruct2Interface::setProp2Local(const Struct2& prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop2 != prop2) {
         m_prop2 = prop2;
         emit prop2Changed(prop2);
@@ -97,7 +98,7 @@ Struct2 OLinkSameStruct2Interface::prop2() const
 
 Struct1 OLinkSameStruct2Interface::func1(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Struct1();
     }
@@ -112,7 +113,7 @@ Struct1 OLinkSameStruct2Interface::func1(const Struct1& param1)
 
 QtPromise::QPromise<Struct1> OLinkSameStruct2Interface::func1Async(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Struct1>::reject("not initialized");
     }
@@ -129,7 +130,7 @@ QtPromise::QPromise<Struct1> OLinkSameStruct2Interface::func1Async(const Struct1
 
 Struct1 OLinkSameStruct2Interface::func2(const Struct1& param1, const Struct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Struct1();
     }
@@ -144,7 +145,7 @@ Struct1 OLinkSameStruct2Interface::func2(const Struct1& param1, const Struct2& p
 
 QtPromise::QPromise<Struct1> OLinkSameStruct2Interface::func2Async(const Struct1& param1, const Struct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Struct1>::reject("not initialized");
     }
@@ -167,7 +168,8 @@ std::string OLinkSameStruct2Interface::olinkObjectName()
 
 void OLinkSameStruct2Interface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sig1") {
         emit sig1(args[0].get<Struct1>());   
@@ -181,13 +183,15 @@ void OLinkSameStruct2Interface::olinkOnSignal(const std::string& signalId, const
 
 void OLinkSameStruct2Interface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkSameStruct2Interface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -196,7 +200,7 @@ void OLinkSameStruct2Interface::olinkOnInit(const std::string& objectId, const n
 
 void OLinkSameStruct2Interface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/tb_same1/olink/olinksamestruct2interfaceadapter.cpp
+++ b/goldenmaster/tb_same1/olink/olinksamestruct2interfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -107,7 +108,8 @@ std::string OLinkSameStruct2InterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkSameStruct2InterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "func1") {
         const Struct1& param1 = args.at(0);
@@ -124,7 +126,8 @@ json OLinkSameStruct2InterfaceAdapter::olinkInvoke(const std::string& methodId, 
 }
 
 void OLinkSameStruct2InterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "prop1") {
         Struct2 prop1 = value.get<Struct2>();
@@ -137,12 +140,14 @@ void OLinkSameStruct2InterfaceAdapter::olinkSetProperty(const std::string& prope
 }
 
 void OLinkSameStruct2InterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkSameStruct2InterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkSameStruct2InterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/tb_same2/http/CMakeLists.txt
+++ b/goldenmaster/tb_same2/http/CMakeLists.txt
@@ -19,4 +19,4 @@ set (TB_SAME2_HTTP_SOURCES
 
 add_library(tb_same2_http STATIC ${TB_SAME2_HTTP_SOURCES})
 target_include_directories(tb_same2_http PRIVATE ../tb_same2)
-target_link_libraries(tb_same2_http PUBLIC Qt5::Network tb_same2_api)
+target_link_libraries(tb_same2_http PUBLIC apigear::utilities_qt Qt5::Network tb_same2_api)

--- a/goldenmaster/tb_same2/http/httpsameenum1interface.cpp
+++ b/goldenmaster/tb_same2/http/httpsameenum1interface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpsameenum1interface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -47,12 +48,11 @@ Enum1::Enum1Enum HttpSameEnum1Interface::prop1() const
 
 Enum1::Enum1Enum HttpSameEnum1Interface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< Enum1::Enum1Enum >(param1));
     QJsonObject reply = post("tb.same2/SameEnum1Interface/func1", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Enum1::value1;
 }
 
@@ -63,14 +63,14 @@ QJsonObject HttpSameEnum1Interface::post(const QString& path, const QJsonObject 
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/tb_same2/http/httpsameenum2interface.cpp
+++ b/goldenmaster/tb_same2/http/httpsameenum2interface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpsameenum2interface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -61,24 +62,22 @@ Enum2::Enum2Enum HttpSameEnum2Interface::prop2() const
 
 Enum1::Enum1Enum HttpSameEnum2Interface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< Enum1::Enum1Enum >(param1));
     QJsonObject reply = post("tb.same2/SameEnum2Interface/func1", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Enum1::value1;
 }
 
 Enum1::Enum1Enum HttpSameEnum2Interface::func2(Enum1::Enum1Enum param1, Enum2::Enum2Enum param2)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< Enum1::Enum1Enum >(param1));
     payload["param2"] = QJsonValue::fromVariant(QVariant::fromValue< Enum2::Enum2Enum >(param2));
     QJsonObject reply = post("tb.same2/SameEnum2Interface/func2", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Enum1::value1;
 }
 
@@ -89,14 +88,14 @@ QJsonObject HttpSameEnum2Interface::post(const QString& path, const QJsonObject 
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/tb_same2/http/httpsamestruct1interface.cpp
+++ b/goldenmaster/tb_same2/http/httpsamestruct1interface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpsamestruct1interface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -47,12 +48,11 @@ Struct1 HttpSameStruct1Interface::prop1() const
 
 Struct1 HttpSameStruct1Interface::func1(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< Struct1 >(param1));
     QJsonObject reply = post("tb.same2/SameStruct1Interface/func1", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Struct1();
 }
 
@@ -63,14 +63,14 @@ QJsonObject HttpSameStruct1Interface::post(const QString& path, const QJsonObjec
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/tb_same2/http/httpsamestruct2interface.cpp
+++ b/goldenmaster/tb_same2/http/httpsamestruct2interface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpsamestruct2interface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -61,24 +62,22 @@ Struct2 HttpSameStruct2Interface::prop2() const
 
 Struct1 HttpSameStruct2Interface::func1(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< Struct1 >(param1));
     QJsonObject reply = post("tb.same2/SameStruct2Interface/func1", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Struct1();
 }
 
 Struct1 HttpSameStruct2Interface::func2(const Struct1& param1, const Struct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< Struct1 >(param1));
     payload["param2"] = QJsonValue::fromVariant(QVariant::fromValue< Struct2 >(param2));
     QJsonObject reply = post("tb.same2/SameStruct2Interface/func2", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return Struct1();
 }
 
@@ -89,14 +88,14 @@ QJsonObject HttpSameStruct2Interface::post(const QString& path, const QJsonObjec
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/tb_same2/implementation/sameenum1interface.cpp
+++ b/goldenmaster/tb_same2/implementation/sameenum1interface.cpp
@@ -48,7 +48,6 @@ Enum1::Enum1Enum SameEnum1Interface::prop1() const
 
 Enum1::Enum1Enum SameEnum1Interface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
     return Enum1::value1;
 }
 } //namespace tb_same2

--- a/goldenmaster/tb_same2/implementation/sameenum2interface.cpp
+++ b/goldenmaster/tb_same2/implementation/sameenum2interface.cpp
@@ -62,13 +62,11 @@ Enum2::Enum2Enum SameEnum2Interface::prop2() const
 
 Enum1::Enum1Enum SameEnum2Interface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
     return Enum1::value1;
 }
 
 Enum1::Enum1Enum SameEnum2Interface::func2(Enum1::Enum1Enum param1, Enum2::Enum2Enum param2)
 {
-    qDebug() << Q_FUNC_INFO;
     return Enum1::value1;
 }
 } //namespace tb_same2

--- a/goldenmaster/tb_same2/implementation/samestruct1interface.cpp
+++ b/goldenmaster/tb_same2/implementation/samestruct1interface.cpp
@@ -48,7 +48,6 @@ Struct1 SameStruct1Interface::prop1() const
 
 Struct1 SameStruct1Interface::func1(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
     return Struct1();
 }
 } //namespace tb_same2

--- a/goldenmaster/tb_same2/implementation/samestruct2interface.cpp
+++ b/goldenmaster/tb_same2/implementation/samestruct2interface.cpp
@@ -62,13 +62,11 @@ Struct2 SameStruct2Interface::prop2() const
 
 Struct1 SameStruct2Interface::func1(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
     return Struct1();
 }
 
 Struct1 SameStruct2Interface::func2(const Struct1& param1, const Struct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
     return Struct1();
 }
 } //namespace tb_same2

--- a/goldenmaster/tb_same2/monitor/sameenum1interfacetraced.cpp
+++ b/goldenmaster/tb_same2/monitor/sameenum1interfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "sameenum1interfacetraced.h"
 #include "tb_same2/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace tb_same2 {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 SameEnum1InterfaceTraced::SameEnum1InterfaceTraced(std::shared_ptr<AbstractSameEnum1Interface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -26,7 +28,7 @@ SameEnum1InterfaceTraced::SameEnum1InterfaceTraced(std::shared_ptr<AbstractSameE
 Enum1::Enum1Enum SameEnum1InterfaceTraced::func1(Enum1::Enum1Enum param1) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SameEnum1InterfaceAgent::trace_func1(this, param1);
@@ -36,7 +38,7 @@ Enum1::Enum1Enum SameEnum1InterfaceTraced::func1(Enum1::Enum1Enum param1)
 void SameEnum1InterfaceTraced::setProp1(Enum1::Enum1Enum prop1)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SameEnum1InterfaceAgent::trace_state(this);
@@ -45,7 +47,7 @@ void SameEnum1InterfaceTraced::setProp1(Enum1::Enum1Enum prop1)
 Enum1::Enum1Enum SameEnum1InterfaceTraced::prop1() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop1();

--- a/goldenmaster/tb_same2/monitor/sameenum2interfacetraced.cpp
+++ b/goldenmaster/tb_same2/monitor/sameenum2interfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "sameenum2interfacetraced.h"
 #include "tb_same2/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace tb_same2 {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 SameEnum2InterfaceTraced::SameEnum2InterfaceTraced(std::shared_ptr<AbstractSameEnum2Interface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -29,7 +31,7 @@ SameEnum2InterfaceTraced::SameEnum2InterfaceTraced(std::shared_ptr<AbstractSameE
 Enum1::Enum1Enum SameEnum2InterfaceTraced::func1(Enum1::Enum1Enum param1) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SameEnum2InterfaceAgent::trace_func1(this, param1);
@@ -40,7 +42,7 @@ Enum1::Enum1Enum SameEnum2InterfaceTraced::func1(Enum1::Enum1Enum param1)
 Enum1::Enum1Enum SameEnum2InterfaceTraced::func2(Enum1::Enum1Enum param1, Enum2::Enum2Enum param2) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SameEnum2InterfaceAgent::trace_func2(this, param1, param2);
@@ -50,7 +52,7 @@ Enum1::Enum1Enum SameEnum2InterfaceTraced::func2(Enum1::Enum1Enum param1, Enum2:
 void SameEnum2InterfaceTraced::setProp1(Enum1::Enum1Enum prop1)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SameEnum2InterfaceAgent::trace_state(this);
@@ -59,7 +61,7 @@ void SameEnum2InterfaceTraced::setProp1(Enum1::Enum1Enum prop1)
 Enum1::Enum1Enum SameEnum2InterfaceTraced::prop1() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop1();
@@ -68,7 +70,7 @@ Enum1::Enum1Enum SameEnum2InterfaceTraced::prop1() const
 void SameEnum2InterfaceTraced::setProp2(Enum2::Enum2Enum prop2)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SameEnum2InterfaceAgent::trace_state(this);
@@ -77,7 +79,7 @@ void SameEnum2InterfaceTraced::setProp2(Enum2::Enum2Enum prop2)
 Enum2::Enum2Enum SameEnum2InterfaceTraced::prop2() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop2();

--- a/goldenmaster/tb_same2/monitor/samestruct1interfacetraced.cpp
+++ b/goldenmaster/tb_same2/monitor/samestruct1interfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "samestruct1interfacetraced.h"
 #include "tb_same2/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace tb_same2 {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 SameStruct1InterfaceTraced::SameStruct1InterfaceTraced(std::shared_ptr<AbstractSameStruct1Interface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -26,7 +28,7 @@ SameStruct1InterfaceTraced::SameStruct1InterfaceTraced(std::shared_ptr<AbstractS
 Struct1 SameStruct1InterfaceTraced::func1(const Struct1& param1) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SameStruct1InterfaceAgent::trace_func1(this, param1);
@@ -36,7 +38,7 @@ Struct1 SameStruct1InterfaceTraced::func1(const Struct1& param1)
 void SameStruct1InterfaceTraced::setProp1(const Struct1& prop1)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SameStruct1InterfaceAgent::trace_state(this);
@@ -45,7 +47,7 @@ void SameStruct1InterfaceTraced::setProp1(const Struct1& prop1)
 Struct1 SameStruct1InterfaceTraced::prop1() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop1();

--- a/goldenmaster/tb_same2/monitor/samestruct2interfacetraced.cpp
+++ b/goldenmaster/tb_same2/monitor/samestruct2interfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "samestruct2interfacetraced.h"
 #include "tb_same2/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace tb_same2 {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 SameStruct2InterfaceTraced::SameStruct2InterfaceTraced(std::shared_ptr<AbstractSameStruct2Interface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -29,7 +31,7 @@ SameStruct2InterfaceTraced::SameStruct2InterfaceTraced(std::shared_ptr<AbstractS
 Struct1 SameStruct2InterfaceTraced::func1(const Struct1& param1) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SameStruct2InterfaceAgent::trace_func1(this, param1);
@@ -40,7 +42,7 @@ Struct1 SameStruct2InterfaceTraced::func1(const Struct1& param1)
 Struct1 SameStruct2InterfaceTraced::func2(const Struct1& param1, const Struct2& param2) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SameStruct2InterfaceAgent::trace_func2(this, param1, param2);
@@ -50,7 +52,7 @@ Struct1 SameStruct2InterfaceTraced::func2(const Struct1& param1, const Struct2& 
 void SameStruct2InterfaceTraced::setProp1(const Struct2& prop1)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SameStruct2InterfaceAgent::trace_state(this);
@@ -59,7 +61,7 @@ void SameStruct2InterfaceTraced::setProp1(const Struct2& prop1)
 Struct2 SameStruct2InterfaceTraced::prop1() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop1();
@@ -68,7 +70,7 @@ Struct2 SameStruct2InterfaceTraced::prop1() const
 void SameStruct2InterfaceTraced::setProp2(const Struct2& prop2)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SameStruct2InterfaceAgent::trace_state(this);
@@ -77,7 +79,7 @@ void SameStruct2InterfaceTraced::setProp2(const Struct2& prop2)
 Struct2 SameStruct2InterfaceTraced::prop2() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop2();

--- a/goldenmaster/tb_same2/monitor/tracedapifactory.cpp
+++ b/goldenmaster/tb_same2/monitor/tracedapifactory.cpp
@@ -1,4 +1,5 @@
 #include "tracedapifactory.h"
+#include "utilities/logger.h"
 #include "samestruct1interfacetraced.h"
 #include "samestruct2interfacetraced.h"
 #include "sameenum1interfacetraced.h"
@@ -10,33 +11,33 @@ TracedApiFactory::TracedApiFactory(IApiFactory& factory, QObject *parent)
     : QObject(parent),
       m_factory(factory)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 std::shared_ptr<AbstractSameStruct1Interface> TracedApiFactory::createSameStruct1Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto sameStruct1Interface = m_factory.createSameStruct1Interface(parent);
     return std::make_shared<SameStruct1InterfaceTraced>(sameStruct1Interface);
 }
 
 std::shared_ptr<AbstractSameStruct2Interface> TracedApiFactory::createSameStruct2Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto sameStruct2Interface = m_factory.createSameStruct2Interface(parent);
     return std::make_shared<SameStruct2InterfaceTraced>(sameStruct2Interface);
 }
 
 std::shared_ptr<AbstractSameEnum1Interface> TracedApiFactory::createSameEnum1Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto sameEnum1Interface = m_factory.createSameEnum1Interface(parent);
     return std::make_shared<SameEnum1InterfaceTraced>(sameEnum1Interface);
 }
 
 std::shared_ptr<AbstractSameEnum2Interface> TracedApiFactory::createSameEnum2Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto sameEnum2Interface = m_factory.createSameEnum2Interface(parent);
     return std::make_shared<SameEnum2InterfaceTraced>(sameEnum2Interface);
 }

--- a/goldenmaster/tb_same2/olink/olinkfactory.cpp
+++ b/goldenmaster/tb_same2/olink/olinkfactory.cpp
@@ -1,4 +1,5 @@
 #include "olinkfactory.h"
+#include "utilities/logger.h"
 #include "olink/olinksamestruct1interface.h"
 #include "olink/olinksamestruct2interface.h"
 #include "olink/olinksameenum1interface.h"
@@ -10,12 +11,12 @@ OLinkFactory::OLinkFactory(ApiGear::ObjectLink::OLinkClient& client, QObject *pa
     : QObject(parent),
       m_client(client)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 std::shared_ptr<AbstractSameStruct1Interface> OLinkFactory::createSameStruct1Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto same_struct1_interface = std::make_shared<OLinkSameStruct1Interface>();
     m_client.linkObjectSource(same_struct1_interface);
     return same_struct1_interface;
@@ -23,7 +24,7 @@ std::shared_ptr<AbstractSameStruct1Interface> OLinkFactory::createSameStruct1Int
 
 std::shared_ptr<AbstractSameStruct2Interface> OLinkFactory::createSameStruct2Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto same_struct2_interface = std::make_shared<OLinkSameStruct2Interface>();
     m_client.linkObjectSource(same_struct2_interface);
     return same_struct2_interface;
@@ -31,7 +32,7 @@ std::shared_ptr<AbstractSameStruct2Interface> OLinkFactory::createSameStruct2Int
 
 std::shared_ptr<AbstractSameEnum1Interface> OLinkFactory::createSameEnum1Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto same_enum1_interface = std::make_shared<OLinkSameEnum1Interface>();
     m_client.linkObjectSource(same_enum1_interface);
     return same_enum1_interface;
@@ -39,7 +40,7 @@ std::shared_ptr<AbstractSameEnum1Interface> OLinkFactory::createSameEnum1Interfa
 
 std::shared_ptr<AbstractSameEnum2Interface> OLinkFactory::createSameEnum2Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto same_enum2_interface = std::make_shared<OLinkSameEnum2Interface>();
     m_client.linkObjectSource(same_enum2_interface);
     return same_enum2_interface;

--- a/goldenmaster/tb_same2/olink/olinksameenum1interface.cpp
+++ b/goldenmaster/tb_same2/olink/olinksameenum1interface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "tb_same2/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -34,12 +35,12 @@ OLinkSameEnum1Interface::OLinkSameEnum1Interface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkSameEnum1Interface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("prop1")) {
         setProp1Local(fields["prop1"].get<Enum1::Enum1Enum>());
     }
@@ -47,7 +48,7 @@ void OLinkSameEnum1Interface::applyState(const nlohmann::json& fields)
 
 void OLinkSameEnum1Interface::setProp1(Enum1::Enum1Enum prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -56,7 +57,7 @@ void OLinkSameEnum1Interface::setProp1(Enum1::Enum1Enum prop1)
 
 void OLinkSameEnum1Interface::setProp1Local(Enum1::Enum1Enum prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop1 != prop1) {
         m_prop1 = prop1;
         emit prop1Changed(prop1);
@@ -70,7 +71,7 @@ Enum1::Enum1Enum OLinkSameEnum1Interface::prop1() const
 
 Enum1::Enum1Enum OLinkSameEnum1Interface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Enum1::value1;
     }
@@ -85,7 +86,7 @@ Enum1::Enum1Enum OLinkSameEnum1Interface::func1(Enum1::Enum1Enum param1)
 
 QtPromise::QPromise<Enum1::Enum1Enum> OLinkSameEnum1Interface::func1Async(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Enum1::Enum1Enum>::reject("not initialized");
     }
@@ -108,7 +109,8 @@ std::string OLinkSameEnum1Interface::olinkObjectName()
 
 void OLinkSameEnum1Interface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sig1") {
         emit sig1(args[0].get<Enum1::Enum1Enum>());   
@@ -118,13 +120,15 @@ void OLinkSameEnum1Interface::olinkOnSignal(const std::string& signalId, const n
 
 void OLinkSameEnum1Interface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkSameEnum1Interface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -133,7 +137,7 @@ void OLinkSameEnum1Interface::olinkOnInit(const std::string& objectId, const nlo
 
 void OLinkSameEnum1Interface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/tb_same2/olink/olinksameenum1interfaceadapter.cpp
+++ b/goldenmaster/tb_same2/olink/olinksameenum1interfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -82,7 +83,8 @@ std::string OLinkSameEnum1InterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkSameEnum1InterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "func1") {
         const Enum1::Enum1Enum& param1 = args.at(0);
@@ -93,7 +95,8 @@ json OLinkSameEnum1InterfaceAdapter::olinkInvoke(const std::string& methodId, co
 }
 
 void OLinkSameEnum1InterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "prop1") {
         Enum1::Enum1Enum prop1 = value.get<Enum1::Enum1Enum>();
@@ -102,12 +105,14 @@ void OLinkSameEnum1InterfaceAdapter::olinkSetProperty(const std::string& propert
 }
 
 void OLinkSameEnum1InterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkSameEnum1InterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkSameEnum1InterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/tb_same2/olink/olinksameenum2interface.cpp
+++ b/goldenmaster/tb_same2/olink/olinksameenum2interface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "tb_same2/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -35,12 +36,12 @@ OLinkSameEnum2Interface::OLinkSameEnum2Interface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkSameEnum2Interface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("prop1")) {
         setProp1Local(fields["prop1"].get<Enum1::Enum1Enum>());
     }
@@ -51,7 +52,7 @@ void OLinkSameEnum2Interface::applyState(const nlohmann::json& fields)
 
 void OLinkSameEnum2Interface::setProp1(Enum1::Enum1Enum prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -60,7 +61,7 @@ void OLinkSameEnum2Interface::setProp1(Enum1::Enum1Enum prop1)
 
 void OLinkSameEnum2Interface::setProp1Local(Enum1::Enum1Enum prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop1 != prop1) {
         m_prop1 = prop1;
         emit prop1Changed(prop1);
@@ -74,7 +75,7 @@ Enum1::Enum1Enum OLinkSameEnum2Interface::prop1() const
 
 void OLinkSameEnum2Interface::setProp2(Enum2::Enum2Enum prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -83,7 +84,7 @@ void OLinkSameEnum2Interface::setProp2(Enum2::Enum2Enum prop2)
 
 void OLinkSameEnum2Interface::setProp2Local(Enum2::Enum2Enum prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop2 != prop2) {
         m_prop2 = prop2;
         emit prop2Changed(prop2);
@@ -97,7 +98,7 @@ Enum2::Enum2Enum OLinkSameEnum2Interface::prop2() const
 
 Enum1::Enum1Enum OLinkSameEnum2Interface::func1(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Enum1::value1;
     }
@@ -112,7 +113,7 @@ Enum1::Enum1Enum OLinkSameEnum2Interface::func1(Enum1::Enum1Enum param1)
 
 QtPromise::QPromise<Enum1::Enum1Enum> OLinkSameEnum2Interface::func1Async(Enum1::Enum1Enum param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Enum1::Enum1Enum>::reject("not initialized");
     }
@@ -129,7 +130,7 @@ QtPromise::QPromise<Enum1::Enum1Enum> OLinkSameEnum2Interface::func1Async(Enum1:
 
 Enum1::Enum1Enum OLinkSameEnum2Interface::func2(Enum1::Enum1Enum param1, Enum2::Enum2Enum param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Enum1::value1;
     }
@@ -144,7 +145,7 @@ Enum1::Enum1Enum OLinkSameEnum2Interface::func2(Enum1::Enum1Enum param1, Enum2::
 
 QtPromise::QPromise<Enum1::Enum1Enum> OLinkSameEnum2Interface::func2Async(Enum1::Enum1Enum param1, Enum2::Enum2Enum param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Enum1::Enum1Enum>::reject("not initialized");
     }
@@ -167,7 +168,8 @@ std::string OLinkSameEnum2Interface::olinkObjectName()
 
 void OLinkSameEnum2Interface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sig1") {
         emit sig1(args[0].get<Enum1::Enum1Enum>());   
@@ -181,13 +183,15 @@ void OLinkSameEnum2Interface::olinkOnSignal(const std::string& signalId, const n
 
 void OLinkSameEnum2Interface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkSameEnum2Interface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -196,7 +200,7 @@ void OLinkSameEnum2Interface::olinkOnInit(const std::string& objectId, const nlo
 
 void OLinkSameEnum2Interface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/tb_same2/olink/olinksameenum2interfaceadapter.cpp
+++ b/goldenmaster/tb_same2/olink/olinksameenum2interfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -107,7 +108,8 @@ std::string OLinkSameEnum2InterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkSameEnum2InterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "func1") {
         const Enum1::Enum1Enum& param1 = args.at(0);
@@ -124,7 +126,8 @@ json OLinkSameEnum2InterfaceAdapter::olinkInvoke(const std::string& methodId, co
 }
 
 void OLinkSameEnum2InterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "prop1") {
         Enum1::Enum1Enum prop1 = value.get<Enum1::Enum1Enum>();
@@ -137,12 +140,14 @@ void OLinkSameEnum2InterfaceAdapter::olinkSetProperty(const std::string& propert
 }
 
 void OLinkSameEnum2InterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkSameEnum2InterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkSameEnum2InterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/tb_same2/olink/olinksamestruct1interface.cpp
+++ b/goldenmaster/tb_same2/olink/olinksamestruct1interface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "tb_same2/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -34,12 +35,12 @@ OLinkSameStruct1Interface::OLinkSameStruct1Interface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkSameStruct1Interface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("prop1")) {
         setProp1Local(fields["prop1"].get<Struct1>());
     }
@@ -47,7 +48,7 @@ void OLinkSameStruct1Interface::applyState(const nlohmann::json& fields)
 
 void OLinkSameStruct1Interface::setProp1(const Struct1& prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -56,7 +57,7 @@ void OLinkSameStruct1Interface::setProp1(const Struct1& prop1)
 
 void OLinkSameStruct1Interface::setProp1Local(const Struct1& prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop1 != prop1) {
         m_prop1 = prop1;
         emit prop1Changed(prop1);
@@ -70,7 +71,7 @@ Struct1 OLinkSameStruct1Interface::prop1() const
 
 Struct1 OLinkSameStruct1Interface::func1(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Struct1();
     }
@@ -85,7 +86,7 @@ Struct1 OLinkSameStruct1Interface::func1(const Struct1& param1)
 
 QtPromise::QPromise<Struct1> OLinkSameStruct1Interface::func1Async(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Struct1>::reject("not initialized");
     }
@@ -108,7 +109,8 @@ std::string OLinkSameStruct1Interface::olinkObjectName()
 
 void OLinkSameStruct1Interface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sig1") {
         emit sig1(args[0].get<Struct1>());   
@@ -118,13 +120,15 @@ void OLinkSameStruct1Interface::olinkOnSignal(const std::string& signalId, const
 
 void OLinkSameStruct1Interface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkSameStruct1Interface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -133,7 +137,7 @@ void OLinkSameStruct1Interface::olinkOnInit(const std::string& objectId, const n
 
 void OLinkSameStruct1Interface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/tb_same2/olink/olinksamestruct1interfaceadapter.cpp
+++ b/goldenmaster/tb_same2/olink/olinksamestruct1interfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -82,7 +83,8 @@ std::string OLinkSameStruct1InterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkSameStruct1InterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "func1") {
         const Struct1& param1 = args.at(0);
@@ -93,7 +95,8 @@ json OLinkSameStruct1InterfaceAdapter::olinkInvoke(const std::string& methodId, 
 }
 
 void OLinkSameStruct1InterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "prop1") {
         Struct1 prop1 = value.get<Struct1>();
@@ -102,12 +105,14 @@ void OLinkSameStruct1InterfaceAdapter::olinkSetProperty(const std::string& prope
 }
 
 void OLinkSameStruct1InterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkSameStruct1InterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkSameStruct1InterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/tb_same2/olink/olinksamestruct2interface.cpp
+++ b/goldenmaster/tb_same2/olink/olinksamestruct2interface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "tb_same2/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -35,12 +36,12 @@ OLinkSameStruct2Interface::OLinkSameStruct2Interface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkSameStruct2Interface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("prop1")) {
         setProp1Local(fields["prop1"].get<Struct2>());
     }
@@ -51,7 +52,7 @@ void OLinkSameStruct2Interface::applyState(const nlohmann::json& fields)
 
 void OLinkSameStruct2Interface::setProp1(const Struct2& prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -60,7 +61,7 @@ void OLinkSameStruct2Interface::setProp1(const Struct2& prop1)
 
 void OLinkSameStruct2Interface::setProp1Local(const Struct2& prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop1 != prop1) {
         m_prop1 = prop1;
         emit prop1Changed(prop1);
@@ -74,7 +75,7 @@ Struct2 OLinkSameStruct2Interface::prop1() const
 
 void OLinkSameStruct2Interface::setProp2(const Struct2& prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -83,7 +84,7 @@ void OLinkSameStruct2Interface::setProp2(const Struct2& prop2)
 
 void OLinkSameStruct2Interface::setProp2Local(const Struct2& prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop2 != prop2) {
         m_prop2 = prop2;
         emit prop2Changed(prop2);
@@ -97,7 +98,7 @@ Struct2 OLinkSameStruct2Interface::prop2() const
 
 Struct1 OLinkSameStruct2Interface::func1(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Struct1();
     }
@@ -112,7 +113,7 @@ Struct1 OLinkSameStruct2Interface::func1(const Struct1& param1)
 
 QtPromise::QPromise<Struct1> OLinkSameStruct2Interface::func1Async(const Struct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Struct1>::reject("not initialized");
     }
@@ -129,7 +130,7 @@ QtPromise::QPromise<Struct1> OLinkSameStruct2Interface::func1Async(const Struct1
 
 Struct1 OLinkSameStruct2Interface::func2(const Struct1& param1, const Struct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return Struct1();
     }
@@ -144,7 +145,7 @@ Struct1 OLinkSameStruct2Interface::func2(const Struct1& param1, const Struct2& p
 
 QtPromise::QPromise<Struct1> OLinkSameStruct2Interface::func2Async(const Struct1& param1, const Struct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<Struct1>::reject("not initialized");
     }
@@ -167,7 +168,8 @@ std::string OLinkSameStruct2Interface::olinkObjectName()
 
 void OLinkSameStruct2Interface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sig1") {
         emit sig1(args[0].get<Struct1>());   
@@ -181,13 +183,15 @@ void OLinkSameStruct2Interface::olinkOnSignal(const std::string& signalId, const
 
 void OLinkSameStruct2Interface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkSameStruct2Interface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -196,7 +200,7 @@ void OLinkSameStruct2Interface::olinkOnInit(const std::string& objectId, const n
 
 void OLinkSameStruct2Interface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/tb_same2/olink/olinksamestruct2interfaceadapter.cpp
+++ b/goldenmaster/tb_same2/olink/olinksamestruct2interfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -107,7 +108,8 @@ std::string OLinkSameStruct2InterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkSameStruct2InterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "func1") {
         const Struct1& param1 = args.at(0);
@@ -124,7 +126,8 @@ json OLinkSameStruct2InterfaceAdapter::olinkInvoke(const std::string& methodId, 
 }
 
 void OLinkSameStruct2InterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "prop1") {
         Struct2 prop1 = value.get<Struct2>();
@@ -137,12 +140,14 @@ void OLinkSameStruct2InterfaceAdapter::olinkSetProperty(const std::string& prope
 }
 
 void OLinkSameStruct2InterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkSameStruct2InterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkSameStruct2InterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/tb_simple/http/CMakeLists.txt
+++ b/goldenmaster/tb_simple/http/CMakeLists.txt
@@ -17,4 +17,4 @@ set (TB_SIMPLE_HTTP_SOURCES
 
 add_library(tb_simple_http STATIC ${TB_SIMPLE_HTTP_SOURCES})
 target_include_directories(tb_simple_http PRIVATE ../tb_simple)
-target_link_libraries(tb_simple_http PUBLIC Qt5::Network tb_simple_api)
+target_link_libraries(tb_simple_http PUBLIC apigear::utilities_qt Qt5::Network tb_simple_api)

--- a/goldenmaster/tb_simple/http/httpsimplearrayinterface.cpp
+++ b/goldenmaster/tb_simple/http/httpsimplearrayinterface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpsimplearrayinterface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -145,89 +146,81 @@ QList<QString> HttpSimpleArrayInterface::propString() const
 
 QList<bool> HttpSimpleArrayInterface::funcBool(const QList<bool>& paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramBool"] = QJsonValue::fromVariant(QVariant::fromValue< QList<bool> >(paramBool));
     QJsonObject reply = post("tb.simple/SimpleArrayInterface/funcBool", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return QList<bool>();
 }
 
 QList<int> HttpSimpleArrayInterface::funcInt(const QList<int>& paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramInt"] = QJsonValue::fromVariant(QVariant::fromValue< QList<int> >(paramInt));
     QJsonObject reply = post("tb.simple/SimpleArrayInterface/funcInt", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return QList<int>();
 }
 
 QList<qint32> HttpSimpleArrayInterface::funcInt32(const QList<qint32>& paramInt32)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramInt32"] = QJsonValue::fromVariant(QVariant::fromValue< QList<qint32> >(paramInt32));
     QJsonObject reply = post("tb.simple/SimpleArrayInterface/funcInt32", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return QList<qint32>();
 }
 
 QList<qint64> HttpSimpleArrayInterface::funcInt64(const QList<qint64>& paramInt64)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramInt64"] = QJsonValue::fromVariant(QVariant::fromValue< QList<qint64> >(paramInt64));
     QJsonObject reply = post("tb.simple/SimpleArrayInterface/funcInt64", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return QList<qint64>();
 }
 
 QList<qreal> HttpSimpleArrayInterface::funcFloat(const QList<qreal>& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramFloat"] = QJsonValue::fromVariant(QVariant::fromValue< QList<qreal> >(paramFloat));
     QJsonObject reply = post("tb.simple/SimpleArrayInterface/funcFloat", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return QList<qreal>();
 }
 
 QList<float> HttpSimpleArrayInterface::funcFloat32(const QList<float>& paramFloat32)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramFloat32"] = QJsonValue::fromVariant(QVariant::fromValue< QList<float> >(paramFloat32));
     QJsonObject reply = post("tb.simple/SimpleArrayInterface/funcFloat32", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return QList<float>();
 }
 
 QList<double> HttpSimpleArrayInterface::funcFloat64(const QList<double>& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramFloat"] = QJsonValue::fromVariant(QVariant::fromValue< QList<double> >(paramFloat));
     QJsonObject reply = post("tb.simple/SimpleArrayInterface/funcFloat64", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return QList<double>();
 }
 
 QList<QString> HttpSimpleArrayInterface::funcString(const QList<QString>& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramString"] = QJsonValue::fromVariant(QVariant::fromValue< QList<QString> >(paramString));
     QJsonObject reply = post("tb.simple/SimpleArrayInterface/funcString", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return QList<QString>();
 }
 
@@ -238,14 +231,14 @@ QJsonObject HttpSimpleArrayInterface::post(const QString& path, const QJsonObjec
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/tb_simple/http/httpsimpleinterface.cpp
+++ b/goldenmaster/tb_simple/http/httpsimpleinterface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpsimpleinterface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -145,99 +146,90 @@ QString HttpSimpleInterface::propString() const
 
 void HttpSimpleInterface::funcVoid()
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     QJsonObject reply = post("tb.simple/SimpleInterface/funcVoid", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return;
 }
 
 bool HttpSimpleInterface::funcBool(bool paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramBool"] = QJsonValue::fromVariant(QVariant::fromValue< bool >(paramBool));
     QJsonObject reply = post("tb.simple/SimpleInterface/funcBool", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return false;
 }
 
 int HttpSimpleInterface::funcInt(int paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramInt"] = QJsonValue::fromVariant(QVariant::fromValue< int >(paramInt));
     QJsonObject reply = post("tb.simple/SimpleInterface/funcInt", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return 0;
 }
 
 qint32 HttpSimpleInterface::funcInt32(qint32 paramInt32)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramInt32"] = QJsonValue::fromVariant(QVariant::fromValue< qint32 >(paramInt32));
     QJsonObject reply = post("tb.simple/SimpleInterface/funcInt32", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return 0;
 }
 
 qint64 HttpSimpleInterface::funcInt64(qint64 paramInt64)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramInt64"] = QJsonValue::fromVariant(QVariant::fromValue< qint64 >(paramInt64));
     QJsonObject reply = post("tb.simple/SimpleInterface/funcInt64", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return 0LL;
 }
 
 qreal HttpSimpleInterface::funcFloat(qreal paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramFloat"] = QJsonValue::fromVariant(QVariant::fromValue< qreal >(paramFloat));
     QJsonObject reply = post("tb.simple/SimpleInterface/funcFloat", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return 0.0f;
 }
 
 float HttpSimpleInterface::funcFloat32(float paramFloat32)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramFloat32"] = QJsonValue::fromVariant(QVariant::fromValue< float >(paramFloat32));
     QJsonObject reply = post("tb.simple/SimpleInterface/funcFloat32", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return 0.0f;
 }
 
 double HttpSimpleInterface::funcFloat64(double paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramFloat"] = QJsonValue::fromVariant(QVariant::fromValue< double >(paramFloat));
     QJsonObject reply = post("tb.simple/SimpleInterface/funcFloat64", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return 0.0;
 }
 
 QString HttpSimpleInterface::funcString(const QString& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramString"] = QJsonValue::fromVariant(QVariant::fromValue< QString >(paramString));
     QJsonObject reply = post("tb.simple/SimpleInterface/funcString", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return QString();
 }
 
@@ -248,14 +240,14 @@ QJsonObject HttpSimpleInterface::post(const QString& path, const QJsonObject &pa
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/tb_simple/implementation/simplearrayinterface.cpp
+++ b/goldenmaster/tb_simple/implementation/simplearrayinterface.cpp
@@ -146,49 +146,41 @@ QList<QString> SimpleArrayInterface::propString() const
 
 QList<bool> SimpleArrayInterface::funcBool(const QList<bool>& paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
     return QList<bool>();
 }
 
 QList<int> SimpleArrayInterface::funcInt(const QList<int>& paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
     return QList<int>();
 }
 
 QList<qint32> SimpleArrayInterface::funcInt32(const QList<qint32>& paramInt32)
 {
-    qDebug() << Q_FUNC_INFO;
     return QList<qint32>();
 }
 
 QList<qint64> SimpleArrayInterface::funcInt64(const QList<qint64>& paramInt64)
 {
-    qDebug() << Q_FUNC_INFO;
     return QList<qint64>();
 }
 
 QList<qreal> SimpleArrayInterface::funcFloat(const QList<qreal>& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
     return QList<qreal>();
 }
 
 QList<float> SimpleArrayInterface::funcFloat32(const QList<float>& paramFloat32)
 {
-    qDebug() << Q_FUNC_INFO;
     return QList<float>();
 }
 
 QList<double> SimpleArrayInterface::funcFloat64(const QList<double>& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
     return QList<double>();
 }
 
 QList<QString> SimpleArrayInterface::funcString(const QList<QString>& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
     return QList<QString>();
 }
 } //namespace tb_simple

--- a/goldenmaster/tb_simple/implementation/simpleinterface.cpp
+++ b/goldenmaster/tb_simple/implementation/simpleinterface.cpp
@@ -146,55 +146,46 @@ QString SimpleInterface::propString() const
 
 void SimpleInterface::funcVoid()
 {
-    qDebug() << Q_FUNC_INFO;
     return;
 }
 
 bool SimpleInterface::funcBool(bool paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
     return false;
 }
 
 int SimpleInterface::funcInt(int paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
     return 0;
 }
 
 qint32 SimpleInterface::funcInt32(qint32 paramInt32)
 {
-    qDebug() << Q_FUNC_INFO;
     return 0;
 }
 
 qint64 SimpleInterface::funcInt64(qint64 paramInt64)
 {
-    qDebug() << Q_FUNC_INFO;
     return 0LL;
 }
 
 qreal SimpleInterface::funcFloat(qreal paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
     return 0.0f;
 }
 
 float SimpleInterface::funcFloat32(float paramFloat32)
 {
-    qDebug() << Q_FUNC_INFO;
     return 0.0f;
 }
 
 double SimpleInterface::funcFloat64(double paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
     return 0.0;
 }
 
 QString SimpleInterface::funcString(const QString& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
     return QString();
 }
 } //namespace tb_simple

--- a/goldenmaster/tb_simple/monitor/simplearrayinterfacetraced.cpp
+++ b/goldenmaster/tb_simple/monitor/simplearrayinterfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "simplearrayinterfacetraced.h"
 #include "tb_simple/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace tb_simple {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 SimpleArrayInterfaceTraced::SimpleArrayInterfaceTraced(std::shared_ptr<AbstractSimpleArrayInterface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -47,7 +49,7 @@ SimpleArrayInterfaceTraced::SimpleArrayInterfaceTraced(std::shared_ptr<AbstractS
 QList<bool> SimpleArrayInterfaceTraced::funcBool(const QList<bool>& paramBool) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleArrayInterfaceAgent::trace_funcBool(this, paramBool);
@@ -58,7 +60,7 @@ QList<bool> SimpleArrayInterfaceTraced::funcBool(const QList<bool>& paramBool)
 QList<int> SimpleArrayInterfaceTraced::funcInt(const QList<int>& paramInt) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleArrayInterfaceAgent::trace_funcInt(this, paramInt);
@@ -69,7 +71,7 @@ QList<int> SimpleArrayInterfaceTraced::funcInt(const QList<int>& paramInt)
 QList<qint32> SimpleArrayInterfaceTraced::funcInt32(const QList<qint32>& paramInt32) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleArrayInterfaceAgent::trace_funcInt32(this, paramInt32);
@@ -80,7 +82,7 @@ QList<qint32> SimpleArrayInterfaceTraced::funcInt32(const QList<qint32>& paramIn
 QList<qint64> SimpleArrayInterfaceTraced::funcInt64(const QList<qint64>& paramInt64) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleArrayInterfaceAgent::trace_funcInt64(this, paramInt64);
@@ -91,7 +93,7 @@ QList<qint64> SimpleArrayInterfaceTraced::funcInt64(const QList<qint64>& paramIn
 QList<qreal> SimpleArrayInterfaceTraced::funcFloat(const QList<qreal>& paramFloat) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleArrayInterfaceAgent::trace_funcFloat(this, paramFloat);
@@ -102,7 +104,7 @@ QList<qreal> SimpleArrayInterfaceTraced::funcFloat(const QList<qreal>& paramFloa
 QList<float> SimpleArrayInterfaceTraced::funcFloat32(const QList<float>& paramFloat32) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleArrayInterfaceAgent::trace_funcFloat32(this, paramFloat32);
@@ -113,7 +115,7 @@ QList<float> SimpleArrayInterfaceTraced::funcFloat32(const QList<float>& paramFl
 QList<double> SimpleArrayInterfaceTraced::funcFloat64(const QList<double>& paramFloat) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleArrayInterfaceAgent::trace_funcFloat64(this, paramFloat);
@@ -124,7 +126,7 @@ QList<double> SimpleArrayInterfaceTraced::funcFloat64(const QList<double>& param
 QList<QString> SimpleArrayInterfaceTraced::funcString(const QList<QString>& paramString) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleArrayInterfaceAgent::trace_funcString(this, paramString);
@@ -134,7 +136,7 @@ QList<QString> SimpleArrayInterfaceTraced::funcString(const QList<QString>& para
 void SimpleArrayInterfaceTraced::setPropBool(const QList<bool>& propBool)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleArrayInterfaceAgent::trace_state(this);
@@ -143,7 +145,7 @@ void SimpleArrayInterfaceTraced::setPropBool(const QList<bool>& propBool)
 QList<bool> SimpleArrayInterfaceTraced::propBool() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propBool();
@@ -152,7 +154,7 @@ QList<bool> SimpleArrayInterfaceTraced::propBool() const
 void SimpleArrayInterfaceTraced::setPropInt(const QList<int>& propInt)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleArrayInterfaceAgent::trace_state(this);
@@ -161,7 +163,7 @@ void SimpleArrayInterfaceTraced::setPropInt(const QList<int>& propInt)
 QList<int> SimpleArrayInterfaceTraced::propInt() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propInt();
@@ -170,7 +172,7 @@ QList<int> SimpleArrayInterfaceTraced::propInt() const
 void SimpleArrayInterfaceTraced::setPropInt32(const QList<qint32>& propInt32)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleArrayInterfaceAgent::trace_state(this);
@@ -179,7 +181,7 @@ void SimpleArrayInterfaceTraced::setPropInt32(const QList<qint32>& propInt32)
 QList<qint32> SimpleArrayInterfaceTraced::propInt32() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propInt32();
@@ -188,7 +190,7 @@ QList<qint32> SimpleArrayInterfaceTraced::propInt32() const
 void SimpleArrayInterfaceTraced::setPropInt64(const QList<qint64>& propInt64)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleArrayInterfaceAgent::trace_state(this);
@@ -197,7 +199,7 @@ void SimpleArrayInterfaceTraced::setPropInt64(const QList<qint64>& propInt64)
 QList<qint64> SimpleArrayInterfaceTraced::propInt64() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propInt64();
@@ -206,7 +208,7 @@ QList<qint64> SimpleArrayInterfaceTraced::propInt64() const
 void SimpleArrayInterfaceTraced::setPropFloat(const QList<qreal>& propFloat)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleArrayInterfaceAgent::trace_state(this);
@@ -215,7 +217,7 @@ void SimpleArrayInterfaceTraced::setPropFloat(const QList<qreal>& propFloat)
 QList<qreal> SimpleArrayInterfaceTraced::propFloat() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propFloat();
@@ -224,7 +226,7 @@ QList<qreal> SimpleArrayInterfaceTraced::propFloat() const
 void SimpleArrayInterfaceTraced::setPropFloat32(const QList<float>& propFloat32)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleArrayInterfaceAgent::trace_state(this);
@@ -233,7 +235,7 @@ void SimpleArrayInterfaceTraced::setPropFloat32(const QList<float>& propFloat32)
 QList<float> SimpleArrayInterfaceTraced::propFloat32() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propFloat32();
@@ -242,7 +244,7 @@ QList<float> SimpleArrayInterfaceTraced::propFloat32() const
 void SimpleArrayInterfaceTraced::setPropFloat64(const QList<double>& propFloat64)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleArrayInterfaceAgent::trace_state(this);
@@ -251,7 +253,7 @@ void SimpleArrayInterfaceTraced::setPropFloat64(const QList<double>& propFloat64
 QList<double> SimpleArrayInterfaceTraced::propFloat64() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propFloat64();
@@ -260,7 +262,7 @@ QList<double> SimpleArrayInterfaceTraced::propFloat64() const
 void SimpleArrayInterfaceTraced::setPropString(const QList<QString>& propString)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleArrayInterfaceAgent::trace_state(this);
@@ -269,7 +271,7 @@ void SimpleArrayInterfaceTraced::setPropString(const QList<QString>& propString)
 QList<QString> SimpleArrayInterfaceTraced::propString() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propString();

--- a/goldenmaster/tb_simple/monitor/simpleinterfacetraced.cpp
+++ b/goldenmaster/tb_simple/monitor/simpleinterfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "simpleinterfacetraced.h"
 #include "tb_simple/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace tb_simple {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 SimpleInterfaceTraced::SimpleInterfaceTraced(std::shared_ptr<AbstractSimpleInterface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -49,7 +51,7 @@ SimpleInterfaceTraced::SimpleInterfaceTraced(std::shared_ptr<AbstractSimpleInter
 void SimpleInterfaceTraced::funcVoid() 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return ;
     }
     SimpleInterfaceAgent::trace_funcVoid(this );
@@ -60,7 +62,7 @@ void SimpleInterfaceTraced::funcVoid()
 bool SimpleInterfaceTraced::funcBool(bool paramBool) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleInterfaceAgent::trace_funcBool(this, paramBool);
@@ -71,7 +73,7 @@ bool SimpleInterfaceTraced::funcBool(bool paramBool)
 int SimpleInterfaceTraced::funcInt(int paramInt) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleInterfaceAgent::trace_funcInt(this, paramInt);
@@ -82,7 +84,7 @@ int SimpleInterfaceTraced::funcInt(int paramInt)
 qint32 SimpleInterfaceTraced::funcInt32(qint32 paramInt32) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleInterfaceAgent::trace_funcInt32(this, paramInt32);
@@ -93,7 +95,7 @@ qint32 SimpleInterfaceTraced::funcInt32(qint32 paramInt32)
 qint64 SimpleInterfaceTraced::funcInt64(qint64 paramInt64) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleInterfaceAgent::trace_funcInt64(this, paramInt64);
@@ -104,7 +106,7 @@ qint64 SimpleInterfaceTraced::funcInt64(qint64 paramInt64)
 qreal SimpleInterfaceTraced::funcFloat(qreal paramFloat) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleInterfaceAgent::trace_funcFloat(this, paramFloat);
@@ -115,7 +117,7 @@ qreal SimpleInterfaceTraced::funcFloat(qreal paramFloat)
 float SimpleInterfaceTraced::funcFloat32(float paramFloat32) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleInterfaceAgent::trace_funcFloat32(this, paramFloat32);
@@ -126,7 +128,7 @@ float SimpleInterfaceTraced::funcFloat32(float paramFloat32)
 double SimpleInterfaceTraced::funcFloat64(double paramFloat) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleInterfaceAgent::trace_funcFloat64(this, paramFloat);
@@ -137,7 +139,7 @@ double SimpleInterfaceTraced::funcFloat64(double paramFloat)
 QString SimpleInterfaceTraced::funcString(const QString& paramString) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     SimpleInterfaceAgent::trace_funcString(this, paramString);
@@ -147,7 +149,7 @@ QString SimpleInterfaceTraced::funcString(const QString& paramString)
 void SimpleInterfaceTraced::setPropBool(bool propBool)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleInterfaceAgent::trace_state(this);
@@ -156,7 +158,7 @@ void SimpleInterfaceTraced::setPropBool(bool propBool)
 bool SimpleInterfaceTraced::propBool() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propBool();
@@ -165,7 +167,7 @@ bool SimpleInterfaceTraced::propBool() const
 void SimpleInterfaceTraced::setPropInt(int propInt)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleInterfaceAgent::trace_state(this);
@@ -174,7 +176,7 @@ void SimpleInterfaceTraced::setPropInt(int propInt)
 int SimpleInterfaceTraced::propInt() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propInt();
@@ -183,7 +185,7 @@ int SimpleInterfaceTraced::propInt() const
 void SimpleInterfaceTraced::setPropInt32(qint32 propInt32)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleInterfaceAgent::trace_state(this);
@@ -192,7 +194,7 @@ void SimpleInterfaceTraced::setPropInt32(qint32 propInt32)
 qint32 SimpleInterfaceTraced::propInt32() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propInt32();
@@ -201,7 +203,7 @@ qint32 SimpleInterfaceTraced::propInt32() const
 void SimpleInterfaceTraced::setPropInt64(qint64 propInt64)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleInterfaceAgent::trace_state(this);
@@ -210,7 +212,7 @@ void SimpleInterfaceTraced::setPropInt64(qint64 propInt64)
 qint64 SimpleInterfaceTraced::propInt64() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propInt64();
@@ -219,7 +221,7 @@ qint64 SimpleInterfaceTraced::propInt64() const
 void SimpleInterfaceTraced::setPropFloat(qreal propFloat)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleInterfaceAgent::trace_state(this);
@@ -228,7 +230,7 @@ void SimpleInterfaceTraced::setPropFloat(qreal propFloat)
 qreal SimpleInterfaceTraced::propFloat() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propFloat();
@@ -237,7 +239,7 @@ qreal SimpleInterfaceTraced::propFloat() const
 void SimpleInterfaceTraced::setPropFloat32(float propFloat32)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleInterfaceAgent::trace_state(this);
@@ -246,7 +248,7 @@ void SimpleInterfaceTraced::setPropFloat32(float propFloat32)
 float SimpleInterfaceTraced::propFloat32() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propFloat32();
@@ -255,7 +257,7 @@ float SimpleInterfaceTraced::propFloat32() const
 void SimpleInterfaceTraced::setPropFloat64(double propFloat64)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleInterfaceAgent::trace_state(this);
@@ -264,7 +266,7 @@ void SimpleInterfaceTraced::setPropFloat64(double propFloat64)
 double SimpleInterfaceTraced::propFloat64() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propFloat64();
@@ -273,7 +275,7 @@ double SimpleInterfaceTraced::propFloat64() const
 void SimpleInterfaceTraced::setPropString(const QString& propString)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     SimpleInterfaceAgent::trace_state(this);
@@ -282,7 +284,7 @@ void SimpleInterfaceTraced::setPropString(const QString& propString)
 QString SimpleInterfaceTraced::propString() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propString();

--- a/goldenmaster/tb_simple/monitor/tracedapifactory.cpp
+++ b/goldenmaster/tb_simple/monitor/tracedapifactory.cpp
@@ -1,4 +1,5 @@
 #include "tracedapifactory.h"
+#include "utilities/logger.h"
 #include "simpleinterfacetraced.h"
 #include "simplearrayinterfacetraced.h"
 
@@ -8,19 +9,19 @@ TracedApiFactory::TracedApiFactory(IApiFactory& factory, QObject *parent)
     : QObject(parent),
       m_factory(factory)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 std::shared_ptr<AbstractSimpleInterface> TracedApiFactory::createSimpleInterface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto simpleInterface = m_factory.createSimpleInterface(parent);
     return std::make_shared<SimpleInterfaceTraced>(simpleInterface);
 }
 
 std::shared_ptr<AbstractSimpleArrayInterface> TracedApiFactory::createSimpleArrayInterface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto simpleArrayInterface = m_factory.createSimpleArrayInterface(parent);
     return std::make_shared<SimpleArrayInterfaceTraced>(simpleArrayInterface);
 }

--- a/goldenmaster/tb_simple/olink/olinkfactory.cpp
+++ b/goldenmaster/tb_simple/olink/olinkfactory.cpp
@@ -1,4 +1,5 @@
 #include "olinkfactory.h"
+#include "utilities/logger.h"
 #include "olink/olinksimpleinterface.h"
 #include "olink/olinksimplearrayinterface.h"
 
@@ -8,12 +9,12 @@ OLinkFactory::OLinkFactory(ApiGear::ObjectLink::OLinkClient& client, QObject *pa
     : QObject(parent),
       m_client(client)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 std::shared_ptr<AbstractSimpleInterface> OLinkFactory::createSimpleInterface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto simple_interface = std::make_shared<OLinkSimpleInterface>();
     m_client.linkObjectSource(simple_interface);
     return simple_interface;
@@ -21,7 +22,7 @@ std::shared_ptr<AbstractSimpleInterface> OLinkFactory::createSimpleInterface(QOb
 
 std::shared_ptr<AbstractSimpleArrayInterface> OLinkFactory::createSimpleArrayInterface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto simple_array_interface = std::make_shared<OLinkSimpleArrayInterface>();
     m_client.linkObjectSource(simple_array_interface);
     return simple_array_interface;

--- a/goldenmaster/tb_simple/olink/olinksimplearrayinterface.cpp
+++ b/goldenmaster/tb_simple/olink/olinksimplearrayinterface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "tb_simple/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -41,12 +42,12 @@ OLinkSimpleArrayInterface::OLinkSimpleArrayInterface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkSimpleArrayInterface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("propBool")) {
         setPropBoolLocal(fields["propBool"].get<QList<bool>>());
     }
@@ -75,7 +76,7 @@ void OLinkSimpleArrayInterface::applyState(const nlohmann::json& fields)
 
 void OLinkSimpleArrayInterface::setPropBool(const QList<bool>& propBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -84,7 +85,7 @@ void OLinkSimpleArrayInterface::setPropBool(const QList<bool>& propBool)
 
 void OLinkSimpleArrayInterface::setPropBoolLocal(const QList<bool>& propBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propBool != propBool) {
         m_propBool = propBool;
         emit propBoolChanged(propBool);
@@ -98,7 +99,7 @@ QList<bool> OLinkSimpleArrayInterface::propBool() const
 
 void OLinkSimpleArrayInterface::setPropInt(const QList<int>& propInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -107,7 +108,7 @@ void OLinkSimpleArrayInterface::setPropInt(const QList<int>& propInt)
 
 void OLinkSimpleArrayInterface::setPropIntLocal(const QList<int>& propInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propInt != propInt) {
         m_propInt = propInt;
         emit propIntChanged(propInt);
@@ -121,7 +122,7 @@ QList<int> OLinkSimpleArrayInterface::propInt() const
 
 void OLinkSimpleArrayInterface::setPropInt32(const QList<qint32>& propInt32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -130,7 +131,7 @@ void OLinkSimpleArrayInterface::setPropInt32(const QList<qint32>& propInt32)
 
 void OLinkSimpleArrayInterface::setPropInt32Local(const QList<qint32>& propInt32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propInt32 != propInt32) {
         m_propInt32 = propInt32;
         emit propInt32Changed(propInt32);
@@ -144,7 +145,7 @@ QList<qint32> OLinkSimpleArrayInterface::propInt32() const
 
 void OLinkSimpleArrayInterface::setPropInt64(const QList<qint64>& propInt64)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -153,7 +154,7 @@ void OLinkSimpleArrayInterface::setPropInt64(const QList<qint64>& propInt64)
 
 void OLinkSimpleArrayInterface::setPropInt64Local(const QList<qint64>& propInt64)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propInt64 != propInt64) {
         m_propInt64 = propInt64;
         emit propInt64Changed(propInt64);
@@ -167,7 +168,7 @@ QList<qint64> OLinkSimpleArrayInterface::propInt64() const
 
 void OLinkSimpleArrayInterface::setPropFloat(const QList<qreal>& propFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -176,7 +177,7 @@ void OLinkSimpleArrayInterface::setPropFloat(const QList<qreal>& propFloat)
 
 void OLinkSimpleArrayInterface::setPropFloatLocal(const QList<qreal>& propFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propFloat != propFloat) {
         m_propFloat = propFloat;
         emit propFloatChanged(propFloat);
@@ -190,7 +191,7 @@ QList<qreal> OLinkSimpleArrayInterface::propFloat() const
 
 void OLinkSimpleArrayInterface::setPropFloat32(const QList<float>& propFloat32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -199,7 +200,7 @@ void OLinkSimpleArrayInterface::setPropFloat32(const QList<float>& propFloat32)
 
 void OLinkSimpleArrayInterface::setPropFloat32Local(const QList<float>& propFloat32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propFloat32 != propFloat32) {
         m_propFloat32 = propFloat32;
         emit propFloat32Changed(propFloat32);
@@ -213,7 +214,7 @@ QList<float> OLinkSimpleArrayInterface::propFloat32() const
 
 void OLinkSimpleArrayInterface::setPropFloat64(const QList<double>& propFloat64)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -222,7 +223,7 @@ void OLinkSimpleArrayInterface::setPropFloat64(const QList<double>& propFloat64)
 
 void OLinkSimpleArrayInterface::setPropFloat64Local(const QList<double>& propFloat64)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propFloat64 != propFloat64) {
         m_propFloat64 = propFloat64;
         emit propFloat64Changed(propFloat64);
@@ -236,7 +237,7 @@ QList<double> OLinkSimpleArrayInterface::propFloat64() const
 
 void OLinkSimpleArrayInterface::setPropString(const QList<QString>& propString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -245,7 +246,7 @@ void OLinkSimpleArrayInterface::setPropString(const QList<QString>& propString)
 
 void OLinkSimpleArrayInterface::setPropStringLocal(const QList<QString>& propString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propString != propString) {
         m_propString = propString;
         emit propStringChanged(propString);
@@ -259,7 +260,7 @@ QList<QString> OLinkSimpleArrayInterface::propString() const
 
 QList<bool> OLinkSimpleArrayInterface::funcBool(const QList<bool>& paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QList<bool>();
     }
@@ -274,7 +275,7 @@ QList<bool> OLinkSimpleArrayInterface::funcBool(const QList<bool>& paramBool)
 
 QtPromise::QPromise<QList<bool>> OLinkSimpleArrayInterface::funcBoolAsync(const QList<bool>& paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<QList<bool>>::reject("not initialized");
     }
@@ -291,7 +292,7 @@ QtPromise::QPromise<QList<bool>> OLinkSimpleArrayInterface::funcBoolAsync(const 
 
 QList<int> OLinkSimpleArrayInterface::funcInt(const QList<int>& paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QList<int>();
     }
@@ -306,7 +307,7 @@ QList<int> OLinkSimpleArrayInterface::funcInt(const QList<int>& paramInt)
 
 QtPromise::QPromise<QList<int>> OLinkSimpleArrayInterface::funcIntAsync(const QList<int>& paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<QList<int>>::reject("not initialized");
     }
@@ -323,7 +324,7 @@ QtPromise::QPromise<QList<int>> OLinkSimpleArrayInterface::funcIntAsync(const QL
 
 QList<qint32> OLinkSimpleArrayInterface::funcInt32(const QList<qint32>& paramInt32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QList<qint32>();
     }
@@ -338,7 +339,7 @@ QList<qint32> OLinkSimpleArrayInterface::funcInt32(const QList<qint32>& paramInt
 
 QtPromise::QPromise<QList<qint32>> OLinkSimpleArrayInterface::funcInt32Async(const QList<qint32>& paramInt32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<QList<qint32>>::reject("not initialized");
     }
@@ -355,7 +356,7 @@ QtPromise::QPromise<QList<qint32>> OLinkSimpleArrayInterface::funcInt32Async(con
 
 QList<qint64> OLinkSimpleArrayInterface::funcInt64(const QList<qint64>& paramInt64)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QList<qint64>();
     }
@@ -370,7 +371,7 @@ QList<qint64> OLinkSimpleArrayInterface::funcInt64(const QList<qint64>& paramInt
 
 QtPromise::QPromise<QList<qint64>> OLinkSimpleArrayInterface::funcInt64Async(const QList<qint64>& paramInt64)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<QList<qint64>>::reject("not initialized");
     }
@@ -387,7 +388,7 @@ QtPromise::QPromise<QList<qint64>> OLinkSimpleArrayInterface::funcInt64Async(con
 
 QList<qreal> OLinkSimpleArrayInterface::funcFloat(const QList<qreal>& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QList<qreal>();
     }
@@ -402,7 +403,7 @@ QList<qreal> OLinkSimpleArrayInterface::funcFloat(const QList<qreal>& paramFloat
 
 QtPromise::QPromise<QList<qreal>> OLinkSimpleArrayInterface::funcFloatAsync(const QList<qreal>& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<QList<qreal>>::reject("not initialized");
     }
@@ -419,7 +420,7 @@ QtPromise::QPromise<QList<qreal>> OLinkSimpleArrayInterface::funcFloatAsync(cons
 
 QList<float> OLinkSimpleArrayInterface::funcFloat32(const QList<float>& paramFloat32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QList<float>();
     }
@@ -434,7 +435,7 @@ QList<float> OLinkSimpleArrayInterface::funcFloat32(const QList<float>& paramFlo
 
 QtPromise::QPromise<QList<float>> OLinkSimpleArrayInterface::funcFloat32Async(const QList<float>& paramFloat32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<QList<float>>::reject("not initialized");
     }
@@ -451,7 +452,7 @@ QtPromise::QPromise<QList<float>> OLinkSimpleArrayInterface::funcFloat32Async(co
 
 QList<double> OLinkSimpleArrayInterface::funcFloat64(const QList<double>& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QList<double>();
     }
@@ -466,7 +467,7 @@ QList<double> OLinkSimpleArrayInterface::funcFloat64(const QList<double>& paramF
 
 QtPromise::QPromise<QList<double>> OLinkSimpleArrayInterface::funcFloat64Async(const QList<double>& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<QList<double>>::reject("not initialized");
     }
@@ -483,7 +484,7 @@ QtPromise::QPromise<QList<double>> OLinkSimpleArrayInterface::funcFloat64Async(c
 
 QList<QString> OLinkSimpleArrayInterface::funcString(const QList<QString>& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QList<QString>();
     }
@@ -498,7 +499,7 @@ QList<QString> OLinkSimpleArrayInterface::funcString(const QList<QString>& param
 
 QtPromise::QPromise<QList<QString>> OLinkSimpleArrayInterface::funcStringAsync(const QList<QString>& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<QList<QString>>::reject("not initialized");
     }
@@ -521,7 +522,8 @@ std::string OLinkSimpleArrayInterface::olinkObjectName()
 
 void OLinkSimpleArrayInterface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sigBool") {
         emit sigBool(args[0].get<QList<bool>>());   
@@ -559,13 +561,15 @@ void OLinkSimpleArrayInterface::olinkOnSignal(const std::string& signalId, const
 
 void OLinkSimpleArrayInterface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkSimpleArrayInterface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -574,7 +578,7 @@ void OLinkSimpleArrayInterface::olinkOnInit(const std::string& objectId, const n
 
 void OLinkSimpleArrayInterface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/tb_simple/olink/olinksimplearrayinterfaceadapter.cpp
+++ b/goldenmaster/tb_simple/olink/olinksimplearrayinterfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -257,7 +258,8 @@ std::string OLinkSimpleArrayInterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkSimpleArrayInterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "funcBool") {
         const QList<bool>& paramBool = args.at(0);
@@ -303,7 +305,8 @@ json OLinkSimpleArrayInterfaceAdapter::olinkInvoke(const std::string& methodId, 
 }
 
 void OLinkSimpleArrayInterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "propBool") {
         QList<bool> propBool = value.get<QList<bool>>();
@@ -340,12 +343,14 @@ void OLinkSimpleArrayInterfaceAdapter::olinkSetProperty(const std::string& prope
 }
 
 void OLinkSimpleArrayInterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkSimpleArrayInterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkSimpleArrayInterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/tb_simple/olink/olinksimpleinterface.cpp
+++ b/goldenmaster/tb_simple/olink/olinksimpleinterface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "tb_simple/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -41,12 +42,12 @@ OLinkSimpleInterface::OLinkSimpleInterface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkSimpleInterface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("propBool")) {
         setPropBoolLocal(fields["propBool"].get<bool>());
     }
@@ -75,7 +76,7 @@ void OLinkSimpleInterface::applyState(const nlohmann::json& fields)
 
 void OLinkSimpleInterface::setPropBool(bool propBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -84,7 +85,7 @@ void OLinkSimpleInterface::setPropBool(bool propBool)
 
 void OLinkSimpleInterface::setPropBoolLocal(bool propBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propBool != propBool) {
         m_propBool = propBool;
         emit propBoolChanged(propBool);
@@ -98,7 +99,7 @@ bool OLinkSimpleInterface::propBool() const
 
 void OLinkSimpleInterface::setPropInt(int propInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -107,7 +108,7 @@ void OLinkSimpleInterface::setPropInt(int propInt)
 
 void OLinkSimpleInterface::setPropIntLocal(int propInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propInt != propInt) {
         m_propInt = propInt;
         emit propIntChanged(propInt);
@@ -121,7 +122,7 @@ int OLinkSimpleInterface::propInt() const
 
 void OLinkSimpleInterface::setPropInt32(qint32 propInt32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -130,7 +131,7 @@ void OLinkSimpleInterface::setPropInt32(qint32 propInt32)
 
 void OLinkSimpleInterface::setPropInt32Local(qint32 propInt32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propInt32 != propInt32) {
         m_propInt32 = propInt32;
         emit propInt32Changed(propInt32);
@@ -144,7 +145,7 @@ qint32 OLinkSimpleInterface::propInt32() const
 
 void OLinkSimpleInterface::setPropInt64(qint64 propInt64)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -153,7 +154,7 @@ void OLinkSimpleInterface::setPropInt64(qint64 propInt64)
 
 void OLinkSimpleInterface::setPropInt64Local(qint64 propInt64)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propInt64 != propInt64) {
         m_propInt64 = propInt64;
         emit propInt64Changed(propInt64);
@@ -167,7 +168,7 @@ qint64 OLinkSimpleInterface::propInt64() const
 
 void OLinkSimpleInterface::setPropFloat(qreal propFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -176,7 +177,7 @@ void OLinkSimpleInterface::setPropFloat(qreal propFloat)
 
 void OLinkSimpleInterface::setPropFloatLocal(qreal propFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propFloat != propFloat) {
         m_propFloat = propFloat;
         emit propFloatChanged(propFloat);
@@ -190,7 +191,7 @@ qreal OLinkSimpleInterface::propFloat() const
 
 void OLinkSimpleInterface::setPropFloat32(float propFloat32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -199,7 +200,7 @@ void OLinkSimpleInterface::setPropFloat32(float propFloat32)
 
 void OLinkSimpleInterface::setPropFloat32Local(float propFloat32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propFloat32 != propFloat32) {
         m_propFloat32 = propFloat32;
         emit propFloat32Changed(propFloat32);
@@ -213,7 +214,7 @@ float OLinkSimpleInterface::propFloat32() const
 
 void OLinkSimpleInterface::setPropFloat64(double propFloat64)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -222,7 +223,7 @@ void OLinkSimpleInterface::setPropFloat64(double propFloat64)
 
 void OLinkSimpleInterface::setPropFloat64Local(double propFloat64)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propFloat64 != propFloat64) {
         m_propFloat64 = propFloat64;
         emit propFloat64Changed(propFloat64);
@@ -236,7 +237,7 @@ double OLinkSimpleInterface::propFloat64() const
 
 void OLinkSimpleInterface::setPropString(const QString& propString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -245,7 +246,7 @@ void OLinkSimpleInterface::setPropString(const QString& propString)
 
 void OLinkSimpleInterface::setPropStringLocal(const QString& propString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propString != propString) {
         m_propString = propString;
         emit propStringChanged(propString);
@@ -259,7 +260,7 @@ QString OLinkSimpleInterface::propString() const
 
 void OLinkSimpleInterface::funcVoid()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -273,7 +274,7 @@ void OLinkSimpleInterface::funcVoid()
 
 QtPromise::QPromise<void> OLinkSimpleInterface::funcVoidAsync()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<void>::reject("not initialized");
     }
@@ -284,7 +285,7 @@ QtPromise::QPromise<void> OLinkSimpleInterface::funcVoidAsync()
 
 bool OLinkSimpleInterface::funcBool(bool paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return false;
     }
@@ -299,7 +300,7 @@ bool OLinkSimpleInterface::funcBool(bool paramBool)
 
 QtPromise::QPromise<bool> OLinkSimpleInterface::funcBoolAsync(bool paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<bool>::reject("not initialized");
     }
@@ -316,7 +317,7 @@ QtPromise::QPromise<bool> OLinkSimpleInterface::funcBoolAsync(bool paramBool)
 
 int OLinkSimpleInterface::funcInt(int paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return 0;
     }
@@ -331,7 +332,7 @@ int OLinkSimpleInterface::funcInt(int paramInt)
 
 QtPromise::QPromise<int> OLinkSimpleInterface::funcIntAsync(int paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<int>::reject("not initialized");
     }
@@ -348,7 +349,7 @@ QtPromise::QPromise<int> OLinkSimpleInterface::funcIntAsync(int paramInt)
 
 qint32 OLinkSimpleInterface::funcInt32(qint32 paramInt32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return 0;
     }
@@ -363,7 +364,7 @@ qint32 OLinkSimpleInterface::funcInt32(qint32 paramInt32)
 
 QtPromise::QPromise<qint32> OLinkSimpleInterface::funcInt32Async(qint32 paramInt32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<qint32>::reject("not initialized");
     }
@@ -380,7 +381,7 @@ QtPromise::QPromise<qint32> OLinkSimpleInterface::funcInt32Async(qint32 paramInt
 
 qint64 OLinkSimpleInterface::funcInt64(qint64 paramInt64)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return 0LL;
     }
@@ -395,7 +396,7 @@ qint64 OLinkSimpleInterface::funcInt64(qint64 paramInt64)
 
 QtPromise::QPromise<qint64> OLinkSimpleInterface::funcInt64Async(qint64 paramInt64)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<qint64>::reject("not initialized");
     }
@@ -412,7 +413,7 @@ QtPromise::QPromise<qint64> OLinkSimpleInterface::funcInt64Async(qint64 paramInt
 
 qreal OLinkSimpleInterface::funcFloat(qreal paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return 0.0f;
     }
@@ -427,7 +428,7 @@ qreal OLinkSimpleInterface::funcFloat(qreal paramFloat)
 
 QtPromise::QPromise<qreal> OLinkSimpleInterface::funcFloatAsync(qreal paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<qreal>::reject("not initialized");
     }
@@ -444,7 +445,7 @@ QtPromise::QPromise<qreal> OLinkSimpleInterface::funcFloatAsync(qreal paramFloat
 
 float OLinkSimpleInterface::funcFloat32(float paramFloat32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return 0.0f;
     }
@@ -459,7 +460,7 @@ float OLinkSimpleInterface::funcFloat32(float paramFloat32)
 
 QtPromise::QPromise<float> OLinkSimpleInterface::funcFloat32Async(float paramFloat32)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<float>::reject("not initialized");
     }
@@ -476,7 +477,7 @@ QtPromise::QPromise<float> OLinkSimpleInterface::funcFloat32Async(float paramFlo
 
 double OLinkSimpleInterface::funcFloat64(double paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return 0.0;
     }
@@ -491,7 +492,7 @@ double OLinkSimpleInterface::funcFloat64(double paramFloat)
 
 QtPromise::QPromise<double> OLinkSimpleInterface::funcFloat64Async(double paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<double>::reject("not initialized");
     }
@@ -508,7 +509,7 @@ QtPromise::QPromise<double> OLinkSimpleInterface::funcFloat64Async(double paramF
 
 QString OLinkSimpleInterface::funcString(const QString& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QString();
     }
@@ -523,7 +524,7 @@ QString OLinkSimpleInterface::funcString(const QString& paramString)
 
 QtPromise::QPromise<QString> OLinkSimpleInterface::funcStringAsync(const QString& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<QString>::reject("not initialized");
     }
@@ -546,7 +547,8 @@ std::string OLinkSimpleInterface::olinkObjectName()
 
 void OLinkSimpleInterface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sigVoid") {
         emit sigVoid();   
@@ -588,13 +590,15 @@ void OLinkSimpleInterface::olinkOnSignal(const std::string& signalId, const nloh
 
 void OLinkSimpleInterface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkSimpleInterface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -603,7 +607,7 @@ void OLinkSimpleInterface::olinkOnInit(const std::string& objectId, const nlohma
 
 void OLinkSimpleInterface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/tb_simple/olink/olinksimpleinterfaceadapter.cpp
+++ b/goldenmaster/tb_simple/olink/olinksimpleinterfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -268,7 +269,8 @@ std::string OLinkSimpleInterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkSimpleInterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "funcVoid") {
         m_impl->funcVoid( );
@@ -318,7 +320,8 @@ json OLinkSimpleInterfaceAdapter::olinkInvoke(const std::string& methodId, const
 }
 
 void OLinkSimpleInterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "propBool") {
         bool propBool = value.get<bool>();
@@ -355,12 +358,14 @@ void OLinkSimpleInterfaceAdapter::olinkSetProperty(const std::string& propertyId
 }
 
 void OLinkSimpleInterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkSimpleInterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkSimpleInterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/testbed1/http/CMakeLists.txt
+++ b/goldenmaster/testbed1/http/CMakeLists.txt
@@ -17,4 +17,4 @@ set (TESTBED1_HTTP_SOURCES
 
 add_library(testbed1_http STATIC ${TESTBED1_HTTP_SOURCES})
 target_include_directories(testbed1_http PRIVATE ../testbed1)
-target_link_libraries(testbed1_http PUBLIC Qt5::Network testbed1_api)
+target_link_libraries(testbed1_http PUBLIC apigear::utilities_qt Qt5::Network testbed1_api)

--- a/goldenmaster/testbed1/http/httpstructarrayinterface.cpp
+++ b/goldenmaster/testbed1/http/httpstructarrayinterface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpstructarrayinterface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -89,45 +90,41 @@ QList<StructString> HttpStructArrayInterface::propString() const
 
 StructBool HttpStructArrayInterface::funcBool(const QList<StructBool>& paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramBool"] = QJsonValue::fromVariant(QVariant::fromValue< QList<StructBool> >(paramBool));
     QJsonObject reply = post("testbed1/StructArrayInterface/funcBool", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return StructBool();
 }
 
 StructBool HttpStructArrayInterface::funcInt(const QList<StructInt>& paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramInt"] = QJsonValue::fromVariant(QVariant::fromValue< QList<StructInt> >(paramInt));
     QJsonObject reply = post("testbed1/StructArrayInterface/funcInt", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return StructBool();
 }
 
 StructBool HttpStructArrayInterface::funcFloat(const QList<StructFloat>& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramFloat"] = QJsonValue::fromVariant(QVariant::fromValue< QList<StructFloat> >(paramFloat));
     QJsonObject reply = post("testbed1/StructArrayInterface/funcFloat", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return StructBool();
 }
 
 StructBool HttpStructArrayInterface::funcString(const QList<StructString>& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramString"] = QJsonValue::fromVariant(QVariant::fromValue< QList<StructString> >(paramString));
     QJsonObject reply = post("testbed1/StructArrayInterface/funcString", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return StructBool();
 }
 
@@ -138,14 +135,14 @@ QJsonObject HttpStructArrayInterface::post(const QString& path, const QJsonObjec
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/testbed1/http/httpstructinterface.cpp
+++ b/goldenmaster/testbed1/http/httpstructinterface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpstructinterface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -89,45 +90,41 @@ StructString HttpStructInterface::propString() const
 
 StructBool HttpStructInterface::funcBool(const StructBool& paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramBool"] = QJsonValue::fromVariant(QVariant::fromValue< StructBool >(paramBool));
     QJsonObject reply = post("testbed1/StructInterface/funcBool", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return StructBool();
 }
 
 StructBool HttpStructInterface::funcInt(const StructInt& paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramInt"] = QJsonValue::fromVariant(QVariant::fromValue< StructInt >(paramInt));
     QJsonObject reply = post("testbed1/StructInterface/funcInt", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return StructBool();
 }
 
 StructFloat HttpStructInterface::funcFloat(const StructFloat& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramFloat"] = QJsonValue::fromVariant(QVariant::fromValue< StructFloat >(paramFloat));
     QJsonObject reply = post("testbed1/StructInterface/funcFloat", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return StructFloat();
 }
 
 StructString HttpStructInterface::funcString(const StructString& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["paramString"] = QJsonValue::fromVariant(QVariant::fromValue< StructString >(paramString));
     QJsonObject reply = post("testbed1/StructInterface/funcString", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return StructString();
 }
 
@@ -138,14 +135,14 @@ QJsonObject HttpStructInterface::post(const QString& path, const QJsonObject &pa
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/testbed1/implementation/structarrayinterface.cpp
+++ b/goldenmaster/testbed1/implementation/structarrayinterface.cpp
@@ -90,25 +90,21 @@ QList<StructString> StructArrayInterface::propString() const
 
 StructBool StructArrayInterface::funcBool(const QList<StructBool>& paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
     return StructBool();
 }
 
 StructBool StructArrayInterface::funcInt(const QList<StructInt>& paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
     return StructBool();
 }
 
 StructBool StructArrayInterface::funcFloat(const QList<StructFloat>& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
     return StructBool();
 }
 
 StructBool StructArrayInterface::funcString(const QList<StructString>& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
     return StructBool();
 }
 } //namespace testbed1

--- a/goldenmaster/testbed1/implementation/structinterface.cpp
+++ b/goldenmaster/testbed1/implementation/structinterface.cpp
@@ -90,25 +90,21 @@ StructString StructInterface::propString() const
 
 StructBool StructInterface::funcBool(const StructBool& paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
     return StructBool();
 }
 
 StructBool StructInterface::funcInt(const StructInt& paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
     return StructBool();
 }
 
 StructFloat StructInterface::funcFloat(const StructFloat& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
     return StructFloat();
 }
 
 StructString StructInterface::funcString(const StructString& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
     return StructString();
 }
 } //namespace testbed1

--- a/goldenmaster/testbed1/monitor/structarrayinterfacetraced.cpp
+++ b/goldenmaster/testbed1/monitor/structarrayinterfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "structarrayinterfacetraced.h"
 #include "testbed1/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace testbed1 {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 StructArrayInterfaceTraced::StructArrayInterfaceTraced(std::shared_ptr<AbstractStructArrayInterface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -35,7 +37,7 @@ StructArrayInterfaceTraced::StructArrayInterfaceTraced(std::shared_ptr<AbstractS
 StructBool StructArrayInterfaceTraced::funcBool(const QList<StructBool>& paramBool) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     StructArrayInterfaceAgent::trace_funcBool(this, paramBool);
@@ -46,7 +48,7 @@ StructBool StructArrayInterfaceTraced::funcBool(const QList<StructBool>& paramBo
 StructBool StructArrayInterfaceTraced::funcInt(const QList<StructInt>& paramInt) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     StructArrayInterfaceAgent::trace_funcInt(this, paramInt);
@@ -57,7 +59,7 @@ StructBool StructArrayInterfaceTraced::funcInt(const QList<StructInt>& paramInt)
 StructBool StructArrayInterfaceTraced::funcFloat(const QList<StructFloat>& paramFloat) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     StructArrayInterfaceAgent::trace_funcFloat(this, paramFloat);
@@ -68,7 +70,7 @@ StructBool StructArrayInterfaceTraced::funcFloat(const QList<StructFloat>& param
 StructBool StructArrayInterfaceTraced::funcString(const QList<StructString>& paramString) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     StructArrayInterfaceAgent::trace_funcString(this, paramString);
@@ -78,7 +80,7 @@ StructBool StructArrayInterfaceTraced::funcString(const QList<StructString>& par
 void StructArrayInterfaceTraced::setPropBool(const QList<StructBool>& propBool)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     StructArrayInterfaceAgent::trace_state(this);
@@ -87,7 +89,7 @@ void StructArrayInterfaceTraced::setPropBool(const QList<StructBool>& propBool)
 QList<StructBool> StructArrayInterfaceTraced::propBool() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propBool();
@@ -96,7 +98,7 @@ QList<StructBool> StructArrayInterfaceTraced::propBool() const
 void StructArrayInterfaceTraced::setPropInt(const QList<StructInt>& propInt)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     StructArrayInterfaceAgent::trace_state(this);
@@ -105,7 +107,7 @@ void StructArrayInterfaceTraced::setPropInt(const QList<StructInt>& propInt)
 QList<StructInt> StructArrayInterfaceTraced::propInt() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propInt();
@@ -114,7 +116,7 @@ QList<StructInt> StructArrayInterfaceTraced::propInt() const
 void StructArrayInterfaceTraced::setPropFloat(const QList<StructFloat>& propFloat)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     StructArrayInterfaceAgent::trace_state(this);
@@ -123,7 +125,7 @@ void StructArrayInterfaceTraced::setPropFloat(const QList<StructFloat>& propFloa
 QList<StructFloat> StructArrayInterfaceTraced::propFloat() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propFloat();
@@ -132,7 +134,7 @@ QList<StructFloat> StructArrayInterfaceTraced::propFloat() const
 void StructArrayInterfaceTraced::setPropString(const QList<StructString>& propString)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     StructArrayInterfaceAgent::trace_state(this);
@@ -141,7 +143,7 @@ void StructArrayInterfaceTraced::setPropString(const QList<StructString>& propSt
 QList<StructString> StructArrayInterfaceTraced::propString() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propString();

--- a/goldenmaster/testbed1/monitor/structinterfacetraced.cpp
+++ b/goldenmaster/testbed1/monitor/structinterfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "structinterfacetraced.h"
 #include "testbed1/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace testbed1 {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 StructInterfaceTraced::StructInterfaceTraced(std::shared_ptr<AbstractStructInterface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -35,7 +37,7 @@ StructInterfaceTraced::StructInterfaceTraced(std::shared_ptr<AbstractStructInter
 StructBool StructInterfaceTraced::funcBool(const StructBool& paramBool) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     StructInterfaceAgent::trace_funcBool(this, paramBool);
@@ -46,7 +48,7 @@ StructBool StructInterfaceTraced::funcBool(const StructBool& paramBool)
 StructBool StructInterfaceTraced::funcInt(const StructInt& paramInt) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     StructInterfaceAgent::trace_funcInt(this, paramInt);
@@ -57,7 +59,7 @@ StructBool StructInterfaceTraced::funcInt(const StructInt& paramInt)
 StructFloat StructInterfaceTraced::funcFloat(const StructFloat& paramFloat) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     StructInterfaceAgent::trace_funcFloat(this, paramFloat);
@@ -68,7 +70,7 @@ StructFloat StructInterfaceTraced::funcFloat(const StructFloat& paramFloat)
 StructString StructInterfaceTraced::funcString(const StructString& paramString) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     StructInterfaceAgent::trace_funcString(this, paramString);
@@ -78,7 +80,7 @@ StructString StructInterfaceTraced::funcString(const StructString& paramString)
 void StructInterfaceTraced::setPropBool(const StructBool& propBool)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     StructInterfaceAgent::trace_state(this);
@@ -87,7 +89,7 @@ void StructInterfaceTraced::setPropBool(const StructBool& propBool)
 StructBool StructInterfaceTraced::propBool() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propBool();
@@ -96,7 +98,7 @@ StructBool StructInterfaceTraced::propBool() const
 void StructInterfaceTraced::setPropInt(const StructInt& propInt)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     StructInterfaceAgent::trace_state(this);
@@ -105,7 +107,7 @@ void StructInterfaceTraced::setPropInt(const StructInt& propInt)
 StructInt StructInterfaceTraced::propInt() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propInt();
@@ -114,7 +116,7 @@ StructInt StructInterfaceTraced::propInt() const
 void StructInterfaceTraced::setPropFloat(const StructFloat& propFloat)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     StructInterfaceAgent::trace_state(this);
@@ -123,7 +125,7 @@ void StructInterfaceTraced::setPropFloat(const StructFloat& propFloat)
 StructFloat StructInterfaceTraced::propFloat() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propFloat();
@@ -132,7 +134,7 @@ StructFloat StructInterfaceTraced::propFloat() const
 void StructInterfaceTraced::setPropString(const StructString& propString)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     StructInterfaceAgent::trace_state(this);
@@ -141,7 +143,7 @@ void StructInterfaceTraced::setPropString(const StructString& propString)
 StructString StructInterfaceTraced::propString() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->propString();

--- a/goldenmaster/testbed1/monitor/tracedapifactory.cpp
+++ b/goldenmaster/testbed1/monitor/tracedapifactory.cpp
@@ -1,4 +1,5 @@
 #include "tracedapifactory.h"
+#include "utilities/logger.h"
 #include "structinterfacetraced.h"
 #include "structarrayinterfacetraced.h"
 
@@ -8,19 +9,19 @@ TracedApiFactory::TracedApiFactory(IApiFactory& factory, QObject *parent)
     : QObject(parent),
       m_factory(factory)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 std::shared_ptr<AbstractStructInterface> TracedApiFactory::createStructInterface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto structInterface = m_factory.createStructInterface(parent);
     return std::make_shared<StructInterfaceTraced>(structInterface);
 }
 
 std::shared_ptr<AbstractStructArrayInterface> TracedApiFactory::createStructArrayInterface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto structArrayInterface = m_factory.createStructArrayInterface(parent);
     return std::make_shared<StructArrayInterfaceTraced>(structArrayInterface);
 }

--- a/goldenmaster/testbed1/olink/olinkfactory.cpp
+++ b/goldenmaster/testbed1/olink/olinkfactory.cpp
@@ -1,4 +1,5 @@
 #include "olinkfactory.h"
+#include "utilities/logger.h"
 #include "olink/olinkstructinterface.h"
 #include "olink/olinkstructarrayinterface.h"
 
@@ -8,12 +9,12 @@ OLinkFactory::OLinkFactory(ApiGear::ObjectLink::OLinkClient& client, QObject *pa
     : QObject(parent),
       m_client(client)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 std::shared_ptr<AbstractStructInterface> OLinkFactory::createStructInterface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto struct_interface = std::make_shared<OLinkStructInterface>();
     m_client.linkObjectSource(struct_interface);
     return struct_interface;
@@ -21,7 +22,7 @@ std::shared_ptr<AbstractStructInterface> OLinkFactory::createStructInterface(QOb
 
 std::shared_ptr<AbstractStructArrayInterface> OLinkFactory::createStructArrayInterface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto struct_array_interface = std::make_shared<OLinkStructArrayInterface>();
     m_client.linkObjectSource(struct_array_interface);
     return struct_array_interface;

--- a/goldenmaster/testbed1/olink/olinkstructarrayinterface.cpp
+++ b/goldenmaster/testbed1/olink/olinkstructarrayinterface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "testbed1/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -37,12 +38,12 @@ OLinkStructArrayInterface::OLinkStructArrayInterface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkStructArrayInterface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("propBool")) {
         setPropBoolLocal(fields["propBool"].get<QList<StructBool>>());
     }
@@ -59,7 +60,7 @@ void OLinkStructArrayInterface::applyState(const nlohmann::json& fields)
 
 void OLinkStructArrayInterface::setPropBool(const QList<StructBool>& propBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -68,7 +69,7 @@ void OLinkStructArrayInterface::setPropBool(const QList<StructBool>& propBool)
 
 void OLinkStructArrayInterface::setPropBoolLocal(const QList<StructBool>& propBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propBool != propBool) {
         m_propBool = propBool;
         emit propBoolChanged(propBool);
@@ -82,7 +83,7 @@ QList<StructBool> OLinkStructArrayInterface::propBool() const
 
 void OLinkStructArrayInterface::setPropInt(const QList<StructInt>& propInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -91,7 +92,7 @@ void OLinkStructArrayInterface::setPropInt(const QList<StructInt>& propInt)
 
 void OLinkStructArrayInterface::setPropIntLocal(const QList<StructInt>& propInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propInt != propInt) {
         m_propInt = propInt;
         emit propIntChanged(propInt);
@@ -105,7 +106,7 @@ QList<StructInt> OLinkStructArrayInterface::propInt() const
 
 void OLinkStructArrayInterface::setPropFloat(const QList<StructFloat>& propFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -114,7 +115,7 @@ void OLinkStructArrayInterface::setPropFloat(const QList<StructFloat>& propFloat
 
 void OLinkStructArrayInterface::setPropFloatLocal(const QList<StructFloat>& propFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propFloat != propFloat) {
         m_propFloat = propFloat;
         emit propFloatChanged(propFloat);
@@ -128,7 +129,7 @@ QList<StructFloat> OLinkStructArrayInterface::propFloat() const
 
 void OLinkStructArrayInterface::setPropString(const QList<StructString>& propString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -137,7 +138,7 @@ void OLinkStructArrayInterface::setPropString(const QList<StructString>& propStr
 
 void OLinkStructArrayInterface::setPropStringLocal(const QList<StructString>& propString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propString != propString) {
         m_propString = propString;
         emit propStringChanged(propString);
@@ -151,7 +152,7 @@ QList<StructString> OLinkStructArrayInterface::propString() const
 
 StructBool OLinkStructArrayInterface::funcBool(const QList<StructBool>& paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return StructBool();
     }
@@ -166,7 +167,7 @@ StructBool OLinkStructArrayInterface::funcBool(const QList<StructBool>& paramBoo
 
 QtPromise::QPromise<StructBool> OLinkStructArrayInterface::funcBoolAsync(const QList<StructBool>& paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<StructBool>::reject("not initialized");
     }
@@ -183,7 +184,7 @@ QtPromise::QPromise<StructBool> OLinkStructArrayInterface::funcBoolAsync(const Q
 
 StructBool OLinkStructArrayInterface::funcInt(const QList<StructInt>& paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return StructBool();
     }
@@ -198,7 +199,7 @@ StructBool OLinkStructArrayInterface::funcInt(const QList<StructInt>& paramInt)
 
 QtPromise::QPromise<StructBool> OLinkStructArrayInterface::funcIntAsync(const QList<StructInt>& paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<StructBool>::reject("not initialized");
     }
@@ -215,7 +216,7 @@ QtPromise::QPromise<StructBool> OLinkStructArrayInterface::funcIntAsync(const QL
 
 StructBool OLinkStructArrayInterface::funcFloat(const QList<StructFloat>& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return StructBool();
     }
@@ -230,7 +231,7 @@ StructBool OLinkStructArrayInterface::funcFloat(const QList<StructFloat>& paramF
 
 QtPromise::QPromise<StructBool> OLinkStructArrayInterface::funcFloatAsync(const QList<StructFloat>& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<StructBool>::reject("not initialized");
     }
@@ -247,7 +248,7 @@ QtPromise::QPromise<StructBool> OLinkStructArrayInterface::funcFloatAsync(const 
 
 StructBool OLinkStructArrayInterface::funcString(const QList<StructString>& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return StructBool();
     }
@@ -262,7 +263,7 @@ StructBool OLinkStructArrayInterface::funcString(const QList<StructString>& para
 
 QtPromise::QPromise<StructBool> OLinkStructArrayInterface::funcStringAsync(const QList<StructString>& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<StructBool>::reject("not initialized");
     }
@@ -285,7 +286,8 @@ std::string OLinkStructArrayInterface::olinkObjectName()
 
 void OLinkStructArrayInterface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sigBool") {
         emit sigBool(args[0].get<QList<StructBool>>());   
@@ -307,13 +309,15 @@ void OLinkStructArrayInterface::olinkOnSignal(const std::string& signalId, const
 
 void OLinkStructArrayInterface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkStructArrayInterface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -322,7 +326,7 @@ void OLinkStructArrayInterface::olinkOnInit(const std::string& objectId, const n
 
 void OLinkStructArrayInterface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/testbed1/olink/olinkstructarrayinterfaceadapter.cpp
+++ b/goldenmaster/testbed1/olink/olinkstructarrayinterfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -157,7 +158,8 @@ std::string OLinkStructArrayInterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkStructArrayInterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "funcBool") {
         const QList<StructBool>& paramBool = args.at(0);
@@ -183,7 +185,8 @@ json OLinkStructArrayInterfaceAdapter::olinkInvoke(const std::string& methodId, 
 }
 
 void OLinkStructArrayInterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "propBool") {
         QList<StructBool> propBool = value.get<QList<StructBool>>();
@@ -204,12 +207,14 @@ void OLinkStructArrayInterfaceAdapter::olinkSetProperty(const std::string& prope
 }
 
 void OLinkStructArrayInterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkStructArrayInterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkStructArrayInterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/testbed1/olink/olinkstructinterface.cpp
+++ b/goldenmaster/testbed1/olink/olinkstructinterface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "testbed1/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -37,12 +38,12 @@ OLinkStructInterface::OLinkStructInterface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkStructInterface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("propBool")) {
         setPropBoolLocal(fields["propBool"].get<StructBool>());
     }
@@ -59,7 +60,7 @@ void OLinkStructInterface::applyState(const nlohmann::json& fields)
 
 void OLinkStructInterface::setPropBool(const StructBool& propBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -68,7 +69,7 @@ void OLinkStructInterface::setPropBool(const StructBool& propBool)
 
 void OLinkStructInterface::setPropBoolLocal(const StructBool& propBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propBool != propBool) {
         m_propBool = propBool;
         emit propBoolChanged(propBool);
@@ -82,7 +83,7 @@ StructBool OLinkStructInterface::propBool() const
 
 void OLinkStructInterface::setPropInt(const StructInt& propInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -91,7 +92,7 @@ void OLinkStructInterface::setPropInt(const StructInt& propInt)
 
 void OLinkStructInterface::setPropIntLocal(const StructInt& propInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propInt != propInt) {
         m_propInt = propInt;
         emit propIntChanged(propInt);
@@ -105,7 +106,7 @@ StructInt OLinkStructInterface::propInt() const
 
 void OLinkStructInterface::setPropFloat(const StructFloat& propFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -114,7 +115,7 @@ void OLinkStructInterface::setPropFloat(const StructFloat& propFloat)
 
 void OLinkStructInterface::setPropFloatLocal(const StructFloat& propFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propFloat != propFloat) {
         m_propFloat = propFloat;
         emit propFloatChanged(propFloat);
@@ -128,7 +129,7 @@ StructFloat OLinkStructInterface::propFloat() const
 
 void OLinkStructInterface::setPropString(const StructString& propString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -137,7 +138,7 @@ void OLinkStructInterface::setPropString(const StructString& propString)
 
 void OLinkStructInterface::setPropStringLocal(const StructString& propString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_propString != propString) {
         m_propString = propString;
         emit propStringChanged(propString);
@@ -151,7 +152,7 @@ StructString OLinkStructInterface::propString() const
 
 StructBool OLinkStructInterface::funcBool(const StructBool& paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return StructBool();
     }
@@ -166,7 +167,7 @@ StructBool OLinkStructInterface::funcBool(const StructBool& paramBool)
 
 QtPromise::QPromise<StructBool> OLinkStructInterface::funcBoolAsync(const StructBool& paramBool)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<StructBool>::reject("not initialized");
     }
@@ -183,7 +184,7 @@ QtPromise::QPromise<StructBool> OLinkStructInterface::funcBoolAsync(const Struct
 
 StructBool OLinkStructInterface::funcInt(const StructInt& paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return StructBool();
     }
@@ -198,7 +199,7 @@ StructBool OLinkStructInterface::funcInt(const StructInt& paramInt)
 
 QtPromise::QPromise<StructBool> OLinkStructInterface::funcIntAsync(const StructInt& paramInt)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<StructBool>::reject("not initialized");
     }
@@ -215,7 +216,7 @@ QtPromise::QPromise<StructBool> OLinkStructInterface::funcIntAsync(const StructI
 
 StructFloat OLinkStructInterface::funcFloat(const StructFloat& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return StructFloat();
     }
@@ -230,7 +231,7 @@ StructFloat OLinkStructInterface::funcFloat(const StructFloat& paramFloat)
 
 QtPromise::QPromise<StructFloat> OLinkStructInterface::funcFloatAsync(const StructFloat& paramFloat)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<StructFloat>::reject("not initialized");
     }
@@ -247,7 +248,7 @@ QtPromise::QPromise<StructFloat> OLinkStructInterface::funcFloatAsync(const Stru
 
 StructString OLinkStructInterface::funcString(const StructString& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return StructString();
     }
@@ -262,7 +263,7 @@ StructString OLinkStructInterface::funcString(const StructString& paramString)
 
 QtPromise::QPromise<StructString> OLinkStructInterface::funcStringAsync(const StructString& paramString)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<StructString>::reject("not initialized");
     }
@@ -285,7 +286,8 @@ std::string OLinkStructInterface::olinkObjectName()
 
 void OLinkStructInterface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sigBool") {
         emit sigBool(args[0].get<StructBool>());   
@@ -307,13 +309,15 @@ void OLinkStructInterface::olinkOnSignal(const std::string& signalId, const nloh
 
 void OLinkStructInterface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkStructInterface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -322,7 +326,7 @@ void OLinkStructInterface::olinkOnInit(const std::string& objectId, const nlohma
 
 void OLinkStructInterface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/testbed1/olink/olinkstructinterfaceadapter.cpp
+++ b/goldenmaster/testbed1/olink/olinkstructinterfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -157,7 +158,8 @@ std::string OLinkStructInterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkStructInterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "funcBool") {
         const StructBool& paramBool = args.at(0);
@@ -183,7 +185,8 @@ json OLinkStructInterfaceAdapter::olinkInvoke(const std::string& methodId, const
 }
 
 void OLinkStructInterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "propBool") {
         StructBool propBool = value.get<StructBool>();
@@ -204,12 +207,14 @@ void OLinkStructInterfaceAdapter::olinkSetProperty(const std::string& propertyId
 }
 
 void OLinkStructInterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkStructInterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkStructInterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/testbed2/http/CMakeLists.txt
+++ b/goldenmaster/testbed2/http/CMakeLists.txt
@@ -19,4 +19,4 @@ set (TESTBED2_HTTP_SOURCES
 
 add_library(testbed2_http STATIC ${TESTBED2_HTTP_SOURCES})
 target_include_directories(testbed2_http PRIVATE ../testbed2)
-target_link_libraries(testbed2_http PUBLIC Qt5::Network testbed2_api)
+target_link_libraries(testbed2_http PUBLIC apigear::utilities_qt Qt5::Network testbed2_api)

--- a/goldenmaster/testbed2/http/httpmanyparaminterface.cpp
+++ b/goldenmaster/testbed2/http/httpmanyparaminterface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpmanyparaminterface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -89,51 +90,47 @@ int HttpManyParamInterface::prop4() const
 
 int HttpManyParamInterface::func1(int param1)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< int >(param1));
     QJsonObject reply = post("testbed2/ManyParamInterface/func1", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return 0;
 }
 
 int HttpManyParamInterface::func2(int param1, int param2)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< int >(param1));
     payload["param2"] = QJsonValue::fromVariant(QVariant::fromValue< int >(param2));
     QJsonObject reply = post("testbed2/ManyParamInterface/func2", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return 0;
 }
 
 int HttpManyParamInterface::func3(int param1, int param2, int param3)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< int >(param1));
     payload["param2"] = QJsonValue::fromVariant(QVariant::fromValue< int >(param2));
     payload["param3"] = QJsonValue::fromVariant(QVariant::fromValue< int >(param3));
     QJsonObject reply = post("testbed2/ManyParamInterface/func3", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return 0;
 }
 
 int HttpManyParamInterface::func4(int param1, int param2, int param3, int param4)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< int >(param1));
     payload["param2"] = QJsonValue::fromVariant(QVariant::fromValue< int >(param2));
     payload["param3"] = QJsonValue::fromVariant(QVariant::fromValue< int >(param3));
     payload["param4"] = QJsonValue::fromVariant(QVariant::fromValue< int >(param4));
     QJsonObject reply = post("testbed2/ManyParamInterface/func4", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return 0;
 }
 
@@ -144,14 +141,14 @@ QJsonObject HttpManyParamInterface::post(const QString& path, const QJsonObject 
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/testbed2/http/httpnestedstruct1interface.cpp
+++ b/goldenmaster/testbed2/http/httpnestedstruct1interface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpnestedstruct1interface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -47,12 +48,11 @@ NestedStruct1 HttpNestedStruct1Interface::prop1() const
 
 NestedStruct1 HttpNestedStruct1Interface::func1(const NestedStruct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< NestedStruct1 >(param1));
     QJsonObject reply = post("testbed2/NestedStruct1Interface/func1", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return NestedStruct1();
 }
 
@@ -63,14 +63,14 @@ QJsonObject HttpNestedStruct1Interface::post(const QString& path, const QJsonObj
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/testbed2/http/httpnestedstruct2interface.cpp
+++ b/goldenmaster/testbed2/http/httpnestedstruct2interface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpnestedstruct2interface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -61,24 +62,22 @@ NestedStruct2 HttpNestedStruct2Interface::prop2() const
 
 NestedStruct1 HttpNestedStruct2Interface::func1(const NestedStruct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< NestedStruct1 >(param1));
     QJsonObject reply = post("testbed2/NestedStruct2Interface/func1", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return NestedStruct1();
 }
 
 NestedStruct1 HttpNestedStruct2Interface::func2(const NestedStruct1& param1, const NestedStruct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< NestedStruct1 >(param1));
     payload["param2"] = QJsonValue::fromVariant(QVariant::fromValue< NestedStruct2 >(param2));
     QJsonObject reply = post("testbed2/NestedStruct2Interface/func2", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return NestedStruct1();
 }
 
@@ -89,14 +88,14 @@ QJsonObject HttpNestedStruct2Interface::post(const QString& path, const QJsonObj
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/testbed2/http/httpnestedstruct3interface.cpp
+++ b/goldenmaster/testbed2/http/httpnestedstruct3interface.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "httpnestedstruct3interface.h"
+#include "apigear/utilities/logger.h"
 
 #include <QtQml>
 
@@ -75,37 +76,34 @@ NestedStruct3 HttpNestedStruct3Interface::prop3() const
 
 NestedStruct1 HttpNestedStruct3Interface::func1(const NestedStruct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< NestedStruct1 >(param1));
     QJsonObject reply = post("testbed2/NestedStruct3Interface/func1", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return NestedStruct1();
 }
 
 NestedStruct1 HttpNestedStruct3Interface::func2(const NestedStruct1& param1, const NestedStruct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< NestedStruct1 >(param1));
     payload["param2"] = QJsonValue::fromVariant(QVariant::fromValue< NestedStruct2 >(param2));
     QJsonObject reply = post("testbed2/NestedStruct3Interface/func2", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return NestedStruct1();
 }
 
 NestedStruct1 HttpNestedStruct3Interface::func3(const NestedStruct1& param1, const NestedStruct2& param2, const NestedStruct3& param3)
 {
-    qDebug() << Q_FUNC_INFO;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     QJsonObject payload;
     payload["param1"] = QJsonValue::fromVariant(QVariant::fromValue< NestedStruct1 >(param1));
     payload["param2"] = QJsonValue::fromVariant(QVariant::fromValue< NestedStruct2 >(param2));
     payload["param3"] = QJsonValue::fromVariant(QVariant::fromValue< NestedStruct3 >(param3));
     QJsonObject reply = post("testbed2/NestedStruct3Interface/func3", payload);
-    qDebug() << QJsonDocument(reply).toJson();
+    AG_LOG_DEBUG(qPrintable(QJsonDocument(reply).toJson()));
     return NestedStruct1();
 }
 
@@ -116,14 +114,14 @@ QJsonObject HttpNestedStruct3Interface::post(const QString& path, const QJsonObj
     request.setUrl(QUrl(QString("%1/%2").arg(address).arg(path)));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     const QByteArray& data = QJsonDocument(payload).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG( qPrintable(data));
     QNetworkReply* reply = m_network->post(request, data);
     // wait for finished signal
     QEventLoop loop;
     connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
     if(reply->error()) {
-        qDebug() << reply->errorString();
+        AG_LOG_ERROR(reply->errorString());
         return QJsonObject();
     }
     const QJsonObject &response = QJsonDocument::fromJson(reply->readAll()).object();

--- a/goldenmaster/testbed2/implementation/manyparaminterface.cpp
+++ b/goldenmaster/testbed2/implementation/manyparaminterface.cpp
@@ -90,25 +90,21 @@ int ManyParamInterface::prop4() const
 
 int ManyParamInterface::func1(int param1)
 {
-    qDebug() << Q_FUNC_INFO;
     return 0;
 }
 
 int ManyParamInterface::func2(int param1, int param2)
 {
-    qDebug() << Q_FUNC_INFO;
     return 0;
 }
 
 int ManyParamInterface::func3(int param1, int param2, int param3)
 {
-    qDebug() << Q_FUNC_INFO;
     return 0;
 }
 
 int ManyParamInterface::func4(int param1, int param2, int param3, int param4)
 {
-    qDebug() << Q_FUNC_INFO;
     return 0;
 }
 } //namespace testbed2

--- a/goldenmaster/testbed2/implementation/nestedstruct1interface.cpp
+++ b/goldenmaster/testbed2/implementation/nestedstruct1interface.cpp
@@ -48,7 +48,6 @@ NestedStruct1 NestedStruct1Interface::prop1() const
 
 NestedStruct1 NestedStruct1Interface::func1(const NestedStruct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
     return NestedStruct1();
 }
 } //namespace testbed2

--- a/goldenmaster/testbed2/implementation/nestedstruct2interface.cpp
+++ b/goldenmaster/testbed2/implementation/nestedstruct2interface.cpp
@@ -62,13 +62,11 @@ NestedStruct2 NestedStruct2Interface::prop2() const
 
 NestedStruct1 NestedStruct2Interface::func1(const NestedStruct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
     return NestedStruct1();
 }
 
 NestedStruct1 NestedStruct2Interface::func2(const NestedStruct1& param1, const NestedStruct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
     return NestedStruct1();
 }
 } //namespace testbed2

--- a/goldenmaster/testbed2/implementation/nestedstruct3interface.cpp
+++ b/goldenmaster/testbed2/implementation/nestedstruct3interface.cpp
@@ -76,19 +76,16 @@ NestedStruct3 NestedStruct3Interface::prop3() const
 
 NestedStruct1 NestedStruct3Interface::func1(const NestedStruct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
     return NestedStruct1();
 }
 
 NestedStruct1 NestedStruct3Interface::func2(const NestedStruct1& param1, const NestedStruct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
     return NestedStruct1();
 }
 
 NestedStruct1 NestedStruct3Interface::func3(const NestedStruct1& param1, const NestedStruct2& param2, const NestedStruct3& param3)
 {
-    qDebug() << Q_FUNC_INFO;
     return NestedStruct1();
 }
 } //namespace testbed2

--- a/goldenmaster/testbed2/monitor/manyparaminterfacetraced.cpp
+++ b/goldenmaster/testbed2/monitor/manyparaminterfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "manyparaminterfacetraced.h"
 #include "testbed2/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace testbed2 {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 ManyParamInterfaceTraced::ManyParamInterfaceTraced(std::shared_ptr<AbstractManyParamInterface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -35,7 +37,7 @@ ManyParamInterfaceTraced::ManyParamInterfaceTraced(std::shared_ptr<AbstractManyP
 int ManyParamInterfaceTraced::func1(int param1) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     ManyParamInterfaceAgent::trace_func1(this, param1);
@@ -46,7 +48,7 @@ int ManyParamInterfaceTraced::func1(int param1)
 int ManyParamInterfaceTraced::func2(int param1, int param2) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     ManyParamInterfaceAgent::trace_func2(this, param1, param2);
@@ -57,7 +59,7 @@ int ManyParamInterfaceTraced::func2(int param1, int param2)
 int ManyParamInterfaceTraced::func3(int param1, int param2, int param3) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     ManyParamInterfaceAgent::trace_func3(this, param1, param2, param3);
@@ -68,7 +70,7 @@ int ManyParamInterfaceTraced::func3(int param1, int param2, int param3)
 int ManyParamInterfaceTraced::func4(int param1, int param2, int param3, int param4) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     ManyParamInterfaceAgent::trace_func4(this, param1, param2, param3, param4);
@@ -78,7 +80,7 @@ int ManyParamInterfaceTraced::func4(int param1, int param2, int param3, int para
 void ManyParamInterfaceTraced::setProp1(int prop1)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     ManyParamInterfaceAgent::trace_state(this);
@@ -87,7 +89,7 @@ void ManyParamInterfaceTraced::setProp1(int prop1)
 int ManyParamInterfaceTraced::prop1() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop1();
@@ -96,7 +98,7 @@ int ManyParamInterfaceTraced::prop1() const
 void ManyParamInterfaceTraced::setProp2(int prop2)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     ManyParamInterfaceAgent::trace_state(this);
@@ -105,7 +107,7 @@ void ManyParamInterfaceTraced::setProp2(int prop2)
 int ManyParamInterfaceTraced::prop2() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop2();
@@ -114,7 +116,7 @@ int ManyParamInterfaceTraced::prop2() const
 void ManyParamInterfaceTraced::setProp3(int prop3)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     ManyParamInterfaceAgent::trace_state(this);
@@ -123,7 +125,7 @@ void ManyParamInterfaceTraced::setProp3(int prop3)
 int ManyParamInterfaceTraced::prop3() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop3();
@@ -132,7 +134,7 @@ int ManyParamInterfaceTraced::prop3() const
 void ManyParamInterfaceTraced::setProp4(int prop4)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     ManyParamInterfaceAgent::trace_state(this);
@@ -141,7 +143,7 @@ void ManyParamInterfaceTraced::setProp4(int prop4)
 int ManyParamInterfaceTraced::prop4() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop4();

--- a/goldenmaster/testbed2/monitor/nestedstruct1interfacetraced.cpp
+++ b/goldenmaster/testbed2/monitor/nestedstruct1interfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "nestedstruct1interfacetraced.h"
 #include "testbed2/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace testbed2 {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 NestedStruct1InterfaceTraced::NestedStruct1InterfaceTraced(std::shared_ptr<AbstractNestedStruct1Interface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -26,7 +28,7 @@ NestedStruct1InterfaceTraced::NestedStruct1InterfaceTraced(std::shared_ptr<Abstr
 NestedStruct1 NestedStruct1InterfaceTraced::func1(const NestedStruct1& param1) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     NestedStruct1InterfaceAgent::trace_func1(this, param1);
@@ -36,7 +38,7 @@ NestedStruct1 NestedStruct1InterfaceTraced::func1(const NestedStruct1& param1)
 void NestedStruct1InterfaceTraced::setProp1(const NestedStruct1& prop1)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     NestedStruct1InterfaceAgent::trace_state(this);
@@ -45,7 +47,7 @@ void NestedStruct1InterfaceTraced::setProp1(const NestedStruct1& prop1)
 NestedStruct1 NestedStruct1InterfaceTraced::prop1() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop1();

--- a/goldenmaster/testbed2/monitor/nestedstruct2interfacetraced.cpp
+++ b/goldenmaster/testbed2/monitor/nestedstruct2interfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "nestedstruct2interfacetraced.h"
 #include "testbed2/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace testbed2 {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 NestedStruct2InterfaceTraced::NestedStruct2InterfaceTraced(std::shared_ptr<AbstractNestedStruct2Interface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -29,7 +31,7 @@ NestedStruct2InterfaceTraced::NestedStruct2InterfaceTraced(std::shared_ptr<Abstr
 NestedStruct1 NestedStruct2InterfaceTraced::func1(const NestedStruct1& param1) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     NestedStruct2InterfaceAgent::trace_func1(this, param1);
@@ -40,7 +42,7 @@ NestedStruct1 NestedStruct2InterfaceTraced::func1(const NestedStruct1& param1)
 NestedStruct1 NestedStruct2InterfaceTraced::func2(const NestedStruct1& param1, const NestedStruct2& param2) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     NestedStruct2InterfaceAgent::trace_func2(this, param1, param2);
@@ -50,7 +52,7 @@ NestedStruct1 NestedStruct2InterfaceTraced::func2(const NestedStruct1& param1, c
 void NestedStruct2InterfaceTraced::setProp1(const NestedStruct1& prop1)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     NestedStruct2InterfaceAgent::trace_state(this);
@@ -59,7 +61,7 @@ void NestedStruct2InterfaceTraced::setProp1(const NestedStruct1& prop1)
 NestedStruct1 NestedStruct2InterfaceTraced::prop1() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop1();
@@ -68,7 +70,7 @@ NestedStruct1 NestedStruct2InterfaceTraced::prop1() const
 void NestedStruct2InterfaceTraced::setProp2(const NestedStruct2& prop2)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     NestedStruct2InterfaceAgent::trace_state(this);
@@ -77,7 +79,7 @@ void NestedStruct2InterfaceTraced::setProp2(const NestedStruct2& prop2)
 NestedStruct2 NestedStruct2InterfaceTraced::prop2() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop2();

--- a/goldenmaster/testbed2/monitor/nestedstruct3interfacetraced.cpp
+++ b/goldenmaster/testbed2/monitor/nestedstruct3interfacetraced.cpp
@@ -1,15 +1,17 @@
 
 #include "nestedstruct3interfacetraced.h"
 #include "testbed2/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace testbed2 {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 NestedStruct3InterfaceTraced::NestedStruct3InterfaceTraced(std::shared_ptr<AbstractNestedStruct3Interface> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -32,7 +34,7 @@ NestedStruct3InterfaceTraced::NestedStruct3InterfaceTraced(std::shared_ptr<Abstr
 NestedStruct1 NestedStruct3InterfaceTraced::func1(const NestedStruct1& param1) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     NestedStruct3InterfaceAgent::trace_func1(this, param1);
@@ -43,7 +45,7 @@ NestedStruct1 NestedStruct3InterfaceTraced::func1(const NestedStruct1& param1)
 NestedStruct1 NestedStruct3InterfaceTraced::func2(const NestedStruct1& param1, const NestedStruct2& param2) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     NestedStruct3InterfaceAgent::trace_func2(this, param1, param2);
@@ -54,7 +56,7 @@ NestedStruct1 NestedStruct3InterfaceTraced::func2(const NestedStruct1& param1, c
 NestedStruct1 NestedStruct3InterfaceTraced::func3(const NestedStruct1& param1, const NestedStruct2& param2, const NestedStruct3& param3) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return  {} ;
     }
     NestedStruct3InterfaceAgent::trace_func3(this, param1, param2, param3);
@@ -64,7 +66,7 @@ NestedStruct1 NestedStruct3InterfaceTraced::func3(const NestedStruct1& param1, c
 void NestedStruct3InterfaceTraced::setProp1(const NestedStruct1& prop1)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     NestedStruct3InterfaceAgent::trace_state(this);
@@ -73,7 +75,7 @@ void NestedStruct3InterfaceTraced::setProp1(const NestedStruct1& prop1)
 NestedStruct1 NestedStruct3InterfaceTraced::prop1() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop1();
@@ -82,7 +84,7 @@ NestedStruct1 NestedStruct3InterfaceTraced::prop1() const
 void NestedStruct3InterfaceTraced::setProp2(const NestedStruct2& prop2)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     NestedStruct3InterfaceAgent::trace_state(this);
@@ -91,7 +93,7 @@ void NestedStruct3InterfaceTraced::setProp2(const NestedStruct2& prop2)
 NestedStruct2 NestedStruct3InterfaceTraced::prop2() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop2();
@@ -100,7 +102,7 @@ NestedStruct2 NestedStruct3InterfaceTraced::prop2() const
 void NestedStruct3InterfaceTraced::setProp3(const NestedStruct3& prop3)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     NestedStruct3InterfaceAgent::trace_state(this);
@@ -109,7 +111,7 @@ void NestedStruct3InterfaceTraced::setProp3(const NestedStruct3& prop3)
 NestedStruct3 NestedStruct3InterfaceTraced::prop3() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->prop3();

--- a/goldenmaster/testbed2/monitor/tracedapifactory.cpp
+++ b/goldenmaster/testbed2/monitor/tracedapifactory.cpp
@@ -1,4 +1,5 @@
 #include "tracedapifactory.h"
+#include "utilities/logger.h"
 #include "manyparaminterfacetraced.h"
 #include "nestedstruct1interfacetraced.h"
 #include "nestedstruct2interfacetraced.h"
@@ -10,33 +11,33 @@ TracedApiFactory::TracedApiFactory(IApiFactory& factory, QObject *parent)
     : QObject(parent),
       m_factory(factory)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 std::shared_ptr<AbstractManyParamInterface> TracedApiFactory::createManyParamInterface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto manyParamInterface = m_factory.createManyParamInterface(parent);
     return std::make_shared<ManyParamInterfaceTraced>(manyParamInterface);
 }
 
 std::shared_ptr<AbstractNestedStruct1Interface> TracedApiFactory::createNestedStruct1Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto nestedStruct1Interface = m_factory.createNestedStruct1Interface(parent);
     return std::make_shared<NestedStruct1InterfaceTraced>(nestedStruct1Interface);
 }
 
 std::shared_ptr<AbstractNestedStruct2Interface> TracedApiFactory::createNestedStruct2Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto nestedStruct2Interface = m_factory.createNestedStruct2Interface(parent);
     return std::make_shared<NestedStruct2InterfaceTraced>(nestedStruct2Interface);
 }
 
 std::shared_ptr<AbstractNestedStruct3Interface> TracedApiFactory::createNestedStruct3Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto nestedStruct3Interface = m_factory.createNestedStruct3Interface(parent);
     return std::make_shared<NestedStruct3InterfaceTraced>(nestedStruct3Interface);
 }

--- a/goldenmaster/testbed2/olink/olinkfactory.cpp
+++ b/goldenmaster/testbed2/olink/olinkfactory.cpp
@@ -1,4 +1,5 @@
 #include "olinkfactory.h"
+#include "utilities/logger.h"
 #include "olink/olinkmanyparaminterface.h"
 #include "olink/olinknestedstruct1interface.h"
 #include "olink/olinknestedstruct2interface.h"
@@ -10,12 +11,12 @@ OLinkFactory::OLinkFactory(ApiGear::ObjectLink::OLinkClient& client, QObject *pa
     : QObject(parent),
       m_client(client)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 std::shared_ptr<AbstractManyParamInterface> OLinkFactory::createManyParamInterface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto many_param_interface = std::make_shared<OLinkManyParamInterface>();
     m_client.linkObjectSource(many_param_interface);
     return many_param_interface;
@@ -23,7 +24,7 @@ std::shared_ptr<AbstractManyParamInterface> OLinkFactory::createManyParamInterfa
 
 std::shared_ptr<AbstractNestedStruct1Interface> OLinkFactory::createNestedStruct1Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto nested_struct1_interface = std::make_shared<OLinkNestedStruct1Interface>();
     m_client.linkObjectSource(nested_struct1_interface);
     return nested_struct1_interface;
@@ -31,7 +32,7 @@ std::shared_ptr<AbstractNestedStruct1Interface> OLinkFactory::createNestedStruct
 
 std::shared_ptr<AbstractNestedStruct2Interface> OLinkFactory::createNestedStruct2Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto nested_struct2_interface = std::make_shared<OLinkNestedStruct2Interface>();
     m_client.linkObjectSource(nested_struct2_interface);
     return nested_struct2_interface;
@@ -39,7 +40,7 @@ std::shared_ptr<AbstractNestedStruct2Interface> OLinkFactory::createNestedStruct
 
 std::shared_ptr<AbstractNestedStruct3Interface> OLinkFactory::createNestedStruct3Interface(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto nested_struct3_interface = std::make_shared<OLinkNestedStruct3Interface>();
     m_client.linkObjectSource(nested_struct3_interface);
     return nested_struct3_interface;

--- a/goldenmaster/testbed2/olink/olinkmanyparaminterface.cpp
+++ b/goldenmaster/testbed2/olink/olinkmanyparaminterface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "testbed2/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -37,12 +38,12 @@ OLinkManyParamInterface::OLinkManyParamInterface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkManyParamInterface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("prop1")) {
         setProp1Local(fields["prop1"].get<int>());
     }
@@ -59,7 +60,7 @@ void OLinkManyParamInterface::applyState(const nlohmann::json& fields)
 
 void OLinkManyParamInterface::setProp1(int prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -68,7 +69,7 @@ void OLinkManyParamInterface::setProp1(int prop1)
 
 void OLinkManyParamInterface::setProp1Local(int prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop1 != prop1) {
         m_prop1 = prop1;
         emit prop1Changed(prop1);
@@ -82,7 +83,7 @@ int OLinkManyParamInterface::prop1() const
 
 void OLinkManyParamInterface::setProp2(int prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -91,7 +92,7 @@ void OLinkManyParamInterface::setProp2(int prop2)
 
 void OLinkManyParamInterface::setProp2Local(int prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop2 != prop2) {
         m_prop2 = prop2;
         emit prop2Changed(prop2);
@@ -105,7 +106,7 @@ int OLinkManyParamInterface::prop2() const
 
 void OLinkManyParamInterface::setProp3(int prop3)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -114,7 +115,7 @@ void OLinkManyParamInterface::setProp3(int prop3)
 
 void OLinkManyParamInterface::setProp3Local(int prop3)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop3 != prop3) {
         m_prop3 = prop3;
         emit prop3Changed(prop3);
@@ -128,7 +129,7 @@ int OLinkManyParamInterface::prop3() const
 
 void OLinkManyParamInterface::setProp4(int prop4)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -137,7 +138,7 @@ void OLinkManyParamInterface::setProp4(int prop4)
 
 void OLinkManyParamInterface::setProp4Local(int prop4)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop4 != prop4) {
         m_prop4 = prop4;
         emit prop4Changed(prop4);
@@ -151,7 +152,7 @@ int OLinkManyParamInterface::prop4() const
 
 int OLinkManyParamInterface::func1(int param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return 0;
     }
@@ -166,7 +167,7 @@ int OLinkManyParamInterface::func1(int param1)
 
 QtPromise::QPromise<int> OLinkManyParamInterface::func1Async(int param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<int>::reject("not initialized");
     }
@@ -183,7 +184,7 @@ QtPromise::QPromise<int> OLinkManyParamInterface::func1Async(int param1)
 
 int OLinkManyParamInterface::func2(int param1, int param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return 0;
     }
@@ -198,7 +199,7 @@ int OLinkManyParamInterface::func2(int param1, int param2)
 
 QtPromise::QPromise<int> OLinkManyParamInterface::func2Async(int param1, int param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<int>::reject("not initialized");
     }
@@ -215,7 +216,7 @@ QtPromise::QPromise<int> OLinkManyParamInterface::func2Async(int param1, int par
 
 int OLinkManyParamInterface::func3(int param1, int param2, int param3)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return 0;
     }
@@ -230,7 +231,7 @@ int OLinkManyParamInterface::func3(int param1, int param2, int param3)
 
 QtPromise::QPromise<int> OLinkManyParamInterface::func3Async(int param1, int param2, int param3)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<int>::reject("not initialized");
     }
@@ -247,7 +248,7 @@ QtPromise::QPromise<int> OLinkManyParamInterface::func3Async(int param1, int par
 
 int OLinkManyParamInterface::func4(int param1, int param2, int param3, int param4)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return 0;
     }
@@ -262,7 +263,7 @@ int OLinkManyParamInterface::func4(int param1, int param2, int param3, int param
 
 QtPromise::QPromise<int> OLinkManyParamInterface::func4Async(int param1, int param2, int param3, int param4)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<int>::reject("not initialized");
     }
@@ -285,7 +286,8 @@ std::string OLinkManyParamInterface::olinkObjectName()
 
 void OLinkManyParamInterface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sig1") {
         emit sig1(args[0].get<int>());   
@@ -307,13 +309,15 @@ void OLinkManyParamInterface::olinkOnSignal(const std::string& signalId, const n
 
 void OLinkManyParamInterface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkManyParamInterface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -322,7 +326,7 @@ void OLinkManyParamInterface::olinkOnInit(const std::string& objectId, const nlo
 
 void OLinkManyParamInterface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/testbed2/olink/olinkmanyparaminterfaceadapter.cpp
+++ b/goldenmaster/testbed2/olink/olinkmanyparaminterfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -157,7 +158,8 @@ std::string OLinkManyParamInterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkManyParamInterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "func1") {
         const int& param1 = args.at(0);
@@ -189,7 +191,8 @@ json OLinkManyParamInterfaceAdapter::olinkInvoke(const std::string& methodId, co
 }
 
 void OLinkManyParamInterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "prop1") {
         int prop1 = value.get<int>();
@@ -210,12 +213,14 @@ void OLinkManyParamInterfaceAdapter::olinkSetProperty(const std::string& propert
 }
 
 void OLinkManyParamInterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkManyParamInterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkManyParamInterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/testbed2/olink/olinknestedstruct1interface.cpp
+++ b/goldenmaster/testbed2/olink/olinknestedstruct1interface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "testbed2/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -34,12 +35,12 @@ OLinkNestedStruct1Interface::OLinkNestedStruct1Interface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkNestedStruct1Interface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("prop1")) {
         setProp1Local(fields["prop1"].get<NestedStruct1>());
     }
@@ -47,7 +48,7 @@ void OLinkNestedStruct1Interface::applyState(const nlohmann::json& fields)
 
 void OLinkNestedStruct1Interface::setProp1(const NestedStruct1& prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -56,7 +57,7 @@ void OLinkNestedStruct1Interface::setProp1(const NestedStruct1& prop1)
 
 void OLinkNestedStruct1Interface::setProp1Local(const NestedStruct1& prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop1 != prop1) {
         m_prop1 = prop1;
         emit prop1Changed(prop1);
@@ -70,7 +71,7 @@ NestedStruct1 OLinkNestedStruct1Interface::prop1() const
 
 NestedStruct1 OLinkNestedStruct1Interface::func1(const NestedStruct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return NestedStruct1();
     }
@@ -85,7 +86,7 @@ NestedStruct1 OLinkNestedStruct1Interface::func1(const NestedStruct1& param1)
 
 QtPromise::QPromise<NestedStruct1> OLinkNestedStruct1Interface::func1Async(const NestedStruct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<NestedStruct1>::reject("not initialized");
     }
@@ -108,7 +109,8 @@ std::string OLinkNestedStruct1Interface::olinkObjectName()
 
 void OLinkNestedStruct1Interface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sig1") {
         emit sig1(args[0].get<NestedStruct1>());   
@@ -118,13 +120,15 @@ void OLinkNestedStruct1Interface::olinkOnSignal(const std::string& signalId, con
 
 void OLinkNestedStruct1Interface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkNestedStruct1Interface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -133,7 +137,7 @@ void OLinkNestedStruct1Interface::olinkOnInit(const std::string& objectId, const
 
 void OLinkNestedStruct1Interface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/testbed2/olink/olinknestedstruct1interfaceadapter.cpp
+++ b/goldenmaster/testbed2/olink/olinknestedstruct1interfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -82,7 +83,8 @@ std::string OLinkNestedStruct1InterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkNestedStruct1InterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "func1") {
         const NestedStruct1& param1 = args.at(0);
@@ -93,7 +95,8 @@ json OLinkNestedStruct1InterfaceAdapter::olinkInvoke(const std::string& methodId
 }
 
 void OLinkNestedStruct1InterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "prop1") {
         NestedStruct1 prop1 = value.get<NestedStruct1>();
@@ -102,12 +105,14 @@ void OLinkNestedStruct1InterfaceAdapter::olinkSetProperty(const std::string& pro
 }
 
 void OLinkNestedStruct1InterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkNestedStruct1InterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkNestedStruct1InterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/testbed2/olink/olinknestedstruct2interface.cpp
+++ b/goldenmaster/testbed2/olink/olinknestedstruct2interface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "testbed2/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -35,12 +36,12 @@ OLinkNestedStruct2Interface::OLinkNestedStruct2Interface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkNestedStruct2Interface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("prop1")) {
         setProp1Local(fields["prop1"].get<NestedStruct1>());
     }
@@ -51,7 +52,7 @@ void OLinkNestedStruct2Interface::applyState(const nlohmann::json& fields)
 
 void OLinkNestedStruct2Interface::setProp1(const NestedStruct1& prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -60,7 +61,7 @@ void OLinkNestedStruct2Interface::setProp1(const NestedStruct1& prop1)
 
 void OLinkNestedStruct2Interface::setProp1Local(const NestedStruct1& prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop1 != prop1) {
         m_prop1 = prop1;
         emit prop1Changed(prop1);
@@ -74,7 +75,7 @@ NestedStruct1 OLinkNestedStruct2Interface::prop1() const
 
 void OLinkNestedStruct2Interface::setProp2(const NestedStruct2& prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -83,7 +84,7 @@ void OLinkNestedStruct2Interface::setProp2(const NestedStruct2& prop2)
 
 void OLinkNestedStruct2Interface::setProp2Local(const NestedStruct2& prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop2 != prop2) {
         m_prop2 = prop2;
         emit prop2Changed(prop2);
@@ -97,7 +98,7 @@ NestedStruct2 OLinkNestedStruct2Interface::prop2() const
 
 NestedStruct1 OLinkNestedStruct2Interface::func1(const NestedStruct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return NestedStruct1();
     }
@@ -112,7 +113,7 @@ NestedStruct1 OLinkNestedStruct2Interface::func1(const NestedStruct1& param1)
 
 QtPromise::QPromise<NestedStruct1> OLinkNestedStruct2Interface::func1Async(const NestedStruct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<NestedStruct1>::reject("not initialized");
     }
@@ -129,7 +130,7 @@ QtPromise::QPromise<NestedStruct1> OLinkNestedStruct2Interface::func1Async(const
 
 NestedStruct1 OLinkNestedStruct2Interface::func2(const NestedStruct1& param1, const NestedStruct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return NestedStruct1();
     }
@@ -144,7 +145,7 @@ NestedStruct1 OLinkNestedStruct2Interface::func2(const NestedStruct1& param1, co
 
 QtPromise::QPromise<NestedStruct1> OLinkNestedStruct2Interface::func2Async(const NestedStruct1& param1, const NestedStruct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<NestedStruct1>::reject("not initialized");
     }
@@ -167,7 +168,8 @@ std::string OLinkNestedStruct2Interface::olinkObjectName()
 
 void OLinkNestedStruct2Interface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sig1") {
         emit sig1(args[0].get<NestedStruct1>());   
@@ -181,13 +183,15 @@ void OLinkNestedStruct2Interface::olinkOnSignal(const std::string& signalId, con
 
 void OLinkNestedStruct2Interface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkNestedStruct2Interface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -196,7 +200,7 @@ void OLinkNestedStruct2Interface::olinkOnInit(const std::string& objectId, const
 
 void OLinkNestedStruct2Interface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/testbed2/olink/olinknestedstruct2interfaceadapter.cpp
+++ b/goldenmaster/testbed2/olink/olinknestedstruct2interfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -107,7 +108,8 @@ std::string OLinkNestedStruct2InterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkNestedStruct2InterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "func1") {
         const NestedStruct1& param1 = args.at(0);
@@ -124,7 +126,8 @@ json OLinkNestedStruct2InterfaceAdapter::olinkInvoke(const std::string& methodId
 }
 
 void OLinkNestedStruct2InterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "prop1") {
         NestedStruct1 prop1 = value.get<NestedStruct1>();
@@ -137,12 +140,14 @@ void OLinkNestedStruct2InterfaceAdapter::olinkSetProperty(const std::string& pro
 }
 
 void OLinkNestedStruct2InterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkNestedStruct2InterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkNestedStruct2InterfaceAdapter::olinkCollectProperties()

--- a/goldenmaster/testbed2/olink/olinknestedstruct3interface.cpp
+++ b/goldenmaster/testbed2/olink/olinknestedstruct3interface.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "testbed2/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -36,12 +37,12 @@ OLinkNestedStruct3Interface::OLinkNestedStruct3Interface(QObject *parent)
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void OLinkNestedStruct3Interface::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(fields.contains("prop1")) {
         setProp1Local(fields["prop1"].get<NestedStruct1>());
     }
@@ -55,7 +56,7 @@ void OLinkNestedStruct3Interface::applyState(const nlohmann::json& fields)
 
 void OLinkNestedStruct3Interface::setProp1(const NestedStruct1& prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -64,7 +65,7 @@ void OLinkNestedStruct3Interface::setProp1(const NestedStruct1& prop1)
 
 void OLinkNestedStruct3Interface::setProp1Local(const NestedStruct1& prop1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop1 != prop1) {
         m_prop1 = prop1;
         emit prop1Changed(prop1);
@@ -78,7 +79,7 @@ NestedStruct1 OLinkNestedStruct3Interface::prop1() const
 
 void OLinkNestedStruct3Interface::setProp2(const NestedStruct2& prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -87,7 +88,7 @@ void OLinkNestedStruct3Interface::setProp2(const NestedStruct2& prop2)
 
 void OLinkNestedStruct3Interface::setProp2Local(const NestedStruct2& prop2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop2 != prop2) {
         m_prop2 = prop2;
         emit prop2Changed(prop2);
@@ -101,7 +102,7 @@ NestedStruct2 OLinkNestedStruct3Interface::prop2() const
 
 void OLinkNestedStruct3Interface::setProp3(const NestedStruct3& prop3)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -110,7 +111,7 @@ void OLinkNestedStruct3Interface::setProp3(const NestedStruct3& prop3)
 
 void OLinkNestedStruct3Interface::setProp3Local(const NestedStruct3& prop3)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_prop3 != prop3) {
         m_prop3 = prop3;
         emit prop3Changed(prop3);
@@ -124,7 +125,7 @@ NestedStruct3 OLinkNestedStruct3Interface::prop3() const
 
 NestedStruct1 OLinkNestedStruct3Interface::func1(const NestedStruct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return NestedStruct1();
     }
@@ -139,7 +140,7 @@ NestedStruct1 OLinkNestedStruct3Interface::func1(const NestedStruct1& param1)
 
 QtPromise::QPromise<NestedStruct1> OLinkNestedStruct3Interface::func1Async(const NestedStruct1& param1)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<NestedStruct1>::reject("not initialized");
     }
@@ -156,7 +157,7 @@ QtPromise::QPromise<NestedStruct1> OLinkNestedStruct3Interface::func1Async(const
 
 NestedStruct1 OLinkNestedStruct3Interface::func2(const NestedStruct1& param1, const NestedStruct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return NestedStruct1();
     }
@@ -171,7 +172,7 @@ NestedStruct1 OLinkNestedStruct3Interface::func2(const NestedStruct1& param1, co
 
 QtPromise::QPromise<NestedStruct1> OLinkNestedStruct3Interface::func2Async(const NestedStruct1& param1, const NestedStruct2& param2)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<NestedStruct1>::reject("not initialized");
     }
@@ -188,7 +189,7 @@ QtPromise::QPromise<NestedStruct1> OLinkNestedStruct3Interface::func2Async(const
 
 NestedStruct1 OLinkNestedStruct3Interface::func3(const NestedStruct1& param1, const NestedStruct2& param2, const NestedStruct3& param3)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return NestedStruct1();
     }
@@ -203,7 +204,7 @@ NestedStruct1 OLinkNestedStruct3Interface::func3(const NestedStruct1& param1, co
 
 QtPromise::QPromise<NestedStruct1> OLinkNestedStruct3Interface::func3Async(const NestedStruct1& param1, const NestedStruct2& param2, const NestedStruct3& param3)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<NestedStruct1>::reject("not initialized");
     }
@@ -226,7 +227,8 @@ std::string OLinkNestedStruct3Interface::olinkObjectName()
 
 void OLinkNestedStruct3Interface::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
     if(signalName == "sig1") {
         emit sig1(args[0].get<NestedStruct1>());   
@@ -244,13 +246,15 @@ void OLinkNestedStruct3Interface::olinkOnSignal(const std::string& signalId, con
 
 void OLinkNestedStruct3Interface::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void OLinkNestedStruct3Interface::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -259,7 +263,7 @@ void OLinkNestedStruct3Interface::olinkOnInit(const std::string& objectId, const
 
 void OLinkNestedStruct3Interface::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }

--- a/goldenmaster/testbed2/olink/olinknestedstruct3interfaceadapter.cpp
+++ b/goldenmaster/testbed2/olink/olinknestedstruct3interfaceadapter.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -132,7 +133,8 @@ std::string OLinkNestedStruct3InterfaceAdapter::olinkObjectName() {
 }
 
 json OLinkNestedStruct3InterfaceAdapter::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
     if(path == "func1") {
         const NestedStruct1& param1 = args.at(0);
@@ -156,7 +158,8 @@ json OLinkNestedStruct3InterfaceAdapter::olinkInvoke(const std::string& methodId
 }
 
 void OLinkNestedStruct3InterfaceAdapter::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
     if(path == "prop1") {
         NestedStruct1 prop1 = value.get<NestedStruct1>();
@@ -173,12 +176,14 @@ void OLinkNestedStruct3InterfaceAdapter::olinkSetProperty(const std::string& pro
 }
 
 void OLinkNestedStruct3InterfaceAdapter::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void OLinkNestedStruct3InterfaceAdapter::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json OLinkNestedStruct3InterfaceAdapter::olinkCollectProperties()

--- a/rules.yaml
+++ b/rules.yaml
@@ -123,6 +123,18 @@ features:
              raw: true
            - source: "apigear/monitor/agentclient.cpp"
              raw: true
+           - source: "apigear/utilities/CMakeLists.txt"
+             raw: true
+           - source: "apigear/utilities/logger.h"
+             raw: true
+           - source: "apigear/utilities/logger.cpp"
+             raw: true
+           - source: "apigear/utilities/tests/CMakeLists.txt"
+             raw: true
+           - source: "apigear/utilities/tests/logger.test.cpp"
+             raw: true
+           - source: "apigear/utilities/tests/test_main.cpp"
+             raw: true
            - source: apigear/olink/CMakeLists.txt
              raw: true
            - source: apigear/olink/olink_common.h

--- a/templates/apigear/CMakeLists.txt
+++ b/templates/apigear/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+add_subdirectory(utilities)
 add_subdirectory(olink)
 add_subdirectory(monitor)
 

--- a/templates/apigear/monitor/CMakeLists.txt
+++ b/templates/apigear/monitor/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(monitor_qt
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(monitor_qt PUBLIC Qt5::Core Qt5::WebSockets)
+target_link_libraries(monitor_qt PUBLIC apigear::utilities_qt Qt5::Core Qt5::WebSockets)
 target_compile_definitions(monitor_qt PRIVATE COMPILING_MONITOR_QT)
 
 # install binary files

--- a/templates/apigear/monitor/agentclient.cpp
+++ b/templates/apigear/monitor/agentclient.cpp
@@ -1,5 +1,5 @@
 #include "agentclient.h"
-
+#include "../utilities/logger.h"
 #include <QtNetwork>
 
 using namespace ApiGear::Monitor;
@@ -155,7 +155,7 @@ void AgentClient::doProcess()
     while (!m_queue.isEmpty()) {
         const QJsonObject &obj = m_queue.dequeue();
         const QByteArray &data = QJsonDocument(obj).toJson();
-        qDebug() << qPrintable(data);
+        AG_LOG_DEBUG(qPrintable(data));
         m_socket->sendBinaryMessage(data);
     }
 }
@@ -185,6 +185,6 @@ void AgentClient::doSendTrace()
         return;
     }
     const QByteArray& data = QJsonDocument(batch).toJson(QJsonDocument::Compact);
-    qDebug() << qPrintable(data);
+    AG_LOG_DEBUG(qPrintable(data));
     m_http->post(request, data);
 }

--- a/templates/apigear/olink/CMakeLists.txt
+++ b/templates/apigear/olink/CMakeLists.txt
@@ -44,7 +44,7 @@ target_include_directories(olink_qt
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(olink_qt PUBLIC olink_core Qt5::Core Qt5::WebSockets)
+target_link_libraries(olink_qt PUBLIC apigear::utilities_qt olink_core Qt5::Core Qt5::WebSockets)
 target_compile_definitions(olink_qt PRIVATE OLINK_QT)
 
 # install binary files

--- a/templates/apigear/olink/olinkhost.cpp
+++ b/templates/apigear/olink/olinkhost.cpp
@@ -25,6 +25,7 @@
 
 #include "olinkremote.h"
 #include "olink/remoteregistry.h"
+#include "../utilities/logger.h"
 
 using namespace ApiGear::ObjectLink;
 
@@ -44,16 +45,16 @@ OLinkHost::~OLinkHost()
 
 void OLinkHost::listen(const QString& host, int port)
 {
-    qDebug() << "wss.listen()";
+    AG_LOG_INFO("wss.listen ");
     m_wss->listen(QHostAddress(host), quint16(port));
-    qDebug() << m_wss->serverAddress() << m_wss->serverPort();
+    AG_LOG_INFO(m_wss->serverAddress().toString().toStdString() + ":" + std::to_string(m_wss->serverPort()));
     connect(m_wss, &QWebSocketServer::newConnection, this, &OLinkHost::onNewConnection);
     connect(m_wss, &QWebSocketServer::closed, this, &OLinkHost::onClosed);
 }
 
 void OLinkHost::onNewConnection()
 {
-    qDebug() << "wss.newConnection()";
+    AG_LOG_INFO("wss.newConnection");
     auto ws = m_wss->nextPendingConnection();
     OLinkRemote* connectionUser = new OLinkRemote(m_registry, ws);
     ws->setParent(connectionUser);
@@ -63,7 +64,7 @@ void OLinkHost::onNewConnection()
 
 void OLinkHost::onClosed()
 {
-    qDebug() << "wss.closed()";
+    AG_LOG_INFO("wss.closed");
 }
 
 RemoteRegistry &OLinkHost::registry()

--- a/templates/apigear/olink/olinkremote.cpp
+++ b/templates/apigear/olink/olinkremote.cpp
@@ -4,6 +4,8 @@
 #include "olink/remotenode.h"
 #include <memory>
 
+#include"../utilities/logger.h"
+
 using namespace ApiGear::ObjectLink;
 
 OLinkRemote::OLinkRemote(RemoteRegistry& registry, QWebSocket* socket)
@@ -21,7 +23,8 @@ OLinkRemote::OLinkRemote(RemoteRegistry& registry, QWebSocket* socket)
 
 void OLinkRemote::writeMessage(const QString &msg)
 {
-    qDebug() << Q_FUNC_INFO << msg;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(msg);
     if(m_socket) {
         m_socket->sendTextMessage(msg);
     }
@@ -29,13 +32,13 @@ void OLinkRemote::writeMessage(const QString &msg)
 
 void OLinkRemote::handleMessage(const QString &msg)
 {
-    qDebug() << Q_FUNC_INFO << msg;
-
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(msg);
     m_node->handleMessage(msg.toStdString());
 }
 
 void OLinkRemote::socketDisconnected()
 {
-    qDebug() << "Client disconnected, connection closed";
+    AG_LOG_INFO("Client disconnected, connection closed");
     this->deleteLater();
 }

--- a/templates/apigear/utilities/CMakeLists.txt
+++ b/templates/apigear/utilities/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.20)
+project(utilities_qt)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+find_package(Qt5 REQUIRED COMPONENTS Core)
+
+set (SOURCES
+    logger.cpp
+)
+add_library(utilities_qt SHARED ${SOURCES})
+add_library(apigear::utilities_qt ALIAS utilities_qt)
+target_include_directories(utilities_qt
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(utilities_qt PUBLIC Qt5::Core)
+
+# install binary files
+install(TARGETS utilities_qt
+        EXPORT  utilities_qtTargets
+        RUNTIME DESTINATION bin           COMPONENT Runtime
+        LIBRARY DESTINATION lib           COMPONENT Runtime
+        ARCHIVE DESTINATION lib           COMPONENT Development)
+# install includes
+install(FILES ${INCLUDES}
+        DESTINATION include/apigear/utilities)
+
+export(EXPORT utilities_qtTargets
+  NAMESPACE apigear::
+)
+
+if(BUILD_TESTING)
+add_subdirectory (tests)
+endif() # BUILD_TESTING

--- a/templates/apigear/utilities/logger.cpp
+++ b/templates/apigear/utilities/logger.cpp
@@ -1,0 +1,156 @@
+/*
+* MIT License
+*
+* Copyright (c) 2021 ApiGear
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "logger.h"
+#include <iostream>
+
+
+
+namespace ApiGear {
+namespace Utilities {
+
+// static logging functions
+static WriteLogFuncStdString logFunc = getDefaultLogStdStringFunc(LogLevel::Warning);
+static WriteLogFuncQString logFuncQString = getDefaultQStringLogFunc(LogLevel::Warning);
+static WriteLogFuncCharPtr logFuncChar = getDefaultCharLogFunc(LogLevel::Warning);
+
+// Constant text messages to add to log.
+static const std::string levelTextDebug = "[debug  ] ";
+static const std::string levelTextError = "[error  ] ";
+static const std::string levelTextWarning = "[warning] ";
+static const std::string levelTextInfo = "[info   ] ";
+
+
+void emitLog(LogLevel level, const std::string& msg) {
+    if (logFunc) {
+        logFunc(level, msg);
+    }
+}
+
+void setLogger(WriteLogFuncStdString func) {
+    logFunc = func;
+}
+
+void emitLog(LogLevel level, const QString& msg) {
+    if (logFuncQString) {
+        logFuncQString(level, msg);
+    }
+}
+
+void setLogger(WriteLogFuncQString func) {
+    logFuncQString = func;
+}
+
+void emitLog(LogLevel level, const char* msg) {
+    if (logFuncChar) {
+        logFuncChar(level, msg);
+    }
+}
+
+void setLogger(WriteLogFuncCharPtr func) {
+    logFuncChar = func;
+}
+
+WriteLogFuncStdString getDefaultLogStdStringFunc(LogLevel minimumLevel) {
+    return [minimumLevel](LogLevel level, const std::string& msg)
+    {
+        if (level < minimumLevel) {
+            return;
+        }
+
+        switch (level)
+        {
+        case LogLevel::Debug:
+            std::clog << levelTextDebug << msg << std::endl;
+            break;
+        case LogLevel::Error:
+            std::cerr << levelTextError << msg << std::endl;
+            break;
+        case LogLevel::Warning:
+            std::cerr << levelTextWarning << msg << std::endl;
+            break;
+        case LogLevel::Info:
+            std::cout << levelTextInfo << msg << std::endl;
+            break;
+        default:
+            break;
+        }
+    };
+}
+
+WriteLogFuncQString getDefaultQStringLogFunc(LogLevel minimumLevel) {
+    return [minimumLevel](LogLevel level, const QString& msg)
+    {
+        if (level < minimumLevel) {
+            return;
+        }
+
+        switch (level)
+        {
+        case LogLevel::Debug:
+            std::clog << levelTextDebug << msg.toStdString() << std::endl;
+            break;
+        case LogLevel::Error:
+            std::cerr << levelTextError << msg.toStdString() << std::endl;
+            break;
+        case LogLevel::Warning:
+            std::cerr << levelTextWarning << msg.toStdString() << std::endl;
+            break;
+        case LogLevel::Info:
+            std::cout << levelTextInfo << msg.toStdString() << std::endl;
+            break;
+        default:
+            break;
+        }
+    };
+}
+
+WriteLogFuncCharPtr getDefaultCharLogFunc(LogLevel minimumLevel) {
+    return [minimumLevel](LogLevel level, const char* msg)
+    {
+        if (level < minimumLevel) {
+            return;
+        }
+
+        switch (level)
+        {
+        case LogLevel::Debug:
+            std::clog << levelTextDebug << msg << std::endl;
+            break;
+        case LogLevel::Error:
+            std::cerr << levelTextError << msg << std::endl;
+            break;
+        case LogLevel::Warning:
+            std::cerr << levelTextWarning << msg << std::endl;
+            break;
+        case LogLevel::Info:
+            std::cout << levelTextInfo << msg << std::endl;
+            break;
+        default:
+            break;
+        }
+    };
+}
+
+
+}} // ApiGear::Utilities

--- a/templates/apigear/utilities/logger.h
+++ b/templates/apigear/utilities/logger.h
@@ -1,0 +1,196 @@
+/*
+* MIT License
+*
+* Copyright (c) 2021 ApiGear
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#pragma once
+
+#include <functional>
+#include <string>
+#include <QString>
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define APIGEAR_LOGGER __attribute__ ((dllexport))
+#else
+#define APIGEAR_LOGGER __declspec(dllexport)
+#endif
+#else
+#if __GNUC__ >= 4
+#define APIGEAR_LOGGER __attribute__ ((visibility ("default")))
+#else
+#define APIGEAR_LOGGER
+#endif
+#endif
+
+/**
+* File defines functionality for logging used in apigear implementation.
+* To avoid conversions, loggers are defined for three types of message used in the project:
+* const std::string&
+* const QString&
+* const char*
+* Have that in mind if you'd like to set your own loggers instead of default one (logging to std::cout/cerr),
+* you may want to change all three of them. See setLogger functions.
+* For convenience of use below macros are defined.
+* Alternatively we recommend using logInfo, logDebug, logWarning, logError functions.
+*/
+
+#define AG_LOG_INFO(str) ApiGear::Utilities::logInfo(str)
+#define AG_LOG_DEBUG(str) ApiGear::Utilities::logDebug(str)
+#define AG_LOG_WARNING(str) ApiGear::Utilities::logWarning(str)
+#define AG_LOG_ERROR(str) ApiGear::Utilities::logError(str)
+
+namespace ApiGear { namespace Utilities {
+
+/**
+* Logging levels for logs across the application.
+*/
+enum APIGEAR_LOGGER LogLevel {
+    Debug = 0,      // Useful for debugging during development
+    Info = 1,       // Some event happened, usually not important
+    Warning = 2,    // Important to know
+    Error = 3       // Must know - something is wrong
+};
+
+/**
+* Used to log messages of type const std::string&.
+* @param level specify the LogLevel
+* @param msg content to be logged
+*/
+void APIGEAR_LOGGER emitLog(LogLevel level, const std::string& msg);
+
+/**
+* Used to log messages of type const QString&.
+* @param level specify the LogLevel
+* @param msg content to be logged
+*/
+void APIGEAR_LOGGER emitLog(LogLevel level, const QString& msg);
+
+/**
+* Used to log messages of type const char*.
+* @param level specify the LogLevel
+* @param msg content to be logged
+*/
+void APIGEAR_LOGGER emitLog(LogLevel level, const char* msg);
+
+
+/**
+* Use to log on LogLevel::Info
+* @param msg to be logged
+* msgType should be one of: std::string&, QString&, char*.
+* For other types user must define own emitLog function.
+*/
+template<typename msgType>
+void APIGEAR_LOGGER logInfo(const msgType msg)
+{
+    emitLog(LogLevel::Info, msg);
+}
+
+/**
+* Use to log on LogLevel::Debug
+* @param msg to be logged
+* msgType should be one of: std::string&, QString&, char*.
+* For other types user must define own emitLog function.
+*/
+template<typename msgType>
+void APIGEAR_LOGGER logDebug(const msgType msg)
+{
+    emitLog(LogLevel::Debug, msg);
+}
+
+/**
+* Use to log on LogLevel::Warning
+* @param msg to be logged
+* msgType should be one of: std::string&, QString&, char*.
+* For other types user must define own emitLog function.
+*/
+template<typename msgType>
+void APIGEAR_LOGGER logWarning(const msgType msg)
+{
+    emitLog(LogLevel::Warning, msg);
+}
+
+/*
+* Use to log on LogLevel::Error
+* @param msg to be logged
+* msgType should be one of: std::string&, QString&, char*.
+* For other types user must define own emitLog function.
+*/
+template<typename msgType>
+void APIGEAR_LOGGER logError(const msgType msg)
+{
+    emitLog(LogLevel::Error, msg);
+}
+
+
+/** A type of function to log messages of const std::string& type. */
+using WriteLogFuncStdString = std::function<void(LogLevel level, const std::string& msg)>;
+/** A type of function to log messages of const QString& type. */
+using WriteLogFuncQString = std::function<void(LogLevel level, const QString& msg)>;
+/** A type of function to log of const char* type. */
+using WriteLogFuncCharPtr = std::function<void(LogLevel level, const char* msg)>;
+
+/**
+* Use to set logger function for messages of const std::string& type.
+* @param func a functions which implements the WriteLogFuncStdString signature
+*/
+void APIGEAR_LOGGER setLogger(WriteLogFuncStdString func);
+/**
+* Use to set logger function for messages of const QString& type.
+* @param func a functions which implements the WriteLogFuncQString signature
+*/
+void APIGEAR_LOGGER setLogger(WriteLogFuncQString func);
+/**
+* Use to set logger function for messages of const char* type.
+* @param func a functions which implements the WriteLogFuncCharPtr signature
+*/
+void APIGEAR_LOGGER setLogger(WriteLogFuncCharPtr func);
+
+/**
+* A getter the default logger for const std::string& messages.
+* @param minimumLevel A log level below which all the logging is skipped.
+* @return A default WriteLogFuncStdString logger function. 
+* Logs info and debug level to std::cout (if log level allows).
+* Logs warnings and errors to std::error (if log level allows).
+*/
+WriteLogFuncStdString APIGEAR_LOGGER getDefaultLogStdStringFunc(LogLevel minimumLevel);
+
+/**
+* A getter the default logger for const QString& messages.
+* @param minimumLevel A log level below which all the logging is skipped.
+* @return A default WriteLogFuncQString logger function.
+* Logs info and debug level to std::cout (if log level allows).
+* Logs warnings and errors to std::error (if log level allows).
+*/
+WriteLogFuncQString APIGEAR_LOGGER getDefaultQStringLogFunc(LogLevel minimumLevel);
+
+/**
+* A getter the default logger for const char* messages.
+* @param minimumLevel A log level below which all the logging is skipped.
+* @return A default WriteLogFuncCharPtr logger function.
+* Logs info and debug level to std::cout (if log level allows).
+* Logs warnings and errors to std::error (if log level allows).
+*/
+WriteLogFuncCharPtr APIGEAR_LOGGER getDefaultCharLogFunc(LogLevel minimumLevel);
+
+
+} } // ApiGear::Utilities
+

--- a/templates/apigear/utilities/tests/CMakeLists.txt
+++ b/templates/apigear/utilities/tests/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 3.20)
+project(test_apigear_utilities)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(CTest)
+
+
+
+
+if(BUILD_TESTING)
+enable_testing()
+
+Include(FetchContent)
+
+FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG        v2.13.8
+    GIT_SHALLOW    TRUE
+    FIND_PACKAGE_ARGS)
+
+FetchContent_MakeAvailable(Catch2)
+
+
+set(CMAKE_CTEST_COMMAND ctest -V)
+if(NOT TARGET check)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+set(TEST_APIGEAR_UTILITIES_SOURCES
+    test_main.cpp
+    logger.test.cpp
+    )
+
+add_executable(test_apigear_utilities ${TEST_APIGEAR_UTILITIES_SOURCES})
+
+# do not automatically run this test on MacOS
+# see https://github.com/apigear-io/template-qtcpp/issues/38
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+add_test(NAME test_apigear_utilities COMMAND $<TARGET_FILE:test_apigear_utilities>)
+add_dependencies(check test_apigear_utilities)
+endif() # NOT Darwin
+
+target_link_libraries(test_apigear_utilities PRIVATE apigear::utilities_qt Catch2::Catch2 Qt::Test)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_apigear_utilities
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+
+
+endif() # BUILD_TESTING

--- a/templates/apigear/utilities/tests/logger.test.cpp
+++ b/templates/apigear/utilities/tests/logger.test.cpp
@@ -1,0 +1,131 @@
+#pragma warning (disable: 4251) 
+#pragma warning (disable: 4099) 
+
+#include <catch2/catch.hpp>
+#include <iostream>
+#include <sstream>
+
+#include "../logger.h"
+
+namespace {
+    struct strTuple {
+        std::string cout;
+        std::string clog;
+        std::string cerr;
+    };
+
+    // we need to capture the strings and restore the buffers
+    // otherwise catch2 REQUIRE etc. checks cause seg faults
+    strTuple captureStdStreams(std::function<void()> testFunction)
+    {
+        using namespace std;
+        strTuple output;
+
+        // redirect std streams to be read by us
+        streambuf* oldCoutBuffer = cout.rdbuf();
+        ostringstream newCout;
+        cout.rdbuf(newCout.rdbuf());
+
+        streambuf* oldClogBuffer = clog.rdbuf();
+        ostringstream newClog;
+        clog.rdbuf(newClog.rdbuf());
+
+        streambuf* oldCerrBuffer = cerr.rdbuf();
+        ostringstream newCerr;
+        cerr.rdbuf(newCerr.rdbuf());
+
+        // run function under test
+        testFunction();
+
+        // save stream content
+        output.cout = newCout.str();
+        output.clog = newClog.str();
+        output.cerr = newCerr.str();
+
+        // reset streams
+        cout.rdbuf(oldCoutBuffer);
+        clog.rdbuf(oldClogBuffer);
+        cerr.rdbuf(oldCerrBuffer);
+
+        return output;
+    };
+
+    auto logAll = [](){
+        ApiGear::Utilities::logDebug("test loglevel debug");
+        ApiGear::Utilities::logInfo("test loglevel info");
+        ApiGear::Utilities::logWarning("test loglevel warning");
+        ApiGear::Utilities::logError("test loglevel error");
+    };
+
+}
+
+SCENARIO("Test console log", "[console][log]")
+{
+    GIVEN("Default settings") {
+        THEN("Warning and Error should be logged") {
+            strTuple output = captureStdStreams(logAll);
+            REQUIRE(output.cout.empty());
+            REQUIRE(output.clog.empty());
+            REQUIRE(output.cerr == "[warning] test loglevel warning\n[error  ] test loglevel error\n");
+        }
+    }
+
+    GIVEN("Set minimum log level to debug") {
+        ApiGear::Utilities::setLogger(ApiGear::Utilities::getDefaultCharLogFunc(ApiGear::Utilities::LogLevel::Debug));
+
+        THEN("Everything should be logged") {
+            strTuple output = captureStdStreams(logAll);
+            REQUIRE(output.cout== "[info   ] test loglevel info\n");
+            REQUIRE(output.clog=="[debug  ] test loglevel debug\n");
+            REQUIRE(output.cerr=="[warning] test loglevel warning\n[error  ] test loglevel error\n");
+        }
+    }
+
+    GIVEN("Set minimum log level to info") {
+        ApiGear::Utilities::setLogger(ApiGear::Utilities::getDefaultCharLogFunc(ApiGear::Utilities::LogLevel::Info));
+
+        THEN("Info, Warning and Error should be logged") {
+            strTuple output = captureStdStreams(logAll);
+            REQUIRE(output.cout== "[info   ] test loglevel info\n");
+            REQUIRE(output.clog.empty());
+            REQUIRE(output.cerr=="[warning] test loglevel warning\n[error  ] test loglevel error\n");
+        }
+    }
+
+    GIVEN("Set minimum log level to warning") {
+        ApiGear::Utilities::setLogger(ApiGear::Utilities::getDefaultCharLogFunc(ApiGear::Utilities::LogLevel::Warning));
+
+        THEN("Warning and Error should be logged") {
+            strTuple output = captureStdStreams(logAll);
+            REQUIRE(output.cout.empty());
+            REQUIRE(output.clog.empty());
+            REQUIRE(output.cerr=="[warning] test loglevel warning\n[error  ] test loglevel error\n");
+        }
+    }
+
+    GIVEN("Set minimum log level to error") {
+        ApiGear::Utilities::setLogger(ApiGear::Utilities::getDefaultCharLogFunc(ApiGear::Utilities::LogLevel::Error));
+
+        THEN("Error should be logged") {
+            strTuple output = captureStdStreams(logAll);
+            REQUIRE(output.cout.empty());
+            REQUIRE(output.clog.empty());
+            REQUIRE(output.cerr=="[error  ] test loglevel error\n");
+        }
+    }
+}
+
+SCENARIO("Test disabled log", "[log]")
+{
+    GIVEN("No log function defined") {
+        ApiGear::Utilities::WriteLogFuncCharPtr noFunc = nullptr;
+        ApiGear::Utilities::setLogger(noFunc);
+
+        THEN("Nothing should be logged") {
+            strTuple output = captureStdStreams(logAll);
+            REQUIRE(output.cout.empty());
+            REQUIRE(output.clog.empty());
+            REQUIRE(output.cerr.empty());
+        }
+    }
+}

--- a/templates/apigear/utilities/tests/test_main.cpp
+++ b/templates/apigear/utilities/tests/test_main.cpp
@@ -1,0 +1,7 @@
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif // __clang__
+
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch.hpp>

--- a/templates/examples/olinkclient/main.cpp.tpl
+++ b/templates/examples/olinkclient/main.cpp.tpl
@@ -2,6 +2,7 @@
 #include <QGuiApplication>
 #include "apigear/olink/olinkclient.h"
 #include "olink/clientregistry.h"
+#include "utilities/logger.h"
 #include <memory>
 {{- $features := .Features }}
 {{- range .System.Modules }}
@@ -66,7 +67,11 @@ int main(int argc, char *argv[])
 {{- if (and (eq $propertyExampleReady  0)  (len $interface.Properties) )}}
     {{- $property := (index $interface.Properties 0) }}
     // Try out properties: subscribe for changes
-    {{$clientClassNameCall}}connect({{$clientClassNameGetPtr}}, &{{ snake $module.Name }}::{{$class}}::{{$property.Name}}Changed, []( {{qtParam $namespacePrefix $property}}){ qDebug() << "{{$property.Name}} property changed ";});
+    {{$clientClassNameCall}}connect({{$clientClassNameGetPtr}}, &{{ snake $module.Name }}::{{$class}}::{{$property.Name}}Changed, 
+            []( {{qtParam $namespacePrefix $property}}){ 
+                static const std::string message = "{{$property.Name}} property changed ";
+                AG_LOG_DEBUG(message);
+            });
     // or ask for change.
     auto local_{{$property.Name}} = {{qtDefault $namespacePrefix $property}};
     {{$clientClassNameCall}}set{{Camel $property.Name}}(local_{{$property.Name}});
@@ -75,7 +80,11 @@ int main(int argc, char *argv[])
 {{- if (and (eq $signalExampleReady  0)  (len $interface.Signals))}}
     // Check the signals with subscribing for its change
     {{- $signal := (index $interface.Signals 0 ) }}
-    {{$clientClassNameCall}}connect({{$clientClassNameGetPtr}}, &{{ snake $module.Name }}::{{$class}}::{{camel $signal.Name}}, []({{qtParams $namespacePrefix $signal.Params}}){ qDebug() << "{{camel $signal.Name}} signal emitted ";});
+    {{$clientClassNameCall}}connect({{$clientClassNameGetPtr}}, &{{ snake $module.Name }}::{{$class}}::{{camel $signal.Name}}, 
+        []({{qtParams $namespacePrefix $signal.Params}}){
+                static const std::string message = "{{camel $signal.Name}} signal emitted ";
+                AG_LOG_DEBUG(message);
+        });
     {{ $signalExampleReady = 1}}
 {{- end }}
 

--- a/templates/http/CMakeLists.txt.tpl
+++ b/templates/http/CMakeLists.txt.tpl
@@ -23,4 +23,4 @@ set ({{$SOURCES}}
 
 add_library({{$module_id}}_http STATIC ${ {{- $SOURCES -}} })
 target_include_directories({{$module_id}}_http PRIVATE ../{{$module_id}})
-target_link_libraries({{$module_id}}_http PUBLIC Qt5::Network {{$module_id}}_api)
+target_link_libraries({{$module_id}}_http PUBLIC apigear::utilities_qt Qt5::Network {{$module_id}}_api)

--- a/templates/library/interface.cpp.tpl
+++ b/templates/library/interface.cpp.tpl
@@ -41,7 +41,6 @@ void {{$class}}::set{{Camel .Name}}({{qtParam "" .}})
 
 {{qtReturn "" .Return}} {{$class}}::{{camel .Name}}({{qtParams "" .Params}})
 {
-    qDebug() << Q_FUNC_INFO;
     return{{ if (not .Return.IsVoid) }} {{qtDefault "" .Return}} {{- end}};
 }
 {{- end }}

--- a/templates/monitor/interfacetraced.cpp.tpl
+++ b/templates/monitor/interfacetraced.cpp.tpl
@@ -4,15 +4,17 @@
 {{- $class := printf "%sTraced" $interfaceName }}
 #include "{{lower .Interface.Name}}traced.h"
 #include "{{snake .Module.Name}}/monitor/agent.h"
+#include "utilities/logger.h"
 
 namespace {{ snake .Module.Name }} {
 
+const std::string noObjectToTraceLogInfo = " object to trace is invalid.";
 
 {{$class}}::{{$class}}(std::shared_ptr<{{$interfaceClass}}> impl)
     :m_impl(impl)
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
 
@@ -40,7 +42,7 @@ namespace {{ snake .Module.Name }} {
 {{qtReturn "" $operation.Return }} {{$class}}::{{lower1 $operation.Name}}({{qtParams "" $operation.Params}}) 
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {{ if(not ($operation.Return.IsVoid)) }} {} {{ end }};
     }
     {{$interfaceName}}Agent::trace_{{$operation.Name}}(this{{- if (len $operation.Params) }},{{ end}} {{qtVars $operation.Params}});
@@ -53,7 +55,7 @@ namespace {{ snake .Module.Name }} {
 void {{$class}}::set{{Camel $property.Name}}({{qtParam "" $property}})
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return;
     }
     {{$interfaceName}}Agent::trace_state(this);
@@ -62,7 +64,7 @@ void {{$class}}::set{{Camel $property.Name}}({{qtParam "" $property}})
 {{qtReturn "" $property}} {{$class}}::{{$property.Name}}() const
 {
     if (!m_impl) {
-        qDebug() << Q_FUNC_INFO << " object to trace is invalid. ";
+        AG_LOG_WARNING(Q_FUNC_INFO + noObjectToTraceLogInfo);
         return {};
     }
     return m_impl->{{$property.Name}}();

--- a/templates/monitor/tracedapifactory.cpp.tpl
+++ b/templates/monitor/tracedapifactory.cpp.tpl
@@ -1,4 +1,5 @@
 #include "tracedapifactory.h"
+#include "utilities/logger.h"
 {{- $moduleName := snake .Module.Name }}
 
 {{- range .Module.Interfaces }}
@@ -12,14 +13,14 @@ TracedApiFactory::TracedApiFactory(IApiFactory& factory, QObject *parent)
     : QObject(parent),
       m_factory(factory)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 {{- range .Module.Interfaces }}
 
 std::shared_ptr<Abstract{{Camel .Name}}> TracedApiFactory::create{{Camel .Name}}(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     {{- $interfaceName := camel .Name  }}
     {{- $tracedclass := printf "%sTraced" (Camel $interfaceName) }}
     auto {{ $interfaceName}} = m_factory.create{{Camel .Name}}(parent);

--- a/templates/olink/olinkadapter.cpp.tpl
+++ b/templates/olink/olinkadapter.cpp.tpl
@@ -13,6 +13,7 @@
 
 #include "olink/remoteregistry.h"
 #include "olink/iremotenode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -80,7 +81,8 @@ std::string {{$class}}::olinkObjectName() {
 }
 
 json {{$class}}::olinkInvoke(const std::string& methodId, const nlohmann::json& args){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(methodId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(methodId);
     std::string path = Name::getMemberName(methodId);
 {{- range .Interface.Operations }}
     if(path == "{{.Name}}") {
@@ -100,7 +102,8 @@ json {{$class}}::olinkInvoke(const std::string& methodId, const nlohmann::json& 
 }
 
 void {{$class}}::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value){
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string path = Name::getMemberName(propertyId);
 {{- range .Interface.Properties }}
     if(path == "{{.Name}}") {
@@ -111,12 +114,14 @@ void {{$class}}::olinkSetProperty(const std::string& propertyId, const nlohmann:
 }
 
 void {{$class}}::olinkLinked(const std::string& objectId, IRemoteNode *node) {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 void {{$class}}::olinkUnlinked(const std::string& objectId)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
 }
 
 json {{$class}}::olinkCollectProperties()

--- a/templates/olink/olinkfactory.cpp.tpl
+++ b/templates/olink/olinkfactory.cpp.tpl
@@ -1,4 +1,5 @@
 #include "olinkfactory.h"
+#include "utilities/logger.h"
 
 {{- range .Module.Interfaces }}
 #include "olink/olink{{.Name|lower}}.h"
@@ -10,14 +11,14 @@ OLinkFactory::OLinkFactory(ApiGear::ObjectLink::OLinkClient& client, QObject *pa
     : QObject(parent),
       m_client(client)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 {{- range .Module.Interfaces }}
 
 std::shared_ptr<Abstract{{Camel .Name}}> OLinkFactory::create{{Camel .Name}}(QObject *parent)
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     auto {{snake .Name}} = std::make_shared<OLink{{.Name}}>();
     m_client.linkObjectSource({{snake .Name}});
     return {{snake .Name}};

--- a/templates/olink/olinkinterface.cpp.tpl
+++ b/templates/olink/olinkinterface.cpp.tpl
@@ -9,6 +9,7 @@
 #include "{{snake .Module.Name}}/api/json.adapter.h"
 
 #include "olink/iclientnode.h"
+#include "utilities/logger.h"
 
 #include <QtCore>
 
@@ -25,12 +26,12 @@ namespace {{snake  .Module.Name }} {
     , m_isReady(false)
     , m_node(nullptr)
 {        
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 }
 
 void {{$class}}::applyState(const nlohmann::json& fields) 
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
 {{- range .Interface.Properties }}
     if(fields.contains("{{.Name}}")) {
         set{{Camel .Name}}Local(fields["{{.Name}}"].get<{{qtReturn "" .}}>());
@@ -42,7 +43,7 @@ void {{$class}}::applyState(const nlohmann::json& fields)
 
 void {{$class}}::set{{Camel .Name}}({{qtParam "" .}})
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return;
     }
@@ -51,7 +52,7 @@ void {{$class}}::set{{Camel .Name}}({{qtParam "" .}})
 
 void {{$class}}::set{{Camel .Name}}Local({{qtParam "" .}})
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if (m_{{.Name}} != {{.Name}}) {
         m_{{.Name}} = {{.Name}};
         emit {{.Name}}Changed({{.Name}});
@@ -71,7 +72,7 @@ void {{$class}}::set{{Camel .Name}}Local({{qtParam "" .}})
 
 {{$return}} {{$class}}::{{camel .Name}}({{qtParams "" .Params}})
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return{{ if (not .Return.IsVoid) }} {{qtDefault "" .Return}} {{- end}};
     }
@@ -95,7 +96,7 @@ void {{$class}}::set{{Camel .Name}}Local({{qtParam "" .}})
 
 QtPromise::QPromise<{{$return}}> {{$class}}::{{camel .Name}}Async({{qtParams "" .Params}})
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_DEBUG(Q_FUNC_INFO);
     if(!m_node) {
         return QtPromise::QPromise<{{$return}}>::reject("not initialized");
     }
@@ -130,7 +131,8 @@ std::string {{$class}}::olinkObjectName()
 
 void {{$class}}::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(signalId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(signalId);
     auto signalName = Name::getMemberName(signalId);
 {{- range .Interface.Signals }}
 {{- $signalName := camel .Name }}
@@ -147,13 +149,15 @@ void {{$class}}::olinkOnSignal(const std::string& signalId, const nlohmann::json
 
 void {{$class}}::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(propertyId);
+    AG_LOG_DEBUG(Q_FUNC_INFO);
+    AG_LOG_DEBUG(propertyId);
     std::string propertyName = Name::getMemberName(propertyId);
     applyState({ {propertyName, value} });
 }
 void {{$class}}::olinkOnInit(const std::string& objectId, const nlohmann::json& props, IClientNode *node)
 {
-    qDebug() << Q_FUNC_INFO << QString::fromStdString(objectId);
+    AG_LOG_INFO(Q_FUNC_INFO);
+    AG_LOG_INFO(objectId);
     m_isReady = true;
     m_node = node;
     applyState(props);
@@ -162,7 +166,7 @@ void {{$class}}::olinkOnInit(const std::string& objectId, const nlohmann::json& 
 
 void {{$class}}::olinkOnRelease()
 {
-    qDebug() << Q_FUNC_INFO;
+    AG_LOG_INFO(Q_FUNC_INFO);
     m_isReady = false;
     m_node = nullptr;
 }


### PR DESCRIPTION
the default log level is warning
the log level allows to skip expensive log function there are 3 types of log functions for QString, std::string and const char* to avoid unnecessary allocations.
In hot path logs are split into verses - to avoid allocation of new string type, separate log for each argument.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->