### PR TITLE
fix: check extended timeouts

### DIFF
--- a/goldenmaster/apigear/tests/olink/CMakeLists.txt
+++ b/goldenmaster/apigear/tests/olink/CMakeLists.txt
@@ -60,13 +60,8 @@ include_directories(test_olink
 
 add_executable(test_olink ${TEST_OLINK_SOURCES})
 
-# do not automatically run this test on MacOS
-# see https://github.com/apigear-io/template-qtcpp/issues/38
-# see https://github.com/apigear-io/template-qtcpp/issues/69
-if ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows"))
 add_test(NAME test_olink COMMAND $<TARGET_FILE:test_olink>)
 add_dependencies(check test_olink)
-endif() # NOT Darwin or Windows
 
 target_link_libraries(test_olink PRIVATE
     olink_qt

--- a/goldenmaster/apigear/tests/olink/private/messagestorage.cpp
+++ b/goldenmaster/apigear/tests/olink/private/messagestorage.cpp
@@ -1,5 +1,6 @@
 #include "messagestorage.h"
 #include <QtCore>
+#include <QTest>
 MessageStorage::MessageStorage(QObject *parent)
     : QObject{parent}
 {
@@ -8,12 +9,8 @@ MessageStorage::MessageStorage(QObject *parent)
 
 QString MessageStorage::getMessage()
 {
-    for (size_t i = 0; i < 25; i++)
-    {
-        QCoreApplication::processEvents();
-        if (!m_messages.isEmpty()) break;
-    }
-    if (m_messages.isEmpty() )
+    auto messageArrived = QTest::qWaitFor([this]() {return !m_messages.isEmpty(); }, 1000);
+    if (!messageArrived)
     {
         return QString();
     }

--- a/goldenmaster/apigear/utilities/tests/CMakeLists.txt
+++ b/goldenmaster/apigear/utilities/tests/CMakeLists.txt
@@ -45,12 +45,8 @@ set(TEST_APIGEAR_UTILITIES_SOURCES
 
 add_executable(test_apigear_utilities ${TEST_APIGEAR_UTILITIES_SOURCES})
 
-# do not automatically run this test on MacOS
-# see https://github.com/apigear-io/template-qtcpp/issues/38
-if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 add_test(NAME test_apigear_utilities COMMAND $<TARGET_FILE:test_apigear_utilities>)
 add_dependencies(check test_apigear_utilities)
-endif() # NOT Darwin
 
 target_link_libraries(test_apigear_utilities PRIVATE apigear::utilities_qt Catch2::Catch2 Qt::Test)
 

--- a/templates/apigear/tests/olink/CMakeLists.txt
+++ b/templates/apigear/tests/olink/CMakeLists.txt
@@ -60,13 +60,8 @@ include_directories(test_olink
 
 add_executable(test_olink ${TEST_OLINK_SOURCES})
 
-# do not automatically run this test on MacOS
-# see https://github.com/apigear-io/template-qtcpp/issues/38
-# see https://github.com/apigear-io/template-qtcpp/issues/69
-if ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows"))
 add_test(NAME test_olink COMMAND $<TARGET_FILE:test_olink>)
 add_dependencies(check test_olink)
-endif() # NOT Darwin or Windows
 
 target_link_libraries(test_olink PRIVATE
     olink_qt

--- a/templates/apigear/tests/olink/private/messagestorage.cpp
+++ b/templates/apigear/tests/olink/private/messagestorage.cpp
@@ -1,5 +1,6 @@
 #include "messagestorage.h"
 #include <QtCore>
+#include <QTest>
 MessageStorage::MessageStorage(QObject *parent)
     : QObject{parent}
 {
@@ -8,12 +9,8 @@ MessageStorage::MessageStorage(QObject *parent)
 
 QString MessageStorage::getMessage()
 {
-    for (size_t i = 0; i < 25; i++)
-    {
-        QCoreApplication::processEvents();
-        if (!m_messages.isEmpty()) break;
-    }
-    if (m_messages.isEmpty() )
+    auto messageArrived = QTest::qWaitFor([this]() {return !m_messages.isEmpty(); }, 1000);
+    if (!messageArrived)
     {
         return QString();
     }

--- a/templates/apigear/utilities/tests/CMakeLists.txt
+++ b/templates/apigear/utilities/tests/CMakeLists.txt
@@ -45,12 +45,8 @@ set(TEST_APIGEAR_UTILITIES_SOURCES
 
 add_executable(test_apigear_utilities ${TEST_APIGEAR_UTILITIES_SOURCES})
 
-# do not automatically run this test on MacOS
-# see https://github.com/apigear-io/template-qtcpp/issues/38
-if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 add_test(NAME test_apigear_utilities COMMAND $<TARGET_FILE:test_apigear_utilities>)
 add_dependencies(check test_apigear_utilities)
-endif() # NOT Darwin
 
 target_link_libraries(test_apigear_utilities PRIVATE apigear::utilities_qt Catch2::Catch2 Qt::Test)
 


### PR DESCRIPTION
Restore running tests on Mac and Windows.
With https://github.com/apigear-io/template-qtcpp/commit/266e7b282bbc0264a1e6bf5d1fc3d2d6b0828cda and extending timeout for checking side effects of receiving messages the tests are working on Mac and Windows.

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->#38 #69

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->