### PR TITLE
Dphan/apigear next qt alignment

### DIFF
--- a/goldenmaster/apigear/utilities/qt_native.json.adapter.h
+++ b/goldenmaster/apigear/utilities/qt_native.json.adapter.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifndef JSON_USE_IMPLICIT_CONVERSIONS
+#define JSON_USE_IMPLICIT_CONVERSIONS 0
+#endif
+#include <nlohmann/json.hpp>
+#include <QtCore>
+
+inline void from_json(const nlohmann::json& j, QString& p) {
+    p = QString::fromStdString(j.get<std::string>());
+}
+
+inline void to_json(nlohmann::json& j, const QString& value) {
+    j = value.toStdString();
+}

--- a/goldenmaster/tb_enum/api/CMakeLists.txt
+++ b/goldenmaster/tb_enum/api/CMakeLists.txt
@@ -5,8 +5,10 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(apigear QUIET COMPONENTS utilities_qt)
-find_package(nlohmann_json REQUIRED)
-find_package(Qt6 REQUIRED COMPONENTS Core)
+
+
+find_package(Qt6 REQUIRED Core )
+find_package(nlohmann_json REQUIRED )
 
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
@@ -28,7 +30,7 @@ target_include_directories(tb_enum_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_enum_api PUBLIC apigear::utilities_qt nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_enum_api PUBLIC apigear::utilities_qt Qt6::Core nlohmann_json::nlohmann_json )
 
 target_compile_definitions(tb_enum_api PRIVATE TB_ENUM_API_LIBRARY)
 

--- a/goldenmaster/tb_enum/api/CMakeLists.txt
+++ b/goldenmaster/tb_enum/api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(tb_enum_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_enum_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_enum_api PUBLIC  nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_enum_api PRIVATE TB_ENUM_API_LIBRARY)
 

--- a/goldenmaster/tb_enum/api/CMakeLists.txt
+++ b/goldenmaster/tb_enum/api/CMakeLists.txt
@@ -4,6 +4,7 @@ project(tb_enum_api LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_package(apigear QUIET COMPONENTS utilities_qt)
 find_package(nlohmann_json REQUIRED)
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
@@ -27,7 +28,7 @@ target_include_directories(tb_enum_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_enum_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_enum_api PUBLIC apigear::utilities_qt nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_enum_api PRIVATE TB_ENUM_API_LIBRARY)
 

--- a/goldenmaster/tb_enum/api/CMakeLists.txt
+++ b/goldenmaster/tb_enum/api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(tb_enum_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_enum_api PUBLIC  nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_enum_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_enum_api PRIVATE TB_ENUM_API_LIBRARY)
 

--- a/goldenmaster/tb_enum/api/api.cpp
+++ b/goldenmaster/tb_enum/api/api.cpp
@@ -16,6 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "api.h"
+// use json.adapter.h to compile the file with this module and export all the necessary symbols in the library
+#include "json.adapter.h"
 
 namespace tb_enum {
 // ********************************************************************

--- a/goldenmaster/tb_enum/api/api.h
+++ b/goldenmaster/tb_enum/api/api.h
@@ -17,9 +17,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #pragma once
 
-#include <QtCore>
-#include <QtCore/QtGlobal>
 #include <QDataStream>
+#include <QtCore/QtGlobal>
+#include <QtCore>
 
 #if defined(TB_ENUM_API_LIBRARY)
 #  define TB_ENUM_API_EXPORT Q_DECL_EXPORT

--- a/goldenmaster/tb_enum/api/json.adapter.h
+++ b/goldenmaster/tb_enum/api/json.adapter.h
@@ -4,16 +4,9 @@
 #define JSON_USE_IMPLICIT_CONVERSIONS 0
 #endif
 #include "api.h"
+#include "apigear/utilities/qt_native.json.adapter.h"
 #include <nlohmann/json.hpp>
 #include <QtCore>
-
-inline void from_json(const nlohmann::json& j, QString& p) {
-    p = QString::fromStdString(j.get<std::string>());
-}
-
-inline void to_json(nlohmann::json& j, const QString& value) {
-    j = value.toStdString();
-}
 
 namespace tb_enum {
 } //namespace tb_enum

--- a/goldenmaster/tb_names/api/CMakeLists.txt
+++ b/goldenmaster/tb_names/api/CMakeLists.txt
@@ -5,8 +5,10 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(apigear QUIET COMPONENTS utilities_qt)
-find_package(nlohmann_json REQUIRED)
-find_package(Qt6 REQUIRED COMPONENTS Core)
+
+
+find_package(Qt6 REQUIRED Core )
+find_package(nlohmann_json REQUIRED )
 
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
@@ -28,7 +30,7 @@ target_include_directories(tb_names_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_names_api PUBLIC apigear::utilities_qt nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_names_api PUBLIC apigear::utilities_qt Qt6::Core nlohmann_json::nlohmann_json )
 
 target_compile_definitions(tb_names_api PRIVATE TB_NAMES_API_LIBRARY)
 

--- a/goldenmaster/tb_names/api/CMakeLists.txt
+++ b/goldenmaster/tb_names/api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(tb_names_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_names_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_names_api PUBLIC  nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_names_api PRIVATE TB_NAMES_API_LIBRARY)
 

--- a/goldenmaster/tb_names/api/CMakeLists.txt
+++ b/goldenmaster/tb_names/api/CMakeLists.txt
@@ -4,6 +4,7 @@ project(tb_names_api LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_package(apigear QUIET COMPONENTS utilities_qt)
 find_package(nlohmann_json REQUIRED)
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
@@ -27,7 +28,7 @@ target_include_directories(tb_names_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_names_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_names_api PUBLIC apigear::utilities_qt nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_names_api PRIVATE TB_NAMES_API_LIBRARY)
 

--- a/goldenmaster/tb_names/api/CMakeLists.txt
+++ b/goldenmaster/tb_names/api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(tb_names_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_names_api PUBLIC  nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_names_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_names_api PRIVATE TB_NAMES_API_LIBRARY)
 

--- a/goldenmaster/tb_names/api/api.cpp
+++ b/goldenmaster/tb_names/api/api.cpp
@@ -16,6 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "api.h"
+// use json.adapter.h to compile the file with this module and export all the necessary symbols in the library
+#include "json.adapter.h"
 
 namespace tb_names {
 

--- a/goldenmaster/tb_names/api/api.h
+++ b/goldenmaster/tb_names/api/api.h
@@ -17,9 +17,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #pragma once
 
-#include <QtCore>
-#include <QtCore/QtGlobal>
 #include <QDataStream>
+#include <QtCore/QtGlobal>
+#include <QtCore>
 
 #if defined(TB_NAMES_API_LIBRARY)
 #  define TB_NAMES_API_EXPORT Q_DECL_EXPORT

--- a/goldenmaster/tb_names/api/json.adapter.h
+++ b/goldenmaster/tb_names/api/json.adapter.h
@@ -4,16 +4,9 @@
 #define JSON_USE_IMPLICIT_CONVERSIONS 0
 #endif
 #include "api.h"
+#include "apigear/utilities/qt_native.json.adapter.h"
 #include <nlohmann/json.hpp>
 #include <QtCore>
-
-inline void from_json(const nlohmann::json& j, QString& p) {
-    p = QString::fromStdString(j.get<std::string>());
-}
-
-inline void to_json(nlohmann::json& j, const QString& value) {
-    j = value.toStdString();
-}
 
 namespace tb_names {
 } //namespace tb_names

--- a/goldenmaster/tb_same1/api/CMakeLists.txt
+++ b/goldenmaster/tb_same1/api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(tb_same1_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same1_api PUBLIC  nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_same1_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_same1_api PRIVATE TB_SAME1_API_LIBRARY)
 

--- a/goldenmaster/tb_same1/api/CMakeLists.txt
+++ b/goldenmaster/tb_same1/api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(tb_same1_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same1_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_same1_api PUBLIC  nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_same1_api PRIVATE TB_SAME1_API_LIBRARY)
 

--- a/goldenmaster/tb_same1/api/CMakeLists.txt
+++ b/goldenmaster/tb_same1/api/CMakeLists.txt
@@ -4,6 +4,7 @@ project(tb_same1_api LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_package(apigear QUIET COMPONENTS utilities_qt)
 find_package(nlohmann_json REQUIRED)
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
@@ -27,7 +28,7 @@ target_include_directories(tb_same1_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same1_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_same1_api PUBLIC apigear::utilities_qt nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_same1_api PRIVATE TB_SAME1_API_LIBRARY)
 

--- a/goldenmaster/tb_same1/api/CMakeLists.txt
+++ b/goldenmaster/tb_same1/api/CMakeLists.txt
@@ -5,8 +5,10 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(apigear QUIET COMPONENTS utilities_qt)
-find_package(nlohmann_json REQUIRED)
-find_package(Qt6 REQUIRED COMPONENTS Core)
+
+
+find_package(Qt6 REQUIRED Core )
+find_package(nlohmann_json REQUIRED )
 
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
@@ -28,7 +30,7 @@ target_include_directories(tb_same1_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same1_api PUBLIC apigear::utilities_qt nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_same1_api PUBLIC apigear::utilities_qt Qt6::Core nlohmann_json::nlohmann_json )
 
 target_compile_definitions(tb_same1_api PRIVATE TB_SAME1_API_LIBRARY)
 

--- a/goldenmaster/tb_same1/api/api.cpp
+++ b/goldenmaster/tb_same1/api/api.cpp
@@ -16,6 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "api.h"
+// use json.adapter.h to compile the file with this module and export all the necessary symbols in the library
+#include "json.adapter.h"
 
 namespace tb_same1 {
 // ********************************************************************

--- a/goldenmaster/tb_same1/api/api.h
+++ b/goldenmaster/tb_same1/api/api.h
@@ -17,9 +17,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #pragma once
 
-#include <QtCore>
-#include <QtCore/QtGlobal>
 #include <QDataStream>
+#include <QtCore/QtGlobal>
+#include <QtCore>
 
 #if defined(TB_SAME1_API_LIBRARY)
 #  define TB_SAME1_API_EXPORT Q_DECL_EXPORT

--- a/goldenmaster/tb_same1/api/json.adapter.h
+++ b/goldenmaster/tb_same1/api/json.adapter.h
@@ -4,16 +4,9 @@
 #define JSON_USE_IMPLICIT_CONVERSIONS 0
 #endif
 #include "api.h"
+#include "apigear/utilities/qt_native.json.adapter.h"
 #include <nlohmann/json.hpp>
 #include <QtCore>
-
-inline void from_json(const nlohmann::json& j, QString& p) {
-    p = QString::fromStdString(j.get<std::string>());
-}
-
-inline void to_json(nlohmann::json& j, const QString& value) {
-    j = value.toStdString();
-}
 
 namespace tb_same1 {
 

--- a/goldenmaster/tb_same2/api/CMakeLists.txt
+++ b/goldenmaster/tb_same2/api/CMakeLists.txt
@@ -4,6 +4,7 @@ project(tb_same2_api LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_package(apigear QUIET COMPONENTS utilities_qt)
 find_package(nlohmann_json REQUIRED)
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
@@ -27,7 +28,7 @@ target_include_directories(tb_same2_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same2_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_same2_api PUBLIC apigear::utilities_qt nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_same2_api PRIVATE TB_SAME2_API_LIBRARY)
 

--- a/goldenmaster/tb_same2/api/CMakeLists.txt
+++ b/goldenmaster/tb_same2/api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(tb_same2_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same2_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_same2_api PUBLIC  nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_same2_api PRIVATE TB_SAME2_API_LIBRARY)
 

--- a/goldenmaster/tb_same2/api/CMakeLists.txt
+++ b/goldenmaster/tb_same2/api/CMakeLists.txt
@@ -5,8 +5,10 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(apigear QUIET COMPONENTS utilities_qt)
-find_package(nlohmann_json REQUIRED)
-find_package(Qt6 REQUIRED COMPONENTS Core)
+
+
+find_package(Qt6 REQUIRED Core )
+find_package(nlohmann_json REQUIRED )
 
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
@@ -28,7 +30,7 @@ target_include_directories(tb_same2_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same2_api PUBLIC apigear::utilities_qt nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_same2_api PUBLIC apigear::utilities_qt Qt6::Core nlohmann_json::nlohmann_json )
 
 target_compile_definitions(tb_same2_api PRIVATE TB_SAME2_API_LIBRARY)
 

--- a/goldenmaster/tb_same2/api/CMakeLists.txt
+++ b/goldenmaster/tb_same2/api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(tb_same2_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_same2_api PUBLIC  nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_same2_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_same2_api PRIVATE TB_SAME2_API_LIBRARY)
 

--- a/goldenmaster/tb_same2/api/api.cpp
+++ b/goldenmaster/tb_same2/api/api.cpp
@@ -16,6 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "api.h"
+// use json.adapter.h to compile the file with this module and export all the necessary symbols in the library
+#include "json.adapter.h"
 
 namespace tb_same2 {
 // ********************************************************************

--- a/goldenmaster/tb_same2/api/api.h
+++ b/goldenmaster/tb_same2/api/api.h
@@ -17,9 +17,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #pragma once
 
-#include <QtCore>
-#include <QtCore/QtGlobal>
 #include <QDataStream>
+#include <QtCore/QtGlobal>
+#include <QtCore>
 
 #if defined(TB_SAME2_API_LIBRARY)
 #  define TB_SAME2_API_EXPORT Q_DECL_EXPORT

--- a/goldenmaster/tb_same2/api/json.adapter.h
+++ b/goldenmaster/tb_same2/api/json.adapter.h
@@ -4,16 +4,9 @@
 #define JSON_USE_IMPLICIT_CONVERSIONS 0
 #endif
 #include "api.h"
+#include "apigear/utilities/qt_native.json.adapter.h"
 #include <nlohmann/json.hpp>
 #include <QtCore>
-
-inline void from_json(const nlohmann::json& j, QString& p) {
-    p = QString::fromStdString(j.get<std::string>());
-}
-
-inline void to_json(nlohmann::json& j, const QString& value) {
-    j = value.toStdString();
-}
 
 namespace tb_same2 {
 

--- a/goldenmaster/tb_simple/api/CMakeLists.txt
+++ b/goldenmaster/tb_simple/api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(tb_simple_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_simple_api PUBLIC  nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_simple_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_simple_api PRIVATE TB_SIMPLE_API_LIBRARY)
 

--- a/goldenmaster/tb_simple/api/CMakeLists.txt
+++ b/goldenmaster/tb_simple/api/CMakeLists.txt
@@ -4,6 +4,7 @@ project(tb_simple_api LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_package(apigear QUIET COMPONENTS utilities_qt)
 find_package(nlohmann_json REQUIRED)
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
@@ -27,7 +28,7 @@ target_include_directories(tb_simple_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_simple_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_simple_api PUBLIC apigear::utilities_qt nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_simple_api PRIVATE TB_SIMPLE_API_LIBRARY)
 

--- a/goldenmaster/tb_simple/api/CMakeLists.txt
+++ b/goldenmaster/tb_simple/api/CMakeLists.txt
@@ -5,8 +5,10 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(apigear QUIET COMPONENTS utilities_qt)
-find_package(nlohmann_json REQUIRED)
-find_package(Qt6 REQUIRED COMPONENTS Core)
+
+
+find_package(Qt6 REQUIRED Core )
+find_package(nlohmann_json REQUIRED )
 
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
@@ -28,7 +30,7 @@ target_include_directories(tb_simple_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_simple_api PUBLIC apigear::utilities_qt nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_simple_api PUBLIC apigear::utilities_qt Qt6::Core nlohmann_json::nlohmann_json )
 
 target_compile_definitions(tb_simple_api PRIVATE TB_SIMPLE_API_LIBRARY)
 

--- a/goldenmaster/tb_simple/api/CMakeLists.txt
+++ b/goldenmaster/tb_simple/api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(tb_simple_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(tb_simple_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(tb_simple_api PUBLIC  nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(tb_simple_api PRIVATE TB_SIMPLE_API_LIBRARY)
 

--- a/goldenmaster/tb_simple/api/api.cpp
+++ b/goldenmaster/tb_simple/api/api.cpp
@@ -16,6 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "api.h"
+// use json.adapter.h to compile the file with this module and export all the necessary symbols in the library
+#include "json.adapter.h"
 
 namespace tb_simple {
 

--- a/goldenmaster/tb_simple/api/api.h
+++ b/goldenmaster/tb_simple/api/api.h
@@ -17,9 +17,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #pragma once
 
-#include <QtCore>
-#include <QtCore/QtGlobal>
 #include <QDataStream>
+#include <QtCore/QtGlobal>
+#include <QtCore>
 
 #if defined(TB_SIMPLE_API_LIBRARY)
 #  define TB_SIMPLE_API_EXPORT Q_DECL_EXPORT

--- a/goldenmaster/tb_simple/api/json.adapter.h
+++ b/goldenmaster/tb_simple/api/json.adapter.h
@@ -4,16 +4,9 @@
 #define JSON_USE_IMPLICIT_CONVERSIONS 0
 #endif
 #include "api.h"
+#include "apigear/utilities/qt_native.json.adapter.h"
 #include <nlohmann/json.hpp>
 #include <QtCore>
-
-inline void from_json(const nlohmann::json& j, QString& p) {
-    p = QString::fromStdString(j.get<std::string>());
-}
-
-inline void to_json(nlohmann::json& j, const QString& value) {
-    j = value.toStdString();
-}
 
 namespace tb_simple {
 } //namespace tb_simple

--- a/goldenmaster/testbed1/api/CMakeLists.txt
+++ b/goldenmaster/testbed1/api/CMakeLists.txt
@@ -5,8 +5,10 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(apigear QUIET COMPONENTS utilities_qt)
-find_package(nlohmann_json REQUIRED)
-find_package(Qt6 REQUIRED COMPONENTS Core)
+
+
+find_package(Qt6 REQUIRED Core )
+find_package(nlohmann_json REQUIRED )
 
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
@@ -28,7 +30,7 @@ target_include_directories(testbed1_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed1_api PUBLIC apigear::utilities_qt nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(testbed1_api PUBLIC apigear::utilities_qt Qt6::Core nlohmann_json::nlohmann_json )
 
 target_compile_definitions(testbed1_api PRIVATE TESTBED1_API_LIBRARY)
 

--- a/goldenmaster/testbed1/api/CMakeLists.txt
+++ b/goldenmaster/testbed1/api/CMakeLists.txt
@@ -4,6 +4,7 @@ project(testbed1_api LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_package(apigear QUIET COMPONENTS utilities_qt)
 find_package(nlohmann_json REQUIRED)
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
@@ -27,7 +28,7 @@ target_include_directories(testbed1_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed1_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(testbed1_api PUBLIC apigear::utilities_qt nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(testbed1_api PRIVATE TESTBED1_API_LIBRARY)
 

--- a/goldenmaster/testbed1/api/CMakeLists.txt
+++ b/goldenmaster/testbed1/api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(testbed1_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed1_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(testbed1_api PUBLIC  nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(testbed1_api PRIVATE TESTBED1_API_LIBRARY)
 

--- a/goldenmaster/testbed1/api/CMakeLists.txt
+++ b/goldenmaster/testbed1/api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(testbed1_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed1_api PUBLIC  nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(testbed1_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(testbed1_api PRIVATE TESTBED1_API_LIBRARY)
 

--- a/goldenmaster/testbed1/api/api.cpp
+++ b/goldenmaster/testbed1/api/api.cpp
@@ -16,6 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "api.h"
+// use json.adapter.h to compile the file with this module and export all the necessary symbols in the library
+#include "json.adapter.h"
 
 namespace testbed1 {
 // ********************************************************************

--- a/goldenmaster/testbed1/api/api.h
+++ b/goldenmaster/testbed1/api/api.h
@@ -17,9 +17,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #pragma once
 
-#include <QtCore>
-#include <QtCore/QtGlobal>
 #include <QDataStream>
+#include <QtCore/QtGlobal>
+#include <QtCore>
 
 #if defined(TESTBED1_API_LIBRARY)
 #  define TESTBED1_API_EXPORT Q_DECL_EXPORT

--- a/goldenmaster/testbed1/api/json.adapter.h
+++ b/goldenmaster/testbed1/api/json.adapter.h
@@ -4,16 +4,9 @@
 #define JSON_USE_IMPLICIT_CONVERSIONS 0
 #endif
 #include "api.h"
+#include "apigear/utilities/qt_native.json.adapter.h"
 #include <nlohmann/json.hpp>
 #include <QtCore>
-
-inline void from_json(const nlohmann::json& j, QString& p) {
-    p = QString::fromStdString(j.get<std::string>());
-}
-
-inline void to_json(nlohmann::json& j, const QString& value) {
-    j = value.toStdString();
-}
 
 namespace testbed1 {
 

--- a/goldenmaster/testbed2/api/CMakeLists.txt
+++ b/goldenmaster/testbed2/api/CMakeLists.txt
@@ -5,8 +5,10 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(apigear QUIET COMPONENTS utilities_qt)
-find_package(nlohmann_json REQUIRED)
-find_package(Qt6 REQUIRED COMPONENTS Core)
+
+
+find_package(Qt6 REQUIRED Core )
+find_package(nlohmann_json REQUIRED )
 
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
@@ -28,7 +30,7 @@ target_include_directories(testbed2_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed2_api PUBLIC apigear::utilities_qt nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(testbed2_api PUBLIC apigear::utilities_qt Qt6::Core nlohmann_json::nlohmann_json )
 
 target_compile_definitions(testbed2_api PRIVATE TESTBED2_API_LIBRARY)
 

--- a/goldenmaster/testbed2/api/CMakeLists.txt
+++ b/goldenmaster/testbed2/api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(testbed2_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed2_api PUBLIC  nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(testbed2_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(testbed2_api PRIVATE TESTBED2_API_LIBRARY)
 

--- a/goldenmaster/testbed2/api/CMakeLists.txt
+++ b/goldenmaster/testbed2/api/CMakeLists.txt
@@ -4,6 +4,7 @@ project(testbed2_api LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_package(apigear QUIET COMPONENTS utilities_qt)
 find_package(nlohmann_json REQUIRED)
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
@@ -27,7 +28,7 @@ target_include_directories(testbed2_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed2_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(testbed2_api PUBLIC apigear::utilities_qt nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(testbed2_api PRIVATE TESTBED2_API_LIBRARY)
 

--- a/goldenmaster/testbed2/api/CMakeLists.txt
+++ b/goldenmaster/testbed2/api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(testbed2_api
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(testbed2_api PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries(testbed2_api PUBLIC  nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions(testbed2_api PRIVATE TESTBED2_API_LIBRARY)
 

--- a/goldenmaster/testbed2/api/api.cpp
+++ b/goldenmaster/testbed2/api/api.cpp
@@ -16,6 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "api.h"
+// use json.adapter.h to compile the file with this module and export all the necessary symbols in the library
+#include "json.adapter.h"
 
 namespace testbed2 {
 // ********************************************************************

--- a/goldenmaster/testbed2/api/api.h
+++ b/goldenmaster/testbed2/api/api.h
@@ -17,9 +17,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #pragma once
 
-#include <QtCore>
-#include <QtCore/QtGlobal>
 #include <QDataStream>
+#include <QtCore/QtGlobal>
+#include <QtCore>
 
 #if defined(TESTBED2_API_LIBRARY)
 #  define TESTBED2_API_EXPORT Q_DECL_EXPORT

--- a/goldenmaster/testbed2/api/json.adapter.h
+++ b/goldenmaster/testbed2/api/json.adapter.h
@@ -4,16 +4,9 @@
 #define JSON_USE_IMPLICIT_CONVERSIONS 0
 #endif
 #include "api.h"
+#include "apigear/utilities/qt_native.json.adapter.h"
 #include <nlohmann/json.hpp>
 #include <QtCore>
-
-inline void from_json(const nlohmann::json& j, QString& p) {
-    p = QString::fromStdString(j.get<std::string>());
-}
-
-inline void to_json(nlohmann::json& j, const QString& value) {
-    j = value.toStdString();
-}
 
 namespace testbed2 {
 

--- a/rules.yaml
+++ b/rules.yaml
@@ -1,5 +1,5 @@
 engines:
-  cli: ">= v0.36.0"
+  cli: ">= v0.38.0"
 features:
   - name: api
     scopes:

--- a/rules.yaml
+++ b/rules.yaml
@@ -90,6 +90,8 @@ features:
              raw: true
            - source: "apigear/utilities/logger.cpp"
              raw: true
+           - source: "apigear/utilities/qt_native.json.adapter.h"
+             raw: true
            - source: "apigear/utilities/tests/CMakeLists.txt"
              raw: true
            - source: "apigear/utilities/tests/logger.test.cpp"

--- a/templates/api/CMakeLists.txt.tpl
+++ b/templates/api/CMakeLists.txt.tpl
@@ -11,6 +11,7 @@ project({{ $lib_id }} LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_package(apigear QUIET COMPONENTS utilities_qt)
 find_package(nlohmann_json REQUIRED)
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
@@ -43,7 +44,7 @@ target_include_directories({{$lib_id}}
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries({{$lib_id}} PUBLIC{{ range .Module.Imports }} {{snake .Name}}_api{{ end }}
+target_link_libraries({{$lib_id}} PUBLIC apigear::utilities_qt{{ range .Module.Imports }} {{snake .Name}}_api{{ end }}
 {{- range .Module.Externs }}
 {{- $extern := qtExtern . }}
 {{- if (not (eq $extern.Component "")) }} {{$extern.Package}}::{{$extern.Component}}

--- a/templates/api/CMakeLists.txt.tpl
+++ b/templates/api/CMakeLists.txt.tpl
@@ -34,7 +34,7 @@ target_include_directories({{$lib_id}}
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries({{$lib_id}} PUBLIC nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries({{$lib_id}} PUBLIC {{ range .Module.Imports }}{{snake .Name}}_api{{ end }} nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions({{$lib_id}} PRIVATE {{ $MODULE_ID }}_LIBRARY)
 

--- a/templates/api/CMakeLists.txt.tpl
+++ b/templates/api/CMakeLists.txt.tpl
@@ -14,6 +14,15 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(nlohmann_json REQUIRED)
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
+{{- range .Module.Externs }}
+{{- $extern := qtExtern . }}
+{{ if (not (eq $extern.Package "")) }}
+find_package({{$extern.Package}} REQUIRED 
+{{- if (not ( eq $extern.Component "")) }} COMPONENTS {{$extern.Component -}}{{- end -}}
+)
+{{- end }}
+{{- end }}
+
 set(OUTPUT_PATH ${LIBRARY_PATH}/)
 
 set ({{$SOURCES}}
@@ -34,7 +43,12 @@ target_include_directories({{$lib_id}}
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries({{$lib_id}} PUBLIC {{ range .Module.Imports }}{{snake .Name}}_api{{ end }} nlohmann_json::nlohmann_json Qt6::Core)
+target_link_libraries({{$lib_id}} PUBLIC{{ range .Module.Imports }} {{snake .Name}}_api{{ end }}
+{{- range .Module.Externs }}
+{{- $extern := qtExtern . }}
+{{- if (not (eq $extern.Component "")) }} {{$extern.Package}}::{{$extern.Component}}
+{{- else }} {{$extern.Component}}{{ end -}}
+{{- end }} nlohmann_json::nlohmann_json Qt6::Core)
 
 target_compile_definitions({{$lib_id}} PRIVATE {{ $MODULE_ID }}_LIBRARY)
 

--- a/templates/api/api.cpp.tpl
+++ b/templates/api/api.cpp.tpl
@@ -2,7 +2,7 @@
 {{- cppGpl .Module }}
 #include "api.h"
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace  .Module.Name }} {
 
 {{- range .Module.Enums }}
 {{- $class := .Name }}
@@ -95,4 +95,4 @@ QDataStream &operator>>(QDataStream &stream, {{$class}} &obj)
 
 {{- end }}
 
-} // namespace {{snake  .Module.Name }}
+} // namespace {{qtNamespace  .Module.Name }}

--- a/templates/api/api.cpp.tpl
+++ b/templates/api/api.cpp.tpl
@@ -1,6 +1,8 @@
 {{- $MODULE_ID := (SNAKE .Module.Name) }}
 {{- cppGpl .Module }}
 #include "api.h"
+// use json.adapter.h to compile the file with this module and export all the necessary symbols in the library
+#include "json.adapter.h"
 
 namespace {{qtNamespace  .Module.Name }} {
 

--- a/templates/api/api.h.tpl
+++ b/templates/api/api.h.tpl
@@ -11,6 +11,10 @@
 #include <QtCore/QtGlobal>
 #include <QDataStream>
 
+{{- range .Module.Imports }}
+#include "{{snake .Name}}/api/api.h"
+{{- end }}
+
 #if defined({{ $MODULE_ID }}_LIBRARY)
 #  define {{ $MODULE_ID }}_EXPORT Q_DECL_EXPORT
 #else

--- a/templates/api/api.h.tpl
+++ b/templates/api/api.h.tpl
@@ -6,16 +6,18 @@
 {{- $version := .Module.Version }}
 #pragma once
 
-#include <QtCore>
-#include <QtCore/QtGlobal>
-#include <QDataStream>
-
+{{- $listqtExterns := qtExterns .Module.Externs}}
+{{- $includes := (collectFields $listqtExterns  "Include")}}
+{{- $includes = (appendList $includes "<QtCore>") }}
+{{- $includes = (appendList $includes "<QtCore/QtGlobal>") }}
+{{- $includes = (appendList $includes "<QDataStream>") }}
 {{- range .Module.Imports }}
-#include "{{snake .Name}}/api/api.h"
+{{- $includeName :=  printf "\"%s/api/api.h\"" (snake .Name) }}
+{{- $includes = (appendList $includes  $includeName) }}
 {{- end }}
-{{- range .Module.Externs }}
-{{- $extern := qtExtern . }}
-#include {{ $extern.Include}}
+{{- $includes = unique $includes }}
+{{ range $includes }}
+#include {{ .}}
 {{- end }}
 
 #if defined({{ $MODULE_ID }}_LIBRARY)

--- a/templates/api/api.h.tpl
+++ b/templates/api/api.h.tpl
@@ -1,8 +1,7 @@
 {{- /* Copyright (c) ApiGear UG 2020 */}}
 {{- $MODULE_ID := printf "%s_API" (SNAKE .Module.Name) }}
-{{- $module_id := snake .Module.Name }}
-{{- $Modulename := Camel .Module.Name }}
-{{- $namespacePrefix := printf "%s::" (snake .Module.Name) }}
+{{- $namespace := qtNamespace .Module.Name }}
+{{- $namespacePrefix := printf "%s::" (qtNamespace .Module.Name) }}
 {{- cppGpl .Module }}
 {{- $version := .Module.Version }}
 #pragma once
@@ -21,7 +20,7 @@
 #  define {{ $MODULE_ID }}_EXPORT Q_DECL_IMPORT
 #endif
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 {{- range .Module.Enums }}
 {{- $class := .Name }}
@@ -198,13 +197,13 @@ signals:
 };
 {{ end }}
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}
 
 {{ range .Module.Enums }}
 {{- $class := .Name }}
-Q_DECLARE_METATYPE({{ $module_id }}::{{$class}}::{{$class}}Enum)
+Q_DECLARE_METATYPE({{ $namespace }}::{{$class}}::{{$class}}Enum)
 {{- end }}
 {{- range .Module.Structs }}
 {{- $class := .Name }}
-Q_DECLARE_METATYPE({{ $module_id }}::{{$class}})
+Q_DECLARE_METATYPE({{ $namespace }}::{{$class}})
 {{- end }}

--- a/templates/api/api.h.tpl
+++ b/templates/api/api.h.tpl
@@ -13,6 +13,10 @@
 {{- range .Module.Imports }}
 #include "{{snake .Name}}/api/api.h"
 {{- end }}
+{{- range .Module.Externs }}
+{{- $extern := qtExtern . }}
+#include {{ $extern.Include}}
+{{- end }}
 
 #if defined({{ $MODULE_ID }}_LIBRARY)
 #  define {{ $MODULE_ID }}_EXPORT Q_DECL_EXPORT

--- a/templates/api/iapifactory.h.tpl
+++ b/templates/api/iapifactory.h.tpl
@@ -10,7 +10,7 @@
 #include <memory>
 
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 {{- range .Module.Interfaces }}
     class Abstract{{Camel .Name}};
@@ -35,4 +35,4 @@ public:
 {{- end }}
 };
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/api/json.adapter.h.tpl
+++ b/templates/api/json.adapter.h.tpl
@@ -5,16 +5,13 @@
 #define JSON_USE_IMPLICIT_CONVERSIONS 0
 #endif
 #include "api.h"
+#include "apigear/utilities/qt_native.json.adapter.h"
 #include <nlohmann/json.hpp>
 #include <QtCore>
 
-inline void from_json(const nlohmann::json& j, QString& p) {
-    p = QString::fromStdString(j.get<std::string>());
-}
-
-inline void to_json(nlohmann::json& j, const QString& value) {
-    j = value.toStdString();
-}
+{{- range .Module.Imports }}
+#include "{{snake .Name}}/api/json.adapter.h"
+{{- end }}
 
 namespace {{snake  .Module.Name }} {
 

--- a/templates/api/json.adapter.h.tpl
+++ b/templates/api/json.adapter.h.tpl
@@ -13,7 +13,7 @@
 #include "{{snake .Name}}/api/json.adapter.h"
 {{- end }}
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 {{- range .Module.Structs }}
 {{- $class := .Name }}
@@ -34,4 +34,4 @@ inline void to_json(nlohmann::json& j, const {{$class}}& p) {
         };
 }
 {{- end }}
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/api/json.adapter.h.tpl
+++ b/templates/api/json.adapter.h.tpl
@@ -1,4 +1,5 @@
 {{- /* Copyright (c) ApiGear UG 2020 */ -}}
+{{- $MODULE_ID := printf "%s_API" (SNAKE .Module.Name) -}}
 #pragma once
 
 #ifndef JSON_USE_IMPLICIT_CONVERSIONS
@@ -12,6 +13,41 @@
 {{- range .Module.Imports }}
 #include "{{snake .Name}}/api/json.adapter.h"
 {{- end }}
+
+
+{{- if .Module.Externs }}
+namespace nlohmann {
+
+{{- range .Module.Externs }}
+{{- $externQt := qtExtern . }}
+
+{{- $type := $externQt.Name }}
+{{- if (not (eq $externQt.NameSpace "")) }}
+{{- $type = printf "%s::%s" $externQt.NameSpace $externQt.Name }}
+{{- end }}
+
+template<>
+struct {{ $MODULE_ID }}_EXPORT adl_serializer<{{$type}}> {
+    static void to_json(nlohmann::json& j, const {{$type}}& p)
+	{
+		// Do serialization here
+		j = nlohmann::json{
+			//{"member_name", p.member }, ...
+		};
+    }
+
+    static void from_json(const nlohmann::json& j, {{$type}}& p)
+    {
+	    // Do deserialization here, e.g.
+	    // p.xyz = j.at("xyz").get<Int>();
+	    p = {{$type}}();
+    }
+};
+
+{{- end }}
+
+} //namespace nlohmann
+{{- end}}
 
 namespace {{qtNamespace .Module.Name }} {
 

--- a/templates/apigear/utilities/qt_native.json.adapter.h
+++ b/templates/apigear/utilities/qt_native.json.adapter.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifndef JSON_USE_IMPLICIT_CONVERSIONS
+#define JSON_USE_IMPLICIT_CONVERSIONS 0
+#endif
+#include <nlohmann/json.hpp>
+#include <QtCore>
+
+inline void from_json(const nlohmann::json& j, QString& p) {
+    p = QString::fromStdString(j.get<std::string>());
+}
+
+inline void to_json(nlohmann::json& j, const QString& value) {
+    j = value.toStdString();
+}

--- a/templates/examples/mqttclient/main.cpp.tpl
+++ b/templates/examples/mqttclient/main.cpp.tpl
@@ -40,9 +40,9 @@ int main(int argc, char *argv[])
     {{- $class := Camel $interface.Name }}
     {{- $modulePrefix := lower1 (Camel $module.Name)}}
     {{- $clientClassName := printf "%s%s"  $modulePrefix $class }}
-    auto {{$clientClassName}} = std::make_shared< {{- snake $module.Name }}::Mqtt{{$interface.Name -}} >(client);
+    auto {{$clientClassName}} = std::make_shared< {{- qtNamespace $module.Name }}::Mqtt{{$interface.Name -}} >(client);
     {{- if $features.monitor }}
-    {{ snake $module.Name }}::{{$class}}Traced {{$clientClassName}}Traced({{$clientClassName}} );
+    {{ qtNamespace $module.Name }}::{{$class}}Traced {{$clientClassName}}Traced({{$clientClassName}} );
     {{- end }}
     {{- end }}
     {{- end }}
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
 
         {{- $class := printf "Abstract%s" (Camel .Name) -}}
         {{- $modulePrefix := lower1 (Camel $module.Name) -}}
-        {{- $namespacePrefix := printf "%s::" (snake $module.Name) -}}
+        {{- $namespacePrefix := printf "%s::" (qtNamespace $module.Name) -}}
         {{- $clientClassNameCall := printf "%s%s->"  $modulePrefix (Camel $interface.Name) -}}
         {{- $clientClassNameGetPtr := printf "%s%s.get()"  $modulePrefix (Camel $interface.Name) -}}
         {{- if $features.monitor -}}
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
 {{- if (and (eq $propertyExampleReady  0)  (len $interface.Properties) )}}
     {{- $property := (index $interface.Properties 0) }}
     // Try out properties: subscribe for changes
-    {{$clientClassNameCall}}connect({{$clientClassNameGetPtr}}, &{{ snake $module.Name }}::{{$class}}::{{$property.Name}}Changed, 
+    {{$clientClassNameCall}}connect({{$clientClassNameGetPtr}}, &{{ qtNamespace $module.Name }}::{{$class}}::{{$property.Name}}Changed, 
             []( {{qtParam $namespacePrefix $property}}){ 
                 static const std::string message = "{{$property.Name}} property changed ";
                 AG_LOG_DEBUG(message);
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
 {{- if (and (eq $signalExampleReady  0)  (len $interface.Signals))}}
     // Check the signals with subscribing for its change
     {{- $signal := (index $interface.Signals 0 ) }}
-    {{$clientClassNameCall}}connect({{$clientClassNameGetPtr}}, &{{ snake $module.Name }}::{{$class}}::{{camel $signal.Name}}, 
+    {{$clientClassNameCall}}connect({{$clientClassNameGetPtr}}, &{{ qtNamespace $module.Name }}::{{$class}}::{{camel $signal.Name}}, 
         []({{qtParams $namespacePrefix $signal.Params}}){
                 static const std::string message = "{{camel $signal.Name}} signal emitted ";
                 AG_LOG_DEBUG(message);

--- a/templates/examples/mqttqml/main.cpp.tpl
+++ b/templates/examples/mqttqml/main.cpp.tpl
@@ -44,12 +44,13 @@ int main(int argc, char *argv[]){
 
 {{- range .System.Modules }}
 {{- $module := . }}
-    {{ snake $module.Name }}::MqttFactory {{ snake $module.Name }}MqttFactory(client);
+    {{- $namespacePrefix := qtNamespace $module.Name }}
+    {{ $namespacePrefix }}::MqttFactory {{ snake $module.Name }}MqttFactory(client);
     {{- if $features.monitor }}
-    {{ snake $module.Name }}::TracedApiFactory {{ snake $module.Name }}TracedMqttFactory({{ snake $module.Name }}MqttFactory); 
-    {{ snake $module.Name }}::ApiFactory::set(&{{ snake $module.Name }}TracedMqttFactory);
+    {{ $namespacePrefix}}::TracedApiFactory {{ snake $module.Name }}TracedMqttFactory({{ snake $module.Name }}MqttFactory); 
+    {{ $namespacePrefix }}::ApiFactory::set(&{{ snake $module.Name }}TracedMqttFactory);
     {{- else }}
-    {{ snake $module.Name }}::ApiFactory::set(&{{ snake $module.Name }}MqttFactory);
+    {{ $namespacePrefix }}::ApiFactory::set(&{{ snake $module.Name }}MqttFactory);
     {{- end}}
 {{- end}}
 
@@ -78,8 +79,8 @@ int main(int argc, char *argv[]){
     {{- $modulePrefix := lower1 (Camel $module.Name)}}
     {{- $instanceName := printf "%s%s"  $modulePrefix $class }}
     {{- $serviceInstanceName := printf "%sMqtt%sService" $modulePrefix $class }}
-    auto {{$instanceName}} = std::make_shared<{{ snake $module.Name }}::{{$class}}>();
-    auto {{$serviceInstanceName}} = std::make_shared< {{- snake $module.Name }}::Mqtt{{$interface.Name}}Adapter>(service, {{ $instanceName }});
+    auto {{$instanceName}} = std::make_shared<{{ qtNamespace $module.Name }}::{{$class}}>();
+    auto {{$serviceInstanceName}} = std::make_shared< {{- qtNamespace $module.Name }}::Mqtt{{$interface.Name}}Adapter>(service, {{ $instanceName }});
     {{- end }}
     {{- end }}
 

--- a/templates/examples/mqttservice/main.cpp.tpl
+++ b/templates/examples/mqttservice/main.cpp.tpl
@@ -40,12 +40,13 @@ int main(int argc, char *argv[]){
     {{- $modulePrefix := lower1 (Camel $module.Name)}}
     {{- $instanceName := printf "%s%s"  $modulePrefix $class }}
     {{- $serviceInstanceName := printf "%sMqtt%sService" $modulePrefix $class }}
-    auto {{$instanceName}} = std::make_shared<{{ snake $module.Name }}::{{$class}}>();
+    {{- $namespacePrefix := qtNamespace $module.Name }}
+    auto {{$instanceName}} = std::make_shared<{{ $namespacePrefix }}::{{$class}}>();
     {{- if $features.monitor }}
-    auto {{$instanceName}}Traced = std::make_shared<{{ snake $module.Name }}::{{$class}}Traced>({{$instanceName}} );
-    auto {{$serviceInstanceName}} = std::make_shared< {{- snake $module.Name }}::Mqtt{{$interface.Name}}Adapter>(service, {{ $instanceName }}Traced);
+    auto {{$instanceName}}Traced = std::make_shared<{{$namespacePrefix }}::{{$class}}Traced>({{$instanceName}} );
+    auto {{$serviceInstanceName}} = std::make_shared<{{$namespacePrefix}}::Mqtt{{$interface.Name}}Adapter>(service, {{ $instanceName }}Traced);
     {{- else}}
-    auto {{$serviceInstanceName}} = std::make_shared< {{- snake $module.Name }}::Mqtt{{$interface.Name}}Adapter>(service, {{ $instanceName }});
+    auto {{$serviceInstanceName}} = std::make_shared<{{$namespacePrefix}}::Mqtt{{$interface.Name}}Adapter>(service, {{ $instanceName }});
     {{- end }}
     {{- end }}
     {{- end }}

--- a/templates/examples/olinkclient/main.cpp.tpl
+++ b/templates/examples/olinkclient/main.cpp.tpl
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
 
         {{- $class := printf "Abstract%s" (Camel .Name) -}}
         {{- $modulePrefix := lower1 (Camel $module.Name) -}}
-        {{- $namespacePrefix := printf "%s::" (snake $module.Name) -}}
+        {{- $namespacePrefix := printf "%s::" (qtNamespace $module.Name) -}}
         {{- $clientClassNameCall := printf "%s%s->"  $modulePrefix (Camel $interface.Name) -}}
         {{- $clientClassNameGetPtr := printf "%s%s.get()"  $modulePrefix (Camel $interface.Name) -}}
         {{- if $features.monitor -}}
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
 {{- if (and (eq $propertyExampleReady  0)  (len $interface.Properties) )}}
     {{- $property := (index $interface.Properties 0) }}
     // Try out properties: subscribe for changes
-    {{$clientClassNameCall}}connect({{$clientClassNameGetPtr}}, &{{ snake $module.Name }}::{{$class}}::{{$property.Name}}Changed, 
+    {{$clientClassNameCall}}connect({{$clientClassNameGetPtr}}, &{{ qtNamespace $module.Name }}::{{$class}}::{{$property.Name}}Changed, 
             []( {{qtParam $namespacePrefix $property}}){ 
                 static const std::string message = "{{$property.Name}} property changed ";
                 AG_LOG_DEBUG(message);
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
 {{- if (and (eq $signalExampleReady  0)  (len $interface.Signals))}}
     // Check the signals with subscribing for its change
     {{- $signal := (index $interface.Signals 0 ) }}
-    {{$clientClassNameCall}}connect({{$clientClassNameGetPtr}}, &{{ snake $module.Name }}::{{$class}}::{{camel $signal.Name}}, 
+    {{$clientClassNameCall}}connect({{$clientClassNameGetPtr}}, &{{ qtNamespace $module.Name }}::{{$class}}::{{camel $signal.Name}}, 
         []({{qtParams $namespacePrefix $signal.Params}}){
                 static const std::string message = "{{camel $signal.Name}} signal emitted ";
                 AG_LOG_DEBUG(message);

--- a/templates/examples/olinkserver/main.cpp.tpl
+++ b/templates/examples/olinkserver/main.cpp.tpl
@@ -39,12 +39,13 @@ int main(int argc, char *argv[]){
     {{- $modulePrefix := lower1 (Camel $module.Name)}}
     {{- $instanceName := printf "%s%s"  $modulePrefix $class }}
     {{- $serviceInstanceName := printf "%sOlink%sService" $modulePrefix $class }}
-    auto {{$instanceName}} = std::make_shared<{{ snake $module.Name }}::{{$class}}>();
+    {{- $namespacePrefix := qtNamespace $module.Name }}
+    auto {{$instanceName}} = std::make_shared<{{ $namespacePrefix }}::{{$class}}>();
     {{- if $features.monitor }}
-    {{ snake $module.Name }}::{{$class}}Traced {{$instanceName}}Traced({{$instanceName}} );
-    auto {{$serviceInstanceName}} = std::make_shared< {{- snake $module.Name }}::OLink{{$interface.Name}}Adapter>(registry, &{{ $instanceName }}Traced);
+    {{ $namespacePrefix }}::{{$class}}Traced {{$instanceName}}Traced({{$instanceName}} );
+    auto {{$serviceInstanceName}} = std::make_shared< {{- $namespacePrefix }}::OLink{{$interface.Name}}Adapter>(registry, &{{ $instanceName }}Traced);
     {{- else}}
-    auto {{$serviceInstanceName}} = std::make_shared< {{- snake $module.Name }}::OLink{{$interface.Name}}Adapter>(registry, {{ $instanceName }}.get());
+    auto {{$serviceInstanceName}} = std::make_shared< {{- $namespacePrefix }}::OLink{{$interface.Name}}Adapter>(registry, {{ $instanceName }}.get());
     {{- end }}
     registry.addSource( {{- $serviceInstanceName }});
     {{- end }}

--- a/templates/examples/qml/main.cpp.tpl
+++ b/templates/examples/qml/main.cpp.tpl
@@ -44,12 +44,13 @@ int main(int argc, char *argv[]){
 
 {{- range .System.Modules }}
 {{- $module := . }}
-    {{ snake $module.Name }}::OLinkFactory {{ snake $module.Name }}OlinkFactory(client);
+    {{- $namespacePrefix := qtNamespace $module.Name }}
+    {{ $namespacePrefix }}::OLinkFactory {{ snake $module.Name }}OlinkFactory(client);
     {{- if $features.monitor }}
-    {{ snake $module.Name }}::TracedApiFactory {{ snake $module.Name }}TracedOlinkFactory({{ snake $module.Name }}OlinkFactory); 
-    {{ snake $module.Name }}::ApiFactory::set(&{{ snake $module.Name }}TracedOlinkFactory);
+    {{$namespacePrefix}}::TracedApiFactory {{ snake $module.Name }}TracedOlinkFactory({{ snake $module.Name }}OlinkFactory); 
+    {{ $namespacePrefix }}::ApiFactory::set(&{{ snake $module.Name }}TracedOlinkFactory);
     {{- else }}
-    {{ snake $module.Name }}::ApiFactory::set(&{{ snake $module.Name }}OlinkFactory);
+    {{ $namespacePrefix }}::ApiFactory::set(&{{ snake $module.Name }}OlinkFactory);
     {{- end}}
 {{- end}}
 
@@ -78,8 +79,9 @@ int main(int argc, char *argv[]){
     {{- $modulePrefix := lower1 (Camel $module.Name)}}
     {{- $instanceName := printf "%s%s"  $modulePrefix $class }}
     {{- $serviceInstanceName := printf "%sOlink%sService" $modulePrefix $class }}
-    {{ snake $module.Name }}::{{$class}} {{$instanceName}};
-    auto {{$serviceInstanceName}} = std::make_shared< {{- snake $module.Name }}::OLink{{$interface.Name}}Adapter>(registry, &{{ $instanceName }});
+    {{- $namespacePrefix := snake $module.Name}}
+    {{ $namespacePrefix }}::{{$class}} {{$instanceName}};
+    auto {{$serviceInstanceName}} = std::make_shared< {{- $namespacePrefix }}::OLink{{$interface.Name}}Adapter>(registry, &{{ $instanceName }});
     registry.addSource( {{- $serviceInstanceName }});
     {{- end }}
     {{- end }}

--- a/templates/http/httpfactory.cpp.tpl
+++ b/templates/http/httpfactory.cpp.tpl
@@ -4,7 +4,7 @@
 #include "http{{.Name|lower}}.h"
 {{- end }}
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 HttpFactory::HttpFactory(QObject *parent)
     : QObject(parent)
@@ -22,4 +22,4 @@ std::shared_ptr<Abstract{{Camel .Name}}> HttpFactory::create{{Camel .Name}}(QObj
 {{- end }}
 
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/http/httpfactory.h.tpl
+++ b/templates/http/httpfactory.h.tpl
@@ -5,7 +5,7 @@
 
 #include "{{snake .Module.Name}}/api/iapifactory.h"
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 class HttpFactory : public QObject, public IApiFactory
 {
@@ -18,4 +18,4 @@ private:
     QNetworkAccessManager *m_network;
 };
 
-} // namespace {{snake  .Module.Name }}
+} // namespace {{qtNamespace .Module.Name }}

--- a/templates/http/httpinterface.cpp.tpl
+++ b/templates/http/httpinterface.cpp.tpl
@@ -7,7 +7,7 @@
 #include "apigear/utilities/logger.h"
 
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 {{$class}}::{{$class}}(QNetworkAccessManager *network, QObject *parent)
     : Abstract{{Camel .Interface.Name}}(parent)
@@ -88,4 +88,4 @@ void {{$class}}::applyState(const QJsonObject &state)
   {{- end }}
 }
 
-} // namespace {{snake  .Module.Name }} 
+} // namespace {{qtNamespace .Module.Name }} 

--- a/templates/http/httpinterface.h.tpl
+++ b/templates/http/httpinterface.h.tpl
@@ -8,7 +8,7 @@
 
 #include "{{snake .Module.Name}}/api/api.h"
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 class {{$class}} : public Abstract{{Camel .Interface.Name}}
 {
@@ -35,4 +35,4 @@ private:
 {{- end }}
 };
 
-} // namespace {{snake  .Module.Name }} 
+} // namespace {{qtNamespace .Module.Name }} 

--- a/templates/library/factory.cpp.tpl
+++ b/templates/library/factory.cpp.tpl
@@ -4,7 +4,7 @@
 #include "{{.Name|lower}}.h"
 {{- end }}
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 Factory::Factory(QObject *parent)
     : QObject(parent)
@@ -20,4 +20,4 @@ std::shared_ptr<Abstract{{Camel .Name}}> Factory::create{{Camel .Name}}(QObject 
 
 {{- end }}
 
-} // namespace {{snake  .Module.Name }}
+} // namespace {{qtNamespace .Module.Name }}

--- a/templates/library/factory.h.tpl
+++ b/templates/library/factory.h.tpl
@@ -11,7 +11,7 @@
 #  define {{ $LIB_ID }}_EXPORT Q_DECL_IMPORT
 #endif
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 /** 
 * A Factory that creates the actual implementaion for interfaces in {{ .Module.Name }}
@@ -29,5 +29,5 @@ public:
 {{- end }}
 };
 
-} // namespace {{snake  .Module.Name }}
+} // namespace {{qtNamespace .Module.Name }}
 

--- a/templates/library/interface.cpp.tpl
+++ b/templates/library/interface.cpp.tpl
@@ -5,7 +5,7 @@
 
 #include "{{lower .Interface.Name}}.h"
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 {{$class}}::{{$class}}(QObject *parent)
     : Abstract{{$class}}(parent)
@@ -42,4 +42,4 @@ void {{$class}}::set{{Camel .Name}}({{qtParam "" .}})
     return{{ if (not .Return.IsVoid) }} {{qtDefault "" .Return}} {{- end}};
 }
 {{- end }}
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/library/interface.h.tpl
+++ b/templates/library/interface.h.tpl
@@ -18,7 +18,7 @@
 #  define {{ $LIB_ID }}_EXPORT Q_DECL_IMPORT
 #endif
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 /**
 * The {{$interfaceNameOriginal}} implementation.
@@ -65,4 +65,4 @@ private:
     {{qtReturn "" .}} m_{{.Name}};
 {{- end }}
 };
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/monitor/agent.cpp.tpl
+++ b/templates/monitor/agent.cpp.tpl
@@ -3,7 +3,7 @@
 #include "agent.h"
 #include "apigear/monitor/agentclient.h"
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 {{- range .Module.Interfaces }}
 {{- $iface := Camel .Name }}
@@ -53,4 +53,4 @@ void {{$class}}::trace_{{.Name}}(Abstract{{$iface}}* obj{{- if (len .Params) }},
 
 {{- end }}
 
-} // namespace {{snake  .Module.Name }}
+} // namespace {{qtNamespace .Module.Name }}

--- a/templates/monitor/agent.h.tpl
+++ b/templates/monitor/agent.h.tpl
@@ -12,7 +12,7 @@
 #  define {{ $MODULE_ID }}_EXPORT Q_DECL_IMPORT
 #endif
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 {{- range .Module.Interfaces }}
 {{- $iface := Camel .Name }}
@@ -34,4 +34,4 @@ public:
 };
 {{- end }}
 
-} // namespace {{snake  .Module.Name }}
+} // namespace {{qtNamespace .Module.Name }}

--- a/templates/monitor/tracedapifactory.cpp.tpl
+++ b/templates/monitor/tracedapifactory.cpp.tpl
@@ -7,7 +7,7 @@
 #include "{{$filename}}.h"
 {{- end }}
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 TracedApiFactory::TracedApiFactory(IApiFactory& factory, QObject *parent)
     : QObject(parent),
@@ -29,4 +29,4 @@ std::shared_ptr<Abstract{{Camel .Name}}> TracedApiFactory::create{{Camel .Name}}
 
 {{- end }}
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/monitor/tracedapifactory.h.tpl
+++ b/templates/monitor/tracedapifactory.h.tpl
@@ -12,7 +12,7 @@
 #  define {{ $MODULE_ID }}_EXPORT Q_DECL_IMPORT
 #endif
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 /** 
 * A Factory that uses an interface created by other factory and wraps it with traces.
@@ -31,4 +31,4 @@ private:
     IApiFactory& m_factory;
 };
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/mqtt/mqttadapter.cpp.tpl
+++ b/templates/mqtt/mqttadapter.cpp.tpl
@@ -15,7 +15,7 @@
 #include <QtCore>
 
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 namespace
 {
@@ -152,4 +152,4 @@ void {{$class}}::unsubscribeAll()
     }
 }
 
-} // namespace {{snake  .Module.Name }}
+} // namespace {{qtNamespace .Module.Name }}

--- a/templates/mqtt/mqttadapter.h.tpl
+++ b/templates/mqtt/mqttadapter.h.tpl
@@ -14,7 +14,7 @@
 #include "mqtt_common.h"
 
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 
 /**
@@ -78,4 +78,4 @@ private:
     std::vector<quint64> m_subscribedIds;
 };
 
-} // namespace {{snake  .Module.Name }}
+} // namespace {{qtNamespace .Module.Name }}

--- a/templates/mqtt/mqttfactory.cpp.tpl
+++ b/templates/mqtt/mqttfactory.cpp.tpl
@@ -5,7 +5,7 @@
 #include "mqtt{{.Name|lower}}.h"
 {{- end }}
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 MqttFactory::MqttFactory(ApiGear::Mqtt::Client& client, QObject *parent)
     : QObject(parent),
@@ -24,4 +24,4 @@ std::shared_ptr<Abstract{{Camel .Name}}> MqttFactory::create{{Camel .Name}}(QObj
 
 {{- end }}
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/mqtt/mqttfactory.h.tpl
+++ b/templates/mqtt/mqttfactory.h.tpl
@@ -7,7 +7,7 @@
 #include <apigear/mqtt/mqttclient.h>
 #include "mqtt_common.h"
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 /** 
 * A Factory that creates a MqttClient version of interfaces in {{$.Module}}
@@ -29,4 +29,4 @@ private:
     ApiGear::Mqtt::Client& m_client;
 };
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/mqtt/mqttinterface.cpp.tpl
+++ b/templates/mqtt/mqttinterface.cpp.tpl
@@ -12,7 +12,7 @@
 
 #include <QtCore>
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 namespace
 {
@@ -243,4 +243,4 @@ void {{$class}}::findAndExecuteCall(const nlohmann::json& value, quint64 callId,
     if (function) function(value);
 }
 
-} // namespace {{snake  .Module.Name }}
+} // namespace {{qtNamespace .Module.Name }}

--- a/templates/mqtt/mqttinterface.h.tpl
+++ b/templates/mqtt/mqttinterface.h.tpl
@@ -20,7 +20,7 @@
 #include <nlohmann/json.hpp>
 #include <map>
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 /**
 * Adapts the general Mqtt Client handler to a {{$interfaceNameOriginal}} in a way it provides access
@@ -141,4 +141,4 @@ private:
     std::mutex m_pendingCallMutex;
 };
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/olink/olinkadapter.cpp.tpl
+++ b/templates/olink/olinkadapter.cpp.tpl
@@ -21,7 +21,7 @@ using namespace ApiGear::ObjectLink;
 
 using json = nlohmann::json;
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 {{$class}}::{{$class}}(RemoteRegistry& registry, Abstract{{$iface}}* impl, QObject *parent)
     : QObject(parent)
@@ -129,4 +129,4 @@ json {{$class}}::olinkCollectProperties()
     return captureState();
 }
 
-} // namespace {{snake  .Module.Name }}
+} // namespace {{qtNamespace .Module.Name }}

--- a/templates/olink/olinkadapter.h.tpl
+++ b/templates/olink/olinkadapter.h.tpl
@@ -17,7 +17,7 @@ class RemoteRegistry;
 class IRemoteNode;
 }}
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 /**
 * Server side for {{.Interface.Name}} implements the {{.Interface.Name}} service.
@@ -105,4 +105,4 @@ private:
     ApiGear::ObjectLink::RemoteRegistry& m_registry;
 };
 
-} // namespace {{snake  .Module.Name }}
+} // namespace {{qtNamespace .Module.Name }}

--- a/templates/olink/olinkfactory.cpp.tpl
+++ b/templates/olink/olinkfactory.cpp.tpl
@@ -5,7 +5,7 @@
 #include "olink/olink{{.Name|lower}}.h"
 {{- end }}
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 OLinkFactory::OLinkFactory(ApiGear::ObjectLink::OLinkClient& client, QObject *parent)
     : QObject(parent),
@@ -26,4 +26,4 @@ std::shared_ptr<Abstract{{Camel .Name}}> OLinkFactory::create{{Camel .Name}}(QOb
 
 {{- end }}
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/olink/olinkfactory.h.tpl
+++ b/templates/olink/olinkfactory.h.tpl
@@ -5,7 +5,7 @@
 #include "{{snake .Module.Name}}/api/iapifactory.h"
 #include <apigear/olink/olinkclient.h>
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 /** 
 * A Factory that creates a OlinkClient version of interfaces in {{ .Module.Name }}
@@ -35,4 +35,4 @@ private:
     ApiGear::ObjectLink::OLinkClient& m_client;
 };
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/olink/olinkinterface.cpp.tpl
+++ b/templates/olink/olinkinterface.cpp.tpl
@@ -17,7 +17,7 @@
 using namespace ApiGear;
 using namespace ApiGear::ObjectLink;
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 {{$class}}::{{$class}}(QObject *parent)
     : Abstract{{Camel .Interface.Name}}(parent)
@@ -175,4 +175,4 @@ void {{$class}}::olinkOnRelease()
     m_node = nullptr;
 }
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/olink/olinkinterface.h.tpl
+++ b/templates/olink/olinkinterface.h.tpl
@@ -25,7 +25,7 @@ class IClientNode;
 using namespace ApiGear;
 using namespace ApiGear::ObjectLink;
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 /**
 * Adapts the general OLink Client handler to a {{$interfaceNameOriginal}} in a way it provides access 
@@ -144,4 +144,4 @@ private:
     IClientNode *m_node;
 };
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/qmlplugin/apifactory.cpp.tpl
+++ b/templates/qmlplugin/apifactory.cpp.tpl
@@ -4,7 +4,7 @@
 
 {{ snake .Module.Name }}::IApiFactory* {{ snake .Module.Name }}::ApiFactory::s_instance(nullptr);
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 ApiFactory::ApiFactory(QObject *parent)
     : QObject(parent)
@@ -41,4 +41,4 @@ std::shared_ptr<Abstract{{Camel .Name}}> ApiFactory::create{{Camel .Name}}(QObje
 };
 {{- end }}
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/qmlplugin/apifactory.h.tpl
+++ b/templates/qmlplugin/apifactory.h.tpl
@@ -10,7 +10,7 @@
 #  define {{ $MODULE_ID }}_EXPORT Q_DECL_IMPORT
 #endif
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 {{- range .Module.Interfaces }}
     class Abstract{{Camel .Name}};
@@ -48,4 +48,4 @@ private:
     static IApiFactory *s_instance;
 };
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/qmlplugin/qml_api.cpp.tpl
+++ b/templates/qmlplugin/qml_api.cpp.tpl
@@ -2,7 +2,7 @@
 {{- cppGpl .Module }}
 #include "qml_api.h"
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 
 {{- range .Module.Structs }}
@@ -24,4 +24,4 @@ namespace {{snake  .Module.Name }} {
 }
 {{- end }}
 
-} // namespace {{snake  .Module.Name }}
+} // namespace {{qtNamespace .Module.Name }}

--- a/templates/qmlplugin/qml_api.h.tpl
+++ b/templates/qmlplugin/qml_api.h.tpl
@@ -20,7 +20,7 @@
 #  define {{ $MODULE_ID }}_EXPORT Q_DECL_IMPORT
 #endif
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 {{- range .Module.Enums }}
 {{- $class := .Name }}
@@ -53,4 +53,4 @@ public:
 {{- end }}
 
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/qmlplugin/qmlinterface.cpp.tpl
+++ b/templates/qmlplugin/qmlinterface.cpp.tpl
@@ -8,7 +8,7 @@
 
 #include <QtQml>
 
-namespace {{snake  .Module.Name }} {
+namespace {{qtNamespace .Module.Name }} {
 
 Qml{{$class}}::Qml{{$class}}(QObject *parent)
     : Abstract{{$class}}(parent)
@@ -58,4 +58,4 @@ void Qml{{$class}}::set{{Camel .Name}}({{qtParam "" .}})
 }
 {{- end }}
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}

--- a/templates/qmlplugin/qmlinterface.h.tpl
+++ b/templates/qmlplugin/qmlinterface.h.tpl
@@ -88,4 +88,4 @@ private:
 	std::shared_ptr<Abstract{{$class}}> m_obj;
 };
 
-} //namespace {{snake  .Module.Name }}
+} //namespace {{qtNamespace .Module.Name }}


### PR DESCRIPTION
- [x] UPDATE the cli version, when released ( https://github.com/apigear-io/cli/pull/146 must be first delivered) 
Implements:
#72 
#73 
#74 
#77

- [x] fix issue for extern module, which has only serializers, in a .h file. Those are only symbols to export, but are not exported since the header is not used anywhere. This cause whole project to fail to build, as other targets want to link against api.lib which is not created for that extern api library:
**Added serializers into api.cpp**

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->