### PR TITLE
fix: fix mqtt feature dependencies

### DIFF
--- a/docs/docs/features/features.md
+++ b/docs/docs/features/features.md
@@ -41,11 +41,15 @@ Features can be used in combination with `api` and add more functionality on top
 - [olink](olink.md) - provides a client and server adapters for each interface, that can be connected to any of the other technology templates with support for [ObjectLink](/docs/advanced/objectlink/intro). Use this feature to connect with ApiGear simulation tools.
 - [monitor](monitor.md) - generates a middleware layer which logs all API events to the [CLI](/docs/cli/intro) or the [Studio](/docs/studio/intro)
 - [MQTT](mqtt.md) experimental - provides minimal working adapters for MQTT client and service side for each interfaces. Check also MQTT in other technology templates that supports it.
--  examples feature - generates:
+-  examples_olink - generates:
     - `olinkserver` example with `main.cpp` that shows your services in olink server.
     - `olinkclient` example with `main.cpp` that shows your interfaces as olink client.
-    - `qml` example with a `main.cpp` and `qmlmain.qml`. The qml uses your interfaces. The main cpp sets olink client factory as a backend for the qml and sets up the olink server with your services (normally you'd have separate app for server)'.
-
+    - `qml` example with a `main.cpp` and `main.qml`. The qml uses your interfaces. The main cpp sets olink client factory (which provides olink client as a backend for the qml) and sets up the olink server with your services (normally you'd have separate app for server)'.
+-  examples_mqtt - generates:
+    - `mqttserver` example with `main.cpp` that shows your services in mqtt server.
+    - `mqttclient` example with `main.cpp` that shows your interfaces as mqtt client.
+    - `mqttqml` example with a `main.cpp` and `main.qml`. The qml uses your interfaces. The main cpp sets mqtt client factory (which provides mqtt client as a backend for the qml) and sets up the mqtt server with your services (normally you'd have separate app for server)'.
+    <br />Have in mind that generated code doesn't provide the mqtt broker. 
 <Figure caption="Features overview, including receiving data from network: Bottom floor shows possible inputs for your API, you can either obtain data from the network with OLink or MQTT or use local implementation. The top floor shows feature qmlpugin for qml oriented applications." src="/img/features/featuresApp.png" />
 <Figure caption="Features overview, including publishing data through network: Topmost floor shows your options for using your local implementation (bottom floor): you can use it in your local app and/or use method of sharing the data with clients in the network." src="/img/features/featuresServer.png" />
 

--- a/rules.yaml
+++ b/rules.yaml
@@ -205,7 +205,6 @@ features:
     requires:
       - api
       - apigear
-      - examples
     scopes:
       - match: module
         prefix: "{{snake .Module.Name}}/mqtt/"
@@ -251,7 +250,7 @@ features:
             target: "qml{{lower .Interface.Name}}.h"
           - source: "qmlplugin/qmlinterface.cpp.tpl"
             target: "qml{{lower .Interface.Name}}.cpp"
-  - name: examples
+  - name: examples_olink
     requires:
       - olink
       - stubs
@@ -275,6 +274,14 @@ features:
           raw: true
         - source: "examples/qml/main.qml.tpl"
           target: "examples/qml/main.qml"
+  - name: examples_mqtt
+    requires:
+      - mqtt
+      - stubs
+      - qmlplugin
+    scopes:
+    - match: system
+      documents:
         - source: "examples/mqttservice/CMakeLists.txt.tpl"
           target: "examples/mqttservice/CMakeLists.txt"
         - source: "examples/mqttservice/main.cpp.tpl"

--- a/templates/CMakeLists.txt.tpl
+++ b/templates/CMakeLists.txt.tpl
@@ -72,12 +72,12 @@ add_subdirectory({{ $moduleId }}/monitor)
 add_subdirectory({{ $moduleId }}/qmlplugin)
 {{- end}}
 {{- end }}
-{{- if $features.examples }}
+{{- if $features.examples_olink }}
 add_subdirectory(examples/olinkserver)
 add_subdirectory(examples/olinkclient)
 add_subdirectory(examples/qml)
 {{- end }}
-{{- if $features.mqtt }}
+{{- if $features.examples_mqtt }}
 add_subdirectory(examples/mqttservice)
 add_subdirectory(examples/mqttclient)
 add_subdirectory(examples/mqttqml)


### PR DESCRIPTION
mqtt feature required examples feature, which pulled olink feature, so having mqtt feature result in having a code for olink, with all its dependencies not required for mqtt.
This was fixed with:
Examples were split into examples_olink and examples_mqtt. Examples are not required mqtt, and need to be explicite requested if expected.
The olink is not required neither for mqtt nor for examples_mqtt. This closes #86

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->