### PR TITLE
fix: change order on starting olink service

### DIFF
--- a/docs/docs/features/olink.md
+++ b/docs/docs/features/olink.md
@@ -184,12 +184,14 @@ As mentioned earlier you need a network layer, here provided by a `ApiGear::Obje
     // Prepare the registry, the server, and an object which you want to expose.
     ApiGear::ObjectLink::RemoteRegistry registry;
     ApiGear::ObjectLink::OLinkHost server(registry);
-    server.listen("localhost", 8182);
     auto ioWorldHello = std::make_shared<io_world::Hello>();
 
     // Create your OLinkHelloAdapter and add it to registry.
     auto ioWorldOlinkHelloService = std::make_shared<io_world::OLinkHelloAdapter>(registry, ioWorldHello.get());
     registry.addSource(ioWorldOlinkHelloService);
+
+    // Start server with source added to registry.
+    server.listen("localhost", 8182);
 
     // use your ioWorldHello implementation, all property changes, and signals will be passed to connected OLink clients.
     auto lastMessage = ioWorldHello->last();

--- a/goldenmaster/examples/olinkserver/main.cpp
+++ b/goldenmaster/examples/olinkserver/main.cpp
@@ -87,7 +87,6 @@ int main(int argc, char *argv[]){
 
     QCoreApplication app(argc, argv);  ApiGear::ObjectLink::RemoteRegistry registry;
     ApiGear::ObjectLink::OLinkHost server(registry);
-    server.listen("localhost", 8182);
     auto testbed2ManyParamInterface = std::make_shared<testbed2::ManyParamInterface>();
     testbed2::ManyParamInterfaceTraced testbed2ManyParamInterfaceTraced(testbed2ManyParamInterface );
     auto testbed2OlinkManyParamInterfaceService = std::make_shared<testbed2::OLinkManyParamInterfaceAdapter>(registry, &testbed2ManyParamInterfaceTraced);
@@ -180,6 +179,10 @@ int main(int argc, char *argv[]){
     counter::CounterTraced counterCounterTraced(counterCounter );
     auto counterOlinkCounterService = std::make_shared<counter::OLinkCounterAdapter>(registry, &counterCounterTraced);
     registry.addSource(counterOlinkCounterService);
+    
+    // Start your server after all the services are added.
+    // This way you are sure that any new client that connects, will find the source it needs.
+    server.listen("localhost", 8182);
 
     auto result = app.exec();
     // Use the server.

--- a/templates/examples/olinkserver/main.cpp.tpl
+++ b/templates/examples/olinkserver/main.cpp.tpl
@@ -29,7 +29,6 @@ int main(int argc, char *argv[]){
 
     QCoreApplication app(argc, argv);  ApiGear::ObjectLink::RemoteRegistry registry;
     ApiGear::ObjectLink::OLinkHost server(registry);
-    server.listen("localhost", 8182);
 
     {{- range.System.Modules }}
     {{- $module := . }}
@@ -50,6 +49,10 @@ int main(int argc, char *argv[]){
     registry.addSource( {{- $serviceInstanceName }});
     {{- end }}
     {{- end }}
+    
+    // Start your server after all the services are added.
+    // This way you are sure that any new client that connects, will find the source it needs.
+    server.listen("localhost", 8182);
 
     auto result = app.exec();
     // Use the server.


### PR DESCRIPTION
Adds information that server should be started when all services are added to registry.
Changes order of starting a server in examples.
If client wants to make a connection before the server is up, the olink client will reconnect until it will succeed. On server start, connection gets established, but if a services is not already to service, the Olink will fail to link service side with a client side. To avoid such sitiation the services should be added to registry befor server starts listening.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here --> https://github.com/apigear-io/template-cpp14/issues/145

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->