### PR TITLE
Dphan/add test value mqtt tests

### DIFF
--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -56,7 +56,14 @@ jobs:
         run: |
              cmake .
              cmake --build .
-             cmake --install . --verbose 
+             cmake --install . --verbose
+      - name: Start Mosquitto
+        if: ${{ matrix.config.os == 'ubuntu-latest'}}
+        uses: namoshek/mosquitto-github-action@v1
+        with:
+          version: '1.6'
+          ports: '1883:1883'
+          container-name: 'mqtt'
       - name: Update path env on Windows for testing
         if: ${{ matrix.config.os == 'windows-latest'}}
         run: echo "$GITHUB_WORKSPACE/goldenmaster/build/bin/Debug/" >> $GITHUB_PATH

--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version: '6.5.2'
+          version: '6.5.3'
           cache: 'true'
           modules: qtwebsockets
       - name: create mqtt dir
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: qt/qtmqtt
-          ref: '6.5.2'
+          ref: '6.5.3'
           path: qtmqtt
       - name: Build qmqtt windows
         if: ${{ matrix.config.os == 'windows-latest'}}

--- a/.github/workflows/ci_build_test_features.yml
+++ b/.github/workflows/ci_build_test_features.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version: '6.5.2'
+          version: '6.5.3'
           cache: 'true'
           modules: qtwebsockets
       - name: create mqtt dir
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: qt/qtmqtt
-          ref: '6.5.2'
+          ref: '6.5.3'
           path: qtmqtt
       - name: Build qmqtt 
         if: ${{ matrix.config.short == 'mqtt'}}

--- a/.github/workflows/ci_build_test_features.yml
+++ b/.github/workflows/ci_build_test_features.yml
@@ -70,6 +70,13 @@ jobs:
       - run: go run main.go install
       - name: generate ${{ matrix.config.short }} feature set
         run: bin/apigear g x -f "${{ matrix.config.features }}" -t . -o test -i apigear/test-apis/testbed.simple.module.yaml,apigear/test-apis/testbed.struct.module.yaml
+      - name: Start Mosquitto
+        if: ${{ matrix.config.short == 'mqtt'}}
+        uses: namoshek/mosquitto-github-action@v1
+        with:
+          version: '1.6'
+          ports: '1883:1883'
+          container-name: 'mqtt'
       - name: Run cmake build & test on Linux/macOS
         working-directory: test
         env:

--- a/goldenmaster/CMakeLists.txt
+++ b/goldenmaster/CMakeLists.txt
@@ -25,6 +25,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 option(BUILD_TESTING "Enable this option to build the test targets" OFF)
 
 if(BUILD_TESTING)
+
+option(ENABLE_MQTT_TEST_FOR_NON_LINUX_OS "By default enable only for linux, due to easy broker setup on CI" OFF)
+
 find_package(Qt6 COMPONENTS Test REQUIRED)
 enable_testing()
 

--- a/goldenmaster/apigear/mqtt/mqttclient.cpp
+++ b/goldenmaster/apigear/mqtt/mqttclient.cpp
@@ -44,7 +44,7 @@ void Client::writeMessage(const QMqttTopicName& topic, const QByteArray& message
     m_client.publish(topic, message, QoS, noRetain);
 }
 
-void Client::onSubscribeTopic(quint64 id, const QString &topic, SimpleSubscribeCallback callback)
+void Client::onSubscribeTopic(quint64 id, const QString &topic, OnSubscribedCallback onSubscribed, SimpleSubscribeCallback callback)
 {
     auto subscription = m_client.subscribe(topic, QoS);
     auto subscribedTopic = subscription->topic();
@@ -69,7 +69,7 @@ void Client::onSubscribeTopic(quint64 id, const QString &topic, SimpleSubscribeC
     m_subscriptions.insert(subscription->topic(), std::make_pair(id, callback));
 }
 
-void Client::onSubscribeForInvokeResponse(quint64 id, const QString &topic, InvokeReplyCallback callback)
+void Client::onSubscribeForInvokeResponse(quint64 id, const QString &topic, OnSubscribedCallback onSubscribed, InvokeReplyCallback callback)
 {
     auto subscription = m_client.subscribe(topic, QoS);
     auto topicFilter = subscription->topic();
@@ -136,17 +136,17 @@ void Client::connectToHost(QString hostAddress,int port)
 
 }
 
-quint64 Client::subscribeTopic(const QString &topic, SimpleSubscribeCallback callback)
+quint64 Client::subscribeTopic(const QString &topic, OnSubscribedCallback onSubscribed, SimpleSubscribeCallback callback)
 {
     auto id = subscriptionIdGenerator.getId();
-    subscribeTopicSignal(id, topic, callback);
+    emit subscribeTopicSignal(id, topic, onSubscribed, callback);
     return id;
 }
 
-quint64 Client::subscribeForInvokeResponse(const QString &topic, InvokeReplyCallback callback)
+quint64 Client::subscribeForInvokeResponse(const QString &topic, OnSubscribedCallback onSubscribed, InvokeReplyCallback callback)
 {
     auto id = subscriptionIdGenerator.getId();
-    subscribeForInvokeResponseSignal(id, topic, callback);
+    emit subscribeForInvokeResponseSignal(id, topic, onSubscribed, callback);
     return id;
 }
 

--- a/goldenmaster/apigear/mqtt/mqttclient.cpp
+++ b/goldenmaster/apigear/mqtt/mqttclient.cpp
@@ -44,7 +44,7 @@ void Client::writeMessage(const QMqttTopicName& topic, const QByteArray& message
     m_client.publish(topic, message, QoS, noRetain);
 }
 
-void Client::onSubscribeTopic(quint64 id, const QString &topic, subscribeCallback callback)
+void Client::onSubscribeTopic(quint64 id, const QString &topic, SimpleSubscribeCallback callback)
 {
     auto subscription = m_client.subscribe(topic, QoS);
     auto subscribedTopic = subscription->topic();
@@ -69,7 +69,7 @@ void Client::onSubscribeTopic(quint64 id, const QString &topic, subscribeCallbac
     m_subscriptions.insert(subscription->topic(), std::make_pair(id, callback));
 }
 
-void Client::onSubscribeForInvokeResponse(quint64 id, const QString &topic, invokeReplyCallback callback)
+void Client::onSubscribeForInvokeResponse(quint64 id, const QString &topic, InvokeReplyCallback callback)
 {
     auto subscription = m_client.subscribe(topic, QoS);
     auto topicFilter = subscription->topic();
@@ -136,14 +136,14 @@ void Client::connectToHost(QString hostAddress,int port)
 
 }
 
-quint64 Client::subscribeTopic(const QString &topic, subscribeCallback callback)
+quint64 Client::subscribeTopic(const QString &topic, SimpleSubscribeCallback callback)
 {
     auto id = subscriptionIdGenerator.getId();
     subscribeTopicSignal(id, topic, callback);
     return id;
 }
 
-quint64 Client::subscribeForInvokeResponse(const QString &topic, invokeReplyCallback callback)
+quint64 Client::subscribeForInvokeResponse(const QString &topic, InvokeReplyCallback callback)
 {
     auto id = subscriptionIdGenerator.getId();
     subscribeForInvokeResponseSignal(id, topic, callback);

--- a/goldenmaster/apigear/mqtt/mqttclient.h
+++ b/goldenmaster/apigear/mqtt/mqttclient.h
@@ -32,18 +32,18 @@ public:
     /** dtor */
     virtual ~Client() override = default;
     // An alias for callback, necessary for signals/slots, which don't handle well function parameters with "const". 
-    using subscribeCallback = std::function<void(const nlohmann::json&)>;
+    using SimpleSubscribeCallback = std::function<void(const nlohmann::json&)>;
     // An alias for callback, necessary for signals/slots, which don't handle well function parameters with "const".
-    using invokeReplyCallback = std::function<void(const nlohmann::json&, quint64)>;
+    using InvokeReplyCallback = std::function<void(const nlohmann::json&, quint64)>;
 public slots:
     // Internal handler for internal messageToWriteWithProperties signal emitted during invoke requests.
     void writeMessageWithProperties(const QMqttTopicName& topic, const QByteArray& message, const QMqttPublishProperties &properties);
     // Internal handler for internal messageToWrite signal emitted by setRemoteProperty.
     void writeMessage(const QMqttTopicName& topic, const QByteArray& message);
     // Internal handler for internal subscribeTopicSignal signal, emitted by  subscribeTopic method.
-    void onSubscribeTopic(quint64 id, const QString &topic, subscribeCallback callback);
+    void onSubscribeTopic(quint64 id, const QString &topic, SimpleSubscribeCallback callback);
     // Internal handler of subscribeForInvokeResponseSignal signal, emitted by subscribeForInvokeResponse method.
-    void onSubscribeForInvokeResponse(quint64 id, const QString &topic, invokeReplyCallback callback);
+    void onSubscribeForInvokeResponse(quint64 id, const QString &topic, InvokeReplyCallback callback);
     // Internal handler for an unsubscribeTopic signal.
     void onUnsubscribedTopic(quint64 subscriptionId);
 
@@ -61,9 +61,9 @@ signals:
     // Internal signal for publishing messages. Used to allow multi thread safe use.
     void messageToWrite(const QMqttTopicName& topic, const QByteArray& message);
     // Internal signal emitted by subscribeTopic. Used to allow multi thread safe use.
-    void subscribeTopicSignal(quint64 id, const QString &topic, subscribeCallback callback);
+    void subscribeTopicSignal(quint64 id, const QString &topic, SimpleSubscribeCallback callback);
     // Internal signal emitted by subscribeForInvokeTopic. Used to allow multi thread safe use.
-    void subscribeForInvokeResponseSignal(quint64 id, const QString &topic, invokeReplyCallback callback);
+    void subscribeForInvokeResponseSignal(quint64 id, const QString &topic, InvokeReplyCallback callback);
     /**
     * Unsubscribes the callback from a topic, and the topic if there is no more callbacks subscribed to it.
     * @param id. A subscription id of a subscribed callback for a topic.
@@ -95,7 +95,7 @@ public:
     * NOTE Remember to unsubscribe the callback with an id given here as a parameter.
     * WARNING make sure that client is already connected.
     */
-    quint64 subscribeTopic(const QString &topic, subscribeCallback callback);
+    quint64 subscribeTopic(const QString &topic, SimpleSubscribeCallback callback);
     /**
     * Subscribes for receiving topic and provides a callback to be executed on receiving topic.
     * May subscribe many callbacks for same topic, all of subscribed callbacks will be executed on receiving the message.
@@ -104,7 +104,7 @@ public:
     * @return an Id for this subscription. Remember to unsubscribe the callback with this id.
     * WARNING make sure that client is already connected.
     */
-    quint64 subscribeForInvokeResponse(const QString &topic, invokeReplyCallback callback);
+    quint64 subscribeForInvokeResponse(const QString &topic, InvokeReplyCallback callback);
 
     /**
     * Publishes message, use requesting for a property of your interface to change.
@@ -139,9 +139,9 @@ private:
     /**The basic implementation of a Mqtt client, which gets adapted to expose interface as a service.*/
     QMqttClient m_client;
     /** Storage for subscribed topics for signals and property changes with their callbacks and subscription identifiers.*/
-    QMultiMap<QMqttTopicFilter, std::pair<quint64, subscribeCallback>> m_subscriptions;
+    QMultiMap<QMqttTopicFilter, std::pair<quint64, SimpleSubscribeCallback>> m_subscriptions;
     /** All invoke responses topic subscriptions and ids for them, stored by the topic*/
-    QMultiMap<QMqttTopicFilter, std::pair<quint64, invokeReplyCallback>> m_invokeReplySubscriptions;
+    QMultiMap<QMqttTopicFilter, std::pair<quint64, InvokeReplyCallback>> m_invokeReplySubscriptions;
     /** Object used to generate ids subscriptions.*/
     UniqueIdGenerator subscriptionIdGenerator;
     /** Object used to generate ids for awaited method invocation responses callbacks.*/

--- a/goldenmaster/apigear/mqtt/mqttservice.cpp
+++ b/goldenmaster/apigear/mqtt/mqttservice.cpp
@@ -74,7 +74,7 @@ void ServiceAdapter::writeMessage(const QMqttTopicName& topic, const QByteArray&
     m_client.publish(topic, message, QoS, retain);
 }
 
-void ServiceAdapter::onSubscribeTopic(quint64 id, const QString &topic, SimpleSubscribeCallback callback)
+void ServiceAdapter::onSubscribeTopic(quint64 id, const QString &topic, OnSubscribedCallback onSubscribed, SimpleSubscribeCallback callback)
 {
     auto subscription = m_client.subscribe(topic, QoS);
     auto subscribedTopic = subscription->topic();
@@ -98,7 +98,7 @@ void ServiceAdapter::onSubscribeTopic(quint64 id, const QString &topic, SimpleSu
     m_subscriptions.insert(subscription->topic(), std::make_pair(id, callback));
 }
 
-void ServiceAdapter::onSubscribeForInvokeTopic(quint64 id, const QString &topic, InvokeSubscribeCallback callback)
+void ServiceAdapter::onSubscribeForInvokeTopic(quint64 id, const QString &topic, OnSubscribedCallback onSubscribed, InvokeSubscribeCallback callback)
 {
     auto subscription = m_client.subscribe(topic, QoS);
     auto topicFilter = subscription->topic();
@@ -127,17 +127,17 @@ void ServiceAdapter::connectToHost(QString hostAddress,int port)
 
 }
 
-quint64 ServiceAdapter::subscribeTopic(const QString &topic, SimpleSubscribeCallback callback)
+quint64 ServiceAdapter::subscribeTopic(const QString &topic, OnSubscribedCallback onSubscribed, SimpleSubscribeCallback callback)
 {
     auto id = subscriptionIdGenerator.getId();
-    subscribeTopicSignal(id, topic, callback);
+    emit subscribeTopicSignal(id, topic, onSubscribed, callback);
     return id;
 }
 
-quint64 ServiceAdapter::subscribeForInvokeTopic(const QString &topic, InvokeSubscribeCallback callback){
+quint64 ServiceAdapter::subscribeForInvokeTopic(const QString &topic, OnSubscribedCallback onSubscribed, InvokeSubscribeCallback callback){
 
     auto id = subscriptionIdGenerator.getId();
-    subscribeForInvokeTopicSignal(id,topic, callback);
+    emit subscribeForInvokeTopicSignal(id, topic, onSubscribed, callback);
     return id;
 }
 

--- a/goldenmaster/apigear/mqtt/mqttservice.cpp
+++ b/goldenmaster/apigear/mqtt/mqttservice.cpp
@@ -127,14 +127,14 @@ void ServiceAdapter::connectToHost(QString hostAddress,int port)
 
 }
 
-quint64 ServiceAdapter::subscribeTopic(const QString &topic, std::function<void(const nlohmann::json&)> callback)
+quint64 ServiceAdapter::subscribeTopic(const QString &topic, SimpleSubscribeCallback callback)
 {
     auto id = subscriptionIdGenerator.getId();
     subscribeTopicSignal(id, topic, callback);
     return id;
 }
 
-quint64 ServiceAdapter::subscribeForInvokeTopic(const QString &topic, std::function<nlohmann::json(const nlohmann::json&)> callback){
+quint64 ServiceAdapter::subscribeForInvokeTopic(const QString &topic, InvokeSubscribeCallback callback){
 
     auto id = subscriptionIdGenerator.getId();
     subscribeForInvokeTopicSignal(id,topic, callback);

--- a/goldenmaster/counter/mqtt/CMakeLists.txt
+++ b/goldenmaster/counter/mqtt/CMakeLists.txt
@@ -31,6 +31,10 @@ target_include_directories(counter_mqtt
     $<INSTALL_INTERFACE:include/counter>
 )
 
+if (ENABLE_MQTT_TEST_FOR_NON_LINUX_OS OR ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")))
+add_subdirectory(tests)
+endif()
+
 target_link_libraries(counter_mqtt PUBLIC counter::counter_api apigear::apigear_mqtt Qt6::Concurrent)
 target_compile_definitions(counter_mqtt PRIVATE COUNTER_MQTT_LIBRARY)
 

--- a/goldenmaster/counter/mqtt/mqttcounter.cpp
+++ b/goldenmaster/counter/mqtt/mqttcounter.cpp
@@ -135,11 +135,14 @@ QFuture<QVector3D> MqttCounter::incrementAsync(const QVector3D& vec)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/increment");
     auto promise = std::make_shared<QPromise<QVector3D>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(QVector3D());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -147,7 +150,9 @@ QFuture<QVector3D> MqttCounter::incrementAsync(const QVector3D& vec)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(QVector3D());
+        promise->addResult(QVector3D());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({vec });       
@@ -156,6 +161,7 @@ QFuture<QVector3D> MqttCounter::incrementAsync(const QVector3D& vec)
         {
             QVector3D value = arg.get<QVector3D>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -178,11 +184,14 @@ QFuture<custom_types::Vector3D> MqttCounter::decrementAsync(const custom_types::
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/decrement");
     auto promise = std::make_shared<QPromise<custom_types::Vector3D>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(custom_types::Vector3D());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -190,7 +199,9 @@ QFuture<custom_types::Vector3D> MqttCounter::decrementAsync(const custom_types::
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(custom_types::Vector3D());
+        promise->addResult(custom_types::Vector3D());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({vec });       
@@ -199,6 +210,7 @@ QFuture<custom_types::Vector3D> MqttCounter::decrementAsync(const custom_types::
         {
             custom_types::Vector3D value = arg.get<custom_types::Vector3D>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/counter/mqtt/mqttcounter.cpp
+++ b/goldenmaster/counter/mqtt/mqttcounter.cpp
@@ -207,9 +207,9 @@ const QString& MqttCounter::interfaceName()
 }
 void MqttCounter::subscribeForPropertiesChanges()
 {
-        static const QString topicvector = interfaceName() + "/prop/vector";
+        const QString topicvector = interfaceName() + "/prop/vector";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicvector, [this](auto& value) { setVectorLocal(value);}));
-        static const QString topicextern_vector = interfaceName() + "/prop/extern_vector";
+        const QString topicextern_vector = interfaceName() + "/prop/extern_vector";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicextern_vector, [this](auto& value) { setExternVectorLocal(value);}));
 }
 void MqttCounter::subscribeForInvokeResponses()

--- a/goldenmaster/counter/mqtt/mqttcounter.h
+++ b/goldenmaster/counter/mqtt/mqttcounter.h
@@ -87,12 +87,16 @@ public:
     * Remote call of ICounter::decrement on the Counter service.
     */
     QFuture<custom_types::Vector3D> decrementAsync(const custom_types::Vector3D& vec);
+    /**
+    * Use to check if the MqttCounter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttCounter is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -120,9 +124,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttCounter.
     * Handles incoming and outgoing messages.
@@ -150,6 +156,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace counter

--- a/goldenmaster/counter/mqtt/mqttcounteradapter.cpp
+++ b/goldenmaster/counter/mqtt/mqttcounteradapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "counter/Counter";
 MqttCounterAdapter::MqttCounterAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractCounter> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -51,12 +52,14 @@ MqttCounterAdapter::MqttCounterAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServic
         subscribeForPropertiesChanges();
         subscribeForInvokeRequests();
         connectServicePropertiesChanges();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttCounterAdapter::~MqttCounterAdapter()
@@ -66,6 +69,12 @@ MqttCounterAdapter::~MqttCounterAdapter()
     unsubscribeAll();
 }
 
+bool MqttCounterAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
+
 const QString& MqttCounterAdapter::interfaceName()
 {
     return InterfaceName;
@@ -74,14 +83,18 @@ const QString& MqttCounterAdapter::interfaceName()
 void MqttCounterAdapter::subscribeForPropertiesChanges()
 {
     const auto setTopic_vector = interfaceName() + "/set/vector";
+    m_pendingSubscriptions.push_back(setTopic_vector);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_vector,
+        [this, setTopic_vector](auto id, bool hasSucceed){handleOnSubscribed(setTopic_vector, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             custom_types::Vector3D vector = value.get<custom_types::Vector3D>();
             m_impl->setVector(vector);
         }));
     const auto setTopic_extern_vector = interfaceName() + "/set/extern_vector";
+    m_pendingSubscriptions.push_back(setTopic_extern_vector);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_extern_vector,
+        [this, setTopic_extern_vector](auto id, bool hasSucceed){handleOnSubscribed(setTopic_extern_vector, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             QVector3D extern_vector = value.get<QVector3D>();
@@ -92,7 +105,9 @@ void MqttCounterAdapter::subscribeForPropertiesChanges()
 void MqttCounterAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_increment = interfaceName() + "/rpc/increment";
+    m_pendingSubscriptions.push_back(invokeTopic_increment);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_increment,
+        [this, invokeTopic_increment](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_increment, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             QVector3D vec = arguments.at(0).get<QVector3D>();
@@ -100,7 +115,9 @@ void MqttCounterAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_decrement = interfaceName() + "/rpc/decrement";
+    m_pendingSubscriptions.push_back(invokeTopic_decrement);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_decrement,
+        [this, invokeTopic_decrement](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_decrement, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             custom_types::Vector3D vec = arguments.at(0).get<custom_types::Vector3D>();
@@ -131,6 +148,25 @@ void MqttCounterAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttCounterAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/counter/mqtt/mqttcounteradapter.h
+++ b/goldenmaster/counter/mqtt/mqttcounteradapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttCounterAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttCounterAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -66,6 +75,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a Counter that gets adapted to be a service in mqtt network.
@@ -76,8 +87,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace counter

--- a/goldenmaster/counter/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/counter/mqtt/tests/CMakeLists.txt
@@ -1,0 +1,60 @@
+
+cmake_minimum_required(VERSION 3.20)
+project(test_counter_generated_mqtt)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(BUILD_TESTING)
+include(CTest)
+enable_testing()
+
+find_package(Qt6 REQUIRED COMPONENTS Test Core)
+find_package(apigear QUIET COMPONENTS apigear_mqtt)
+find_package(counter QUIET COMPONENTS counter_impl counter_mqtt)
+
+find_package(Catch2 REQUIRED)
+
+set(CMAKE_CTEST_COMMAND ctest -V)
+if(NOT TARGET check)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+set(TEST_COUNTER_GENERATED_MQTT_SOURCES
+    test_main.cpp
+    )
+
+include_directories(test_counter_generated_mqtt
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+add_executable(test_counter_generated_mqtt ${TEST_COUNTER_GENERATED_MQTT_SOURCES})
+add_test(NAME test_counter_generated_mqtt COMMAND $<TARGET_FILE:test_counter_generated_mqtt>)
+add_dependencies(check test_counter_generated_mqtt)
+
+target_link_libraries(test_counter_generated_mqtt PRIVATE
+    apigear_mqtt
+    counter_impl
+    counter_mqtt
+    Catch2::Catch2
+    Qt::Test)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_counter_generated_mqtt
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+
+endif() # BUILD_TESTING

--- a/goldenmaster/counter/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/counter/mqtt/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 endif()
 
 set(TEST_COUNTER_GENERATED_MQTT_SOURCES
+    test_mqttcounter.cpp
     test_main.cpp
     )
 

--- a/goldenmaster/counter/mqtt/tests/test_main.cpp
+++ b/goldenmaster/counter/mqtt/tests/test_main.cpp
@@ -1,0 +1,12 @@
+#define CATCH_CONFIG_RUNNER
+
+#include <QCoreApplication>
+#include <catch2/catch.hpp>
+
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv); // -platform offscreen
+    int result = Catch::Session().run(argc, argv); // --break
+    return result;
+}

--- a/goldenmaster/counter/mqtt/tests/test_mqttcounter.cpp
+++ b/goldenmaster/counter/mqtt/tests/test_mqttcounter.cpp
@@ -1,0 +1,130 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/counter.h"
+#include "mqtt/mqttcounter.h"
+#include "mqtt/mqttcounteradapter.h"
+
+#include "custom_types/api/test_struct_helper.h"
+#include "extern_types/api/test_struct_helper.h"
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  counter Counter tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientCounter = std::make_shared<counter::MqttCounter >(client);
+    auto implCounter = std::make_shared<counter::Counter>();
+    auto serviceCounter = std::make_shared<counter::MqttCounterAdapter>(service, implCounter);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientCounter, &serviceCounter]() {return clientCounter->isReady() && serviceCounter->isReady(); }, timeout));
+    SECTION("Test setting vector")
+    {
+        std::atomic<bool> isvectorChanged = false;
+        clientCounter->connect(clientCounter.get(), &counter::AbstractCounter::vectorChanged, [&isvectorChanged ](auto value){isvectorChanged  = true;});
+        auto test_value = custom_types::Vector3D();
+        custom_types::fillTestVector3D(test_value);
+        clientCounter->setVector(test_value);
+        REQUIRE(QTest::qWaitFor([&isvectorChanged]() {return isvectorChanged  == true; }, timeout));
+        REQUIRE(implCounter->vector() == test_value);
+        REQUIRE(clientCounter->vector() == test_value);
+    }
+    SECTION("Test method increment")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientCounter, &finished](){
+            [[maybe_unused]] auto result = clientCounter->increment(QVector3D());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method increment async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientCounter->incrementAsync(QVector3D());
+        resultFuture.then([&finished](QVector3D /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == QVector3D());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method decrement")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientCounter, &finished](){
+            [[maybe_unused]] auto result = clientCounter->decrement(custom_types::Vector3D());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method decrement async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientCounter->decrementAsync(custom_types::Vector3D());
+        resultFuture.then([&finished](custom_types::Vector3D /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == custom_types::Vector3D());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientCounter.reset();
+    serviceCounter.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/custom_types/mqtt/CMakeLists.txt
+++ b/goldenmaster/custom_types/mqtt/CMakeLists.txt
@@ -29,6 +29,10 @@ target_include_directories(custom_types_mqtt
     $<INSTALL_INTERFACE:include/custom_types>
 )
 
+if (ENABLE_MQTT_TEST_FOR_NON_LINUX_OS OR ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")))
+add_subdirectory(tests)
+endif()
+
 target_link_libraries(custom_types_mqtt PUBLIC custom_types::custom_types_api apigear::apigear_mqtt Qt6::Concurrent)
 target_compile_definitions(custom_types_mqtt PRIVATE CUSTOM_TYPES_MQTT_LIBRARY)
 

--- a/goldenmaster/custom_types/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/custom_types/mqtt/tests/CMakeLists.txt
@@ -1,0 +1,60 @@
+
+cmake_minimum_required(VERSION 3.20)
+project(test_custom_types_generated_mqtt)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(BUILD_TESTING)
+include(CTest)
+enable_testing()
+
+find_package(Qt6 REQUIRED COMPONENTS Test Core)
+find_package(apigear QUIET COMPONENTS apigear_mqtt)
+find_package(custom_types QUIET COMPONENTS custom_types_impl custom_types_mqtt)
+
+find_package(Catch2 REQUIRED)
+
+set(CMAKE_CTEST_COMMAND ctest -V)
+if(NOT TARGET check)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+set(TEST_CUSTOM_TYPES_GENERATED_MQTT_SOURCES
+    test_main.cpp
+    )
+
+include_directories(test_custom_types_generated_mqtt
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+add_executable(test_custom_types_generated_mqtt ${TEST_CUSTOM_TYPES_GENERATED_MQTT_SOURCES})
+add_test(NAME test_custom_types_generated_mqtt COMMAND $<TARGET_FILE:test_custom_types_generated_mqtt>)
+add_dependencies(check test_custom_types_generated_mqtt)
+
+target_link_libraries(test_custom_types_generated_mqtt PRIVATE
+    apigear_mqtt
+    custom_types_impl
+    custom_types_mqtt
+    Catch2::Catch2
+    Qt::Test)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_custom_types_generated_mqtt
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+
+endif() # BUILD_TESTING

--- a/goldenmaster/custom_types/mqtt/tests/test_main.cpp
+++ b/goldenmaster/custom_types/mqtt/tests/test_main.cpp
@@ -1,0 +1,12 @@
+#define CATCH_CONFIG_RUNNER
+
+#include <QCoreApplication>
+#include <catch2/catch.hpp>
+
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv); // -platform offscreen
+    int result = Catch::Session().run(argc, argv); // --break
+    return result;
+}

--- a/goldenmaster/extern_types/mqtt/CMakeLists.txt
+++ b/goldenmaster/extern_types/mqtt/CMakeLists.txt
@@ -29,6 +29,10 @@ target_include_directories(extern_types_mqtt
     $<INSTALL_INTERFACE:include/extern_types>
 )
 
+if (ENABLE_MQTT_TEST_FOR_NON_LINUX_OS OR ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")))
+add_subdirectory(tests)
+endif()
+
 target_link_libraries(extern_types_mqtt PUBLIC extern_types::extern_types_api apigear::apigear_mqtt Qt6::Concurrent)
 target_compile_definitions(extern_types_mqtt PRIVATE EXTERN_TYPES_MQTT_LIBRARY)
 

--- a/goldenmaster/extern_types/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/extern_types/mqtt/tests/CMakeLists.txt
@@ -1,0 +1,60 @@
+
+cmake_minimum_required(VERSION 3.20)
+project(test_extern_types_generated_mqtt)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(BUILD_TESTING)
+include(CTest)
+enable_testing()
+
+find_package(Qt6 REQUIRED COMPONENTS Test Core)
+find_package(apigear QUIET COMPONENTS apigear_mqtt)
+find_package(extern_types QUIET COMPONENTS extern_types_impl extern_types_mqtt)
+
+find_package(Catch2 REQUIRED)
+
+set(CMAKE_CTEST_COMMAND ctest -V)
+if(NOT TARGET check)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+set(TEST_EXTERN_TYPES_GENERATED_MQTT_SOURCES
+    test_main.cpp
+    )
+
+include_directories(test_extern_types_generated_mqtt
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+add_executable(test_extern_types_generated_mqtt ${TEST_EXTERN_TYPES_GENERATED_MQTT_SOURCES})
+add_test(NAME test_extern_types_generated_mqtt COMMAND $<TARGET_FILE:test_extern_types_generated_mqtt>)
+add_dependencies(check test_extern_types_generated_mqtt)
+
+target_link_libraries(test_extern_types_generated_mqtt PRIVATE
+    apigear_mqtt
+    extern_types_impl
+    extern_types_mqtt
+    Catch2::Catch2
+    Qt::Test)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_extern_types_generated_mqtt
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+
+endif() # BUILD_TESTING

--- a/goldenmaster/extern_types/mqtt/tests/test_main.cpp
+++ b/goldenmaster/extern_types/mqtt/tests/test_main.cpp
@@ -1,0 +1,12 @@
+#define CATCH_CONFIG_RUNNER
+
+#include <QCoreApplication>
+#include <catch2/catch.hpp>
+
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv); // -platform offscreen
+    int result = Catch::Session().run(argc, argv); // --break
+    return result;
+}

--- a/goldenmaster/tb_enum/mqtt/CMakeLists.txt
+++ b/goldenmaster/tb_enum/mqtt/CMakeLists.txt
@@ -31,6 +31,10 @@ target_include_directories(tb_enum_mqtt
     $<INSTALL_INTERFACE:include/tb_enum>
 )
 
+if (ENABLE_MQTT_TEST_FOR_NON_LINUX_OS OR ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")))
+add_subdirectory(tests)
+endif()
+
 target_link_libraries(tb_enum_mqtt PUBLIC tb_enum::tb_enum_api apigear::apigear_mqtt Qt6::Concurrent)
 target_compile_definitions(tb_enum_mqtt PRIVATE TB_ENUM_MQTT_LIBRARY)
 

--- a/goldenmaster/tb_enum/mqtt/mqttenuminterface.cpp
+++ b/goldenmaster/tb_enum/mqtt/mqttenuminterface.cpp
@@ -193,11 +193,14 @@ QFuture<Enum0::Enum0Enum> MqttEnumInterface::func0Async(Enum0::Enum0Enum param0)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func0");
     auto promise = std::make_shared<QPromise<Enum0::Enum0Enum>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(Enum0::Value0);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -205,7 +208,9 @@ QFuture<Enum0::Enum0Enum> MqttEnumInterface::func0Async(Enum0::Enum0Enum param0)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(Enum0::Value0);
+        promise->addResult(Enum0::Value0);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param0 });       
@@ -214,6 +219,7 @@ QFuture<Enum0::Enum0Enum> MqttEnumInterface::func0Async(Enum0::Enum0Enum param0)
         {
             Enum0::Enum0Enum value = arg.get<Enum0::Enum0Enum>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -236,11 +242,14 @@ QFuture<Enum1::Enum1Enum> MqttEnumInterface::func1Async(Enum1::Enum1Enum param1)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func1");
     auto promise = std::make_shared<QPromise<Enum1::Enum1Enum>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(Enum1::Value1);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -248,7 +257,9 @@ QFuture<Enum1::Enum1Enum> MqttEnumInterface::func1Async(Enum1::Enum1Enum param1)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(Enum1::Value1);
+        promise->addResult(Enum1::Value1);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1 });       
@@ -257,6 +268,7 @@ QFuture<Enum1::Enum1Enum> MqttEnumInterface::func1Async(Enum1::Enum1Enum param1)
         {
             Enum1::Enum1Enum value = arg.get<Enum1::Enum1Enum>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -279,11 +291,14 @@ QFuture<Enum2::Enum2Enum> MqttEnumInterface::func2Async(Enum2::Enum2Enum param2)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func2");
     auto promise = std::make_shared<QPromise<Enum2::Enum2Enum>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(Enum2::Value2);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -291,7 +306,9 @@ QFuture<Enum2::Enum2Enum> MqttEnumInterface::func2Async(Enum2::Enum2Enum param2)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(Enum2::Value2);
+        promise->addResult(Enum2::Value2);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param2 });       
@@ -300,6 +317,7 @@ QFuture<Enum2::Enum2Enum> MqttEnumInterface::func2Async(Enum2::Enum2Enum param2)
         {
             Enum2::Enum2Enum value = arg.get<Enum2::Enum2Enum>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -322,11 +340,14 @@ QFuture<Enum3::Enum3Enum> MqttEnumInterface::func3Async(Enum3::Enum3Enum param3)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func3");
     auto promise = std::make_shared<QPromise<Enum3::Enum3Enum>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(Enum3::Value3);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -334,7 +355,9 @@ QFuture<Enum3::Enum3Enum> MqttEnumInterface::func3Async(Enum3::Enum3Enum param3)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(Enum3::Value3);
+        promise->addResult(Enum3::Value3);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param3 });       
@@ -343,6 +366,7 @@ QFuture<Enum3::Enum3Enum> MqttEnumInterface::func3Async(Enum3::Enum3Enum param3)
         {
             Enum3::Enum3Enum value = arg.get<Enum3::Enum3Enum>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/tb_enum/mqtt/mqttenuminterface.cpp
+++ b/goldenmaster/tb_enum/mqtt/mqttenuminterface.cpp
@@ -351,27 +351,27 @@ const QString& MqttEnumInterface::interfaceName()
 }
 void MqttEnumInterface::subscribeForPropertiesChanges()
 {
-        static const QString topicprop0 = interfaceName() + "/prop/prop0";
+        const QString topicprop0 = interfaceName() + "/prop/prop0";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop0, [this](auto& value) { setProp0Local(value);}));
-        static const QString topicprop1 = interfaceName() + "/prop/prop1";
+        const QString topicprop1 = interfaceName() + "/prop/prop1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
-        static const QString topicprop2 = interfaceName() + "/prop/prop2";
+        const QString topicprop2 = interfaceName() + "/prop/prop2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2, [this](auto& value) { setProp2Local(value);}));
-        static const QString topicprop3 = interfaceName() + "/prop/prop3";
+        const QString topicprop3 = interfaceName() + "/prop/prop3";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop3, [this](auto& value) { setProp3Local(value);}));
 }
 void MqttEnumInterface::subscribeForSignals()
 {
-        static const QString topicsig0 = interfaceName() + "/sig/sig0";
+        const QString topicsig0 = interfaceName() + "/sig/sig0";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig0, [this](const nlohmann::json& argumentsArray){
             emit sig0(argumentsArray[0].get<Enum0::Enum0Enum>());}));
-        static const QString topicsig1 = interfaceName() + "/sig/sig1";
+        const QString topicsig1 = interfaceName() + "/sig/sig1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
             emit sig1(argumentsArray[0].get<Enum1::Enum1Enum>());}));
-        static const QString topicsig2 = interfaceName() + "/sig/sig2";
+        const QString topicsig2 = interfaceName() + "/sig/sig2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2, [this](const nlohmann::json& argumentsArray){
             emit sig2(argumentsArray[0].get<Enum2::Enum2Enum>());}));
-        static const QString topicsig3 = interfaceName() + "/sig/sig3";
+        const QString topicsig3 = interfaceName() + "/sig/sig3";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig3, [this](const nlohmann::json& argumentsArray){
             emit sig3(argumentsArray[0].get<Enum3::Enum3Enum>());}));
 }

--- a/goldenmaster/tb_enum/mqtt/mqttenuminterface.h
+++ b/goldenmaster/tb_enum/mqtt/mqttenuminterface.h
@@ -125,12 +125,16 @@ public:
     * Remote call of IEnumInterface::func3 on the EnumInterface service.
     */
     QFuture<Enum3::Enum3Enum> func3Async(Enum3::Enum3Enum param3);
+    /**
+    * Use to check if the MqttEnumInterface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttEnumInterface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -168,9 +172,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttEnumInterface.
     * Handles incoming and outgoing messages.
@@ -198,6 +204,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_enum

--- a/goldenmaster/tb_enum/mqtt/mqttenuminterfaceadapter.cpp
+++ b/goldenmaster/tb_enum/mqtt/mqttenuminterfaceadapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "tb.enum/EnumInterface";
 MqttEnumInterfaceAdapter::MqttEnumInterfaceAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractEnumInterface> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -53,12 +54,14 @@ MqttEnumInterfaceAdapter::MqttEnumInterfaceAdapter(ApiGear::Mqtt::ServiceAdapter
         subscribeForInvokeRequests();
         connectServicePropertiesChanges();
         connectServiceSignals();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttEnumInterfaceAdapter::~MqttEnumInterfaceAdapter()
@@ -68,6 +71,12 @@ MqttEnumInterfaceAdapter::~MqttEnumInterfaceAdapter()
     unsubscribeAll();
 }
 
+bool MqttEnumInterfaceAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
+
 const QString& MqttEnumInterfaceAdapter::interfaceName()
 {
     return InterfaceName;
@@ -76,28 +85,36 @@ const QString& MqttEnumInterfaceAdapter::interfaceName()
 void MqttEnumInterfaceAdapter::subscribeForPropertiesChanges()
 {
     const auto setTopic_prop0 = interfaceName() + "/set/prop0";
+    m_pendingSubscriptions.push_back(setTopic_prop0);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop0,
+        [this, setTopic_prop0](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop0, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             Enum0::Enum0Enum prop0 = value.get<Enum0::Enum0Enum>();
             m_impl->setProp0(prop0);
         }));
     const auto setTopic_prop1 = interfaceName() + "/set/prop1";
+    m_pendingSubscriptions.push_back(setTopic_prop1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop1,
+        [this, setTopic_prop1](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop1, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             Enum1::Enum1Enum prop1 = value.get<Enum1::Enum1Enum>();
             m_impl->setProp1(prop1);
         }));
     const auto setTopic_prop2 = interfaceName() + "/set/prop2";
+    m_pendingSubscriptions.push_back(setTopic_prop2);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop2,
+        [this, setTopic_prop2](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop2, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             Enum2::Enum2Enum prop2 = value.get<Enum2::Enum2Enum>();
             m_impl->setProp2(prop2);
         }));
     const auto setTopic_prop3 = interfaceName() + "/set/prop3";
+    m_pendingSubscriptions.push_back(setTopic_prop3);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop3,
+        [this, setTopic_prop3](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop3, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             Enum3::Enum3Enum prop3 = value.get<Enum3::Enum3Enum>();
@@ -108,7 +125,9 @@ void MqttEnumInterfaceAdapter::subscribeForPropertiesChanges()
 void MqttEnumInterfaceAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_func0 = interfaceName() + "/rpc/func0";
+    m_pendingSubscriptions.push_back(invokeTopic_func0);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func0,
+        [this, invokeTopic_func0](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func0, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             Enum0::Enum0Enum param0 = arguments.at(0).get<Enum0::Enum0Enum>();
@@ -116,7 +135,9 @@ void MqttEnumInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_func1 = interfaceName() + "/rpc/func1";
+    m_pendingSubscriptions.push_back(invokeTopic_func1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func1,
+        [this, invokeTopic_func1](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func1, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             Enum1::Enum1Enum param1 = arguments.at(0).get<Enum1::Enum1Enum>();
@@ -124,7 +145,9 @@ void MqttEnumInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_func2 = interfaceName() + "/rpc/func2";
+    m_pendingSubscriptions.push_back(invokeTopic_func2);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func2,
+        [this, invokeTopic_func2](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func2, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             Enum2::Enum2Enum param2 = arguments.at(0).get<Enum2::Enum2Enum>();
@@ -132,7 +155,9 @@ void MqttEnumInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_func3 = interfaceName() + "/rpc/func3";
+    m_pendingSubscriptions.push_back(invokeTopic_func3);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func3,
+        [this, invokeTopic_func3](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func3, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             Enum3::Enum3Enum param3 = arguments.at(0).get<Enum3::Enum3Enum>();
@@ -206,6 +231,25 @@ void MqttEnumInterfaceAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttEnumInterfaceAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/tb_enum/mqtt/mqttenuminterfaceadapter.h
+++ b/goldenmaster/tb_enum/mqtt/mqttenuminterfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttEnumInterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttEnumInterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a EnumInterface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_enum

--- a/goldenmaster/tb_enum/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/tb_enum/mqtt/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 endif()
 
 set(TEST_TB_ENUM_GENERATED_MQTT_SOURCES
+    test_mqttenuminterface.cpp
     test_main.cpp
     )
 

--- a/goldenmaster/tb_enum/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/tb_enum/mqtt/tests/CMakeLists.txt
@@ -1,0 +1,60 @@
+
+cmake_minimum_required(VERSION 3.20)
+project(test_tb_enum_generated_mqtt)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(BUILD_TESTING)
+include(CTest)
+enable_testing()
+
+find_package(Qt6 REQUIRED COMPONENTS Test Core)
+find_package(apigear QUIET COMPONENTS apigear_mqtt)
+find_package(tb_enum QUIET COMPONENTS tb_enum_impl tb_enum_mqtt)
+
+find_package(Catch2 REQUIRED)
+
+set(CMAKE_CTEST_COMMAND ctest -V)
+if(NOT TARGET check)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+set(TEST_TB_ENUM_GENERATED_MQTT_SOURCES
+    test_main.cpp
+    )
+
+include_directories(test_tb_enum_generated_mqtt
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+add_executable(test_tb_enum_generated_mqtt ${TEST_TB_ENUM_GENERATED_MQTT_SOURCES})
+add_test(NAME test_tb_enum_generated_mqtt COMMAND $<TARGET_FILE:test_tb_enum_generated_mqtt>)
+add_dependencies(check test_tb_enum_generated_mqtt)
+
+target_link_libraries(test_tb_enum_generated_mqtt PRIVATE
+    apigear_mqtt
+    tb_enum_impl
+    tb_enum_mqtt
+    Catch2::Catch2
+    Qt::Test)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_tb_enum_generated_mqtt
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+
+endif() # BUILD_TESTING

--- a/goldenmaster/tb_enum/mqtt/tests/test_main.cpp
+++ b/goldenmaster/tb_enum/mqtt/tests/test_main.cpp
@@ -1,0 +1,12 @@
+#define CATCH_CONFIG_RUNNER
+
+#include <QCoreApplication>
+#include <catch2/catch.hpp>
+
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv); // -platform offscreen
+    int result = Catch::Session().run(argc, argv); // --break
+    return result;
+}

--- a/goldenmaster/tb_enum/mqtt/tests/test_mqttenuminterface.cpp
+++ b/goldenmaster/tb_enum/mqtt/tests/test_mqttenuminterface.cpp
@@ -1,0 +1,261 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/enuminterface.h"
+#include "mqtt/mqttenuminterface.h"
+#include "mqtt/mqttenuminterfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.enum EnumInterface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientEnumInterface = std::make_shared<tb_enum::MqttEnumInterface >(client);
+    auto implEnumInterface = std::make_shared<tb_enum::EnumInterface>();
+    auto serviceEnumInterface = std::make_shared<tb_enum::MqttEnumInterfaceAdapter>(service, implEnumInterface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientEnumInterface, &serviceEnumInterface]() {return clientEnumInterface->isReady() && serviceEnumInterface->isReady(); }, timeout));
+    SECTION("Test setting prop0")
+    {
+        std::atomic<bool> isprop0Changed = false;
+        clientEnumInterface->connect(clientEnumInterface.get(), &tb_enum::AbstractEnumInterface::prop0Changed, [&isprop0Changed ](auto value){isprop0Changed  = true;});
+        auto test_value = tb_enum::Enum0::Value1;
+        clientEnumInterface->setProp0(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop0Changed]() {return isprop0Changed  == true; }, timeout));
+        REQUIRE(implEnumInterface->prop0() == test_value);
+        REQUIRE(clientEnumInterface->prop0() == test_value);
+    }
+    SECTION("Test setting prop1")
+    {
+        std::atomic<bool> isprop1Changed = false;
+        clientEnumInterface->connect(clientEnumInterface.get(), &tb_enum::AbstractEnumInterface::prop1Changed, [&isprop1Changed ](auto value){isprop1Changed  = true;});
+        auto test_value = tb_enum::Enum1::Value2;
+        clientEnumInterface->setProp1(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop1Changed]() {return isprop1Changed  == true; }, timeout));
+        REQUIRE(implEnumInterface->prop1() == test_value);
+        REQUIRE(clientEnumInterface->prop1() == test_value);
+    }
+    SECTION("Test setting prop2")
+    {
+        std::atomic<bool> isprop2Changed = false;
+        clientEnumInterface->connect(clientEnumInterface.get(), &tb_enum::AbstractEnumInterface::prop2Changed, [&isprop2Changed ](auto value){isprop2Changed  = true;});
+        auto test_value = tb_enum::Enum2::Value1;
+        clientEnumInterface->setProp2(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop2Changed]() {return isprop2Changed  == true; }, timeout));
+        REQUIRE(implEnumInterface->prop2() == test_value);
+        REQUIRE(clientEnumInterface->prop2() == test_value);
+    }
+    SECTION("Test setting prop3")
+    {
+        std::atomic<bool> isprop3Changed = false;
+        clientEnumInterface->connect(clientEnumInterface.get(), &tb_enum::AbstractEnumInterface::prop3Changed, [&isprop3Changed ](auto value){isprop3Changed  = true;});
+        auto test_value = tb_enum::Enum3::Value2;
+        clientEnumInterface->setProp3(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop3Changed]() {return isprop3Changed  == true; }, timeout));
+        REQUIRE(implEnumInterface->prop3() == test_value);
+        REQUIRE(clientEnumInterface->prop3() == test_value);
+    }
+    SECTION("Test emit sig0")
+    {
+        std::atomic<bool> issig0Emitted = false;
+
+        clientEnumInterface->connect(clientEnumInterface.get(), &tb_enum::AbstractEnumInterface::sig0,
+        [&issig0Emitted](tb_enum::Enum0::Enum0Enum param0)
+        {
+            REQUIRE(param0 == tb_enum::Enum0::Value1);
+            issig0Emitted  = true;
+        });
+
+        emit implEnumInterface->sig0(tb_enum::Enum0::Value1);
+        REQUIRE(QTest::qWaitFor([&issig0Emitted ]() {return issig0Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sig1")
+    {
+        std::atomic<bool> issig1Emitted = false;
+
+        clientEnumInterface->connect(clientEnumInterface.get(), &tb_enum::AbstractEnumInterface::sig1,
+        [&issig1Emitted](tb_enum::Enum1::Enum1Enum param1)
+        {
+            REQUIRE(param1 == tb_enum::Enum1::Value2);
+            issig1Emitted  = true;
+        });
+
+        emit implEnumInterface->sig1(tb_enum::Enum1::Value2);
+        REQUIRE(QTest::qWaitFor([&issig1Emitted ]() {return issig1Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sig2")
+    {
+        std::atomic<bool> issig2Emitted = false;
+
+        clientEnumInterface->connect(clientEnumInterface.get(), &tb_enum::AbstractEnumInterface::sig2,
+        [&issig2Emitted](tb_enum::Enum2::Enum2Enum param2)
+        {
+            REQUIRE(param2 == tb_enum::Enum2::Value1);
+            issig2Emitted  = true;
+        });
+
+        emit implEnumInterface->sig2(tb_enum::Enum2::Value1);
+        REQUIRE(QTest::qWaitFor([&issig2Emitted ]() {return issig2Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sig3")
+    {
+        std::atomic<bool> issig3Emitted = false;
+
+        clientEnumInterface->connect(clientEnumInterface.get(), &tb_enum::AbstractEnumInterface::sig3,
+        [&issig3Emitted](tb_enum::Enum3::Enum3Enum param3)
+        {
+            REQUIRE(param3 == tb_enum::Enum3::Value2);
+            issig3Emitted  = true;
+        });
+
+        emit implEnumInterface->sig3(tb_enum::Enum3::Value2);
+        REQUIRE(QTest::qWaitFor([&issig3Emitted ]() {return issig3Emitted   == true; }, timeout));
+    }
+    SECTION("Test method func0")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientEnumInterface, &finished](){
+            [[maybe_unused]] auto result = clientEnumInterface->func0(tb_enum::Enum0::Value0);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func0 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientEnumInterface->func0Async(tb_enum::Enum0::Value0);
+        resultFuture.then([&finished](tb_enum::Enum0::Enum0Enum /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_enum::Enum0::Value0);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method func1")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientEnumInterface, &finished](){
+            [[maybe_unused]] auto result = clientEnumInterface->func1(tb_enum::Enum1::Value1);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func1 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientEnumInterface->func1Async(tb_enum::Enum1::Value1);
+        resultFuture.then([&finished](tb_enum::Enum1::Enum1Enum /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_enum::Enum1::Value1);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method func2")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientEnumInterface, &finished](){
+            [[maybe_unused]] auto result = clientEnumInterface->func2(tb_enum::Enum2::Value2);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func2 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientEnumInterface->func2Async(tb_enum::Enum2::Value2);
+        resultFuture.then([&finished](tb_enum::Enum2::Enum2Enum /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_enum::Enum2::Value2);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method func3")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientEnumInterface, &finished](){
+            [[maybe_unused]] auto result = clientEnumInterface->func3(tb_enum::Enum3::Value3);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func3 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientEnumInterface->func3Async(tb_enum::Enum3::Value3);
+        resultFuture.then([&finished](tb_enum::Enum3::Enum3Enum /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_enum::Enum3::Value3);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientEnumInterface.reset();
+    serviceEnumInterface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_names/mqtt/CMakeLists.txt
+++ b/goldenmaster/tb_names/mqtt/CMakeLists.txt
@@ -31,6 +31,10 @@ target_include_directories(tb_names_mqtt
     $<INSTALL_INTERFACE:include/tb_names>
 )
 
+if (ENABLE_MQTT_TEST_FOR_NON_LINUX_OS OR ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")))
+add_subdirectory(tests)
+endif()
+
 target_link_libraries(tb_names_mqtt PUBLIC tb_names::tb_names_api apigear::apigear_mqtt Qt6::Concurrent)
 target_compile_definitions(tb_names_mqtt PRIVATE TB_NAMES_MQTT_LIBRARY)
 

--- a/goldenmaster/tb_names/mqtt/mqttnam_es.cpp
+++ b/goldenmaster/tb_names/mqtt/mqttnam_es.cpp
@@ -235,19 +235,19 @@ const QString& MqttNam_Es::interfaceName()
 }
 void MqttNam_Es::subscribeForPropertiesChanges()
 {
-        static const QString topicSwitch = interfaceName() + "/prop/Switch";
+        const QString topicSwitch = interfaceName() + "/prop/Switch";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicSwitch, [this](auto& value) { setSwitchLocal(value);}));
-        static const QString topicSOME_PROPERTY = interfaceName() + "/prop/SOME_PROPERTY";
+        const QString topicSOME_PROPERTY = interfaceName() + "/prop/SOME_PROPERTY";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicSOME_PROPERTY, [this](auto& value) { setSomePropertyLocal(value);}));
-        static const QString topicSome_Poperty2 = interfaceName() + "/prop/Some_Poperty2";
+        const QString topicSome_Poperty2 = interfaceName() + "/prop/Some_Poperty2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicSome_Poperty2, [this](auto& value) { setSomePoperty2Local(value);}));
 }
 void MqttNam_Es::subscribeForSignals()
 {
-        static const QString topicSOME_SIGNAL = interfaceName() + "/sig/SOME_SIGNAL";
+        const QString topicSOME_SIGNAL = interfaceName() + "/sig/SOME_SIGNAL";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicSOME_SIGNAL, [this](const nlohmann::json& argumentsArray){
             emit someSignal(argumentsArray[0].get<bool>());}));
-        static const QString topicSome_Signal2 = interfaceName() + "/sig/Some_Signal2";
+        const QString topicSome_Signal2 = interfaceName() + "/sig/Some_Signal2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicSome_Signal2, [this](const nlohmann::json& argumentsArray){
             emit someSignal2(argumentsArray[0].get<bool>());}));
 }

--- a/goldenmaster/tb_names/mqtt/mqttnam_es.cpp
+++ b/goldenmaster/tb_names/mqtt/mqttnam_es.cpp
@@ -165,11 +165,13 @@ QFuture<void> MqttNam_Es::someFunctionAsync(bool SOME_PARAM)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/SOME_FUNCTION");
     auto promise = std::make_shared<QPromise<void>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->finish();
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -177,7 +179,8 @@ QFuture<void> MqttNam_Es::someFunctionAsync(bool SOME_PARAM)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->finish();
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({SOME_PARAM });       
@@ -207,11 +210,13 @@ QFuture<void> MqttNam_Es::someFunction2Async(bool Some_Param)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/Some_Function2");
     auto promise = std::make_shared<QPromise<void>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->finish();
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -219,7 +224,8 @@ QFuture<void> MqttNam_Es::someFunction2Async(bool Some_Param)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->finish();
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({Some_Param });       

--- a/goldenmaster/tb_names/mqtt/mqttnam_es.h
+++ b/goldenmaster/tb_names/mqtt/mqttnam_es.h
@@ -97,12 +97,16 @@ public:
     * Remote call of INamEs::Some_Function2 on the Nam_Es service.
     */
     QFuture<void> someFunction2Async(bool Some_Param);
+    /**
+    * Use to check if the MqttNam_Es is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttNam_Es is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -136,9 +140,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttNam_Es.
     * Handles incoming and outgoing messages.
@@ -166,6 +172,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_names

--- a/goldenmaster/tb_names/mqtt/mqttnam_esadapter.cpp
+++ b/goldenmaster/tb_names/mqtt/mqttnam_esadapter.cpp
@@ -31,7 +31,7 @@ namespace tb_names {
 
 namespace
 {
-const QString InterfaceName = "tb.names/NamEs";
+const QString InterfaceName = "tb.names/Nam_Es";
 }
 
 
@@ -161,14 +161,14 @@ void MqttNam_EsAdapter::connectServicePropertiesChanges()
 
 void MqttNam_EsAdapter::connectServiceSignals()
 {
-    const auto topic_someSignal = interfaceName() + "/sig/someSignal";
+    const auto topic_someSignal = interfaceName() + "/sig/SOME_SIGNAL";
     connect(m_impl.get(), &AbstractNamEs::someSignal, this,
         [this, topic_someSignal](bool SOME_PARAM)
         {
             nlohmann::json args = { SOME_PARAM };
             m_mqttServiceAdapter.emitPropertyChange(topic_someSignal, args);
         });
-    const auto topic_someSignal2 = interfaceName() + "/sig/someSignal2";
+    const auto topic_someSignal2 = interfaceName() + "/sig/Some_Signal2";
     connect(m_impl.get(), &AbstractNamEs::someSignal2, this,
         [this, topic_someSignal2](bool Some_Param)
         {

--- a/goldenmaster/tb_names/mqtt/mqttnam_esadapter.h
+++ b/goldenmaster/tb_names/mqtt/mqttnam_esadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttNam_EsAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttNam_EsAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a Nam_Es that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_names

--- a/goldenmaster/tb_names/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/tb_names/mqtt/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 endif()
 
 set(TEST_TB_NAMES_GENERATED_MQTT_SOURCES
+    test_mqttnam_es.cpp
     test_main.cpp
     )
 

--- a/goldenmaster/tb_names/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/tb_names/mqtt/tests/CMakeLists.txt
@@ -1,0 +1,60 @@
+
+cmake_minimum_required(VERSION 3.20)
+project(test_tb_names_generated_mqtt)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(BUILD_TESTING)
+include(CTest)
+enable_testing()
+
+find_package(Qt6 REQUIRED COMPONENTS Test Core)
+find_package(apigear QUIET COMPONENTS apigear_mqtt)
+find_package(tb_names QUIET COMPONENTS tb_names_impl tb_names_mqtt)
+
+find_package(Catch2 REQUIRED)
+
+set(CMAKE_CTEST_COMMAND ctest -V)
+if(NOT TARGET check)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+set(TEST_TB_NAMES_GENERATED_MQTT_SOURCES
+    test_main.cpp
+    )
+
+include_directories(test_tb_names_generated_mqtt
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+add_executable(test_tb_names_generated_mqtt ${TEST_TB_NAMES_GENERATED_MQTT_SOURCES})
+add_test(NAME test_tb_names_generated_mqtt COMMAND $<TARGET_FILE:test_tb_names_generated_mqtt>)
+add_dependencies(check test_tb_names_generated_mqtt)
+
+target_link_libraries(test_tb_names_generated_mqtt PRIVATE
+    apigear_mqtt
+    tb_names_impl
+    tb_names_mqtt
+    Catch2::Catch2
+    Qt::Test)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_tb_names_generated_mqtt
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+
+endif() # BUILD_TESTING

--- a/goldenmaster/tb_names/mqtt/tests/test_main.cpp
+++ b/goldenmaster/tb_names/mqtt/tests/test_main.cpp
@@ -1,0 +1,12 @@
+#define CATCH_CONFIG_RUNNER
+
+#include <QCoreApplication>
+#include <catch2/catch.hpp>
+
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv); // -platform offscreen
+    int result = Catch::Session().run(argc, argv); // --break
+    return result;
+}

--- a/goldenmaster/tb_names/mqtt/tests/test_mqttnam_es.cpp
+++ b/goldenmaster/tb_names/mqtt/tests/test_mqttnam_es.cpp
@@ -1,0 +1,171 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/nam_es.h"
+#include "mqtt/mqttnam_es.h"
+#include "mqtt/mqttnam_esadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.names NamEs tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientNamEs = std::make_shared<tb_names::MqttNam_Es >(client);
+    auto implNamEs = std::make_shared<tb_names::NamEs>();
+    auto serviceNamEs = std::make_shared<tb_names::MqttNam_EsAdapter>(service, implNamEs);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientNamEs, &serviceNamEs]() {return clientNamEs->isReady() && serviceNamEs->isReady(); }, timeout));
+    SECTION("Test setting Switch")
+    {
+        std::atomic<bool> isSwitchChanged = false;
+        clientNamEs->connect(clientNamEs.get(), &tb_names::AbstractNamEs::SwitchChanged, [&isSwitchChanged ](auto value){isSwitchChanged  = true;});
+        auto test_value = true;
+        clientNamEs->setSwitch(test_value);
+        REQUIRE(QTest::qWaitFor([&isSwitchChanged]() {return isSwitchChanged  == true; }, timeout));
+        REQUIRE(implNamEs->Switch() == test_value);
+        REQUIRE(clientNamEs->Switch() == test_value);
+    }
+    SECTION("Test setting SOME_PROPERTY")
+    {
+        std::atomic<bool> isSOME_PROPERTYChanged = false;
+        clientNamEs->connect(clientNamEs.get(), &tb_names::AbstractNamEs::SOME_PROPERTYChanged, [&isSOME_PROPERTYChanged ](auto value){isSOME_PROPERTYChanged  = true;});
+        auto test_value = 1;
+        clientNamEs->setSomeProperty(test_value);
+        REQUIRE(QTest::qWaitFor([&isSOME_PROPERTYChanged]() {return isSOME_PROPERTYChanged  == true; }, timeout));
+        REQUIRE(implNamEs->SOME_PROPERTY() == test_value);
+        REQUIRE(clientNamEs->SOME_PROPERTY() == test_value);
+    }
+    SECTION("Test setting Some_Poperty2")
+    {
+        std::atomic<bool> isSome_Poperty2Changed = false;
+        clientNamEs->connect(clientNamEs.get(), &tb_names::AbstractNamEs::Some_Poperty2Changed, [&isSome_Poperty2Changed ](auto value){isSome_Poperty2Changed  = true;});
+        auto test_value = 1;
+        clientNamEs->setSomePoperty2(test_value);
+        REQUIRE(QTest::qWaitFor([&isSome_Poperty2Changed]() {return isSome_Poperty2Changed  == true; }, timeout));
+        REQUIRE(implNamEs->Some_Poperty2() == test_value);
+        REQUIRE(clientNamEs->Some_Poperty2() == test_value);
+    }
+    SECTION("Test emit SOME_SIGNAL")
+    {
+        std::atomic<bool> isSOME_SIGNALEmitted = false;
+
+        clientNamEs->connect(clientNamEs.get(), &tb_names::AbstractNamEs::someSignal,
+        [&isSOME_SIGNALEmitted](bool SOME_PARAM)
+        {
+            REQUIRE(SOME_PARAM == true);
+            isSOME_SIGNALEmitted  = true;
+        });
+
+        emit implNamEs->someSignal(true);
+        REQUIRE(QTest::qWaitFor([&isSOME_SIGNALEmitted ]() {return isSOME_SIGNALEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit Some_Signal2")
+    {
+        std::atomic<bool> isSome_Signal2Emitted = false;
+
+        clientNamEs->connect(clientNamEs.get(), &tb_names::AbstractNamEs::someSignal2,
+        [&isSome_Signal2Emitted](bool Some_Param)
+        {
+            REQUIRE(Some_Param == true);
+            isSome_Signal2Emitted  = true;
+        });
+
+        emit implNamEs->someSignal2(true);
+        REQUIRE(QTest::qWaitFor([&isSome_Signal2Emitted ]() {return isSome_Signal2Emitted   == true; }, timeout));
+    }
+    SECTION("Test method SOME_FUNCTION")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientNamEs, &finished](){
+            clientNamEs->someFunction(false);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method SOME_FUNCTION async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNamEs->someFunctionAsync(false);
+        resultFuture.then([&finished](){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method Some_Function2")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientNamEs, &finished](){
+            clientNamEs->someFunction2(false);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method Some_Function2 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNamEs->someFunction2Async(false);
+        resultFuture.then([&finished](){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientNamEs.reset();
+    serviceNamEs.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_same1/mqtt/CMakeLists.txt
+++ b/goldenmaster/tb_same1/mqtt/CMakeLists.txt
@@ -37,6 +37,10 @@ target_include_directories(tb_same1_mqtt
     $<INSTALL_INTERFACE:include/tb_same1>
 )
 
+if (ENABLE_MQTT_TEST_FOR_NON_LINUX_OS OR ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")))
+add_subdirectory(tests)
+endif()
+
 target_link_libraries(tb_same1_mqtt PUBLIC tb_same1::tb_same1_api apigear::apigear_mqtt Qt6::Concurrent)
 target_compile_definitions(tb_same1_mqtt PRIVATE TB_SAME1_MQTT_LIBRARY)
 

--- a/goldenmaster/tb_same1/mqtt/mqttsameenum1interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/mqttsameenum1interface.cpp
@@ -33,7 +33,7 @@ const QString InterfaceName = "tb.same1/SameEnum1Interface";
 MqttSameEnum1Interface::MqttSameEnum1Interface(ApiGear::Mqtt::Client& client, QObject *parent)
     : AbstractSameEnum1Interface(parent)
     , m_prop1(Enum1::Value1)
-    , m_isReady(false)
+    , m_finishedInitialization(false)
     , m_client(client)
 {
     if (m_client.isReady())
@@ -47,11 +47,13 @@ MqttSameEnum1Interface::MqttSameEnum1Interface(ApiGear::Mqtt::Client& client, QO
             subscribeForPropertiesChanges();
             subscribeForSignals();
             subscribeForInvokeResponses();
+            m_finishedInitialization = true;
     });
     connect(&m_client, &ApiGear::Mqtt::Client::disconnected, [this](){
         m_subscribedIds.clear();
         m_InvokeCallsInfo.clear();
     });
+    m_finishedInitialization = m_client.isReady();
 }
 
 MqttSameEnum1Interface::~MqttSameEnum1Interface()
@@ -59,6 +61,11 @@ MqttSameEnum1Interface::~MqttSameEnum1Interface()
     disconnect(&m_client, &ApiGear::Mqtt::Client::disconnected, 0, 0);
     disconnect(&m_client, &ApiGear::Mqtt::Client::ready, 0, 0);
     unsubscribeAll();
+}
+
+bool MqttSameEnum1Interface::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
 }
 
 void MqttSameEnum1Interface::setProp1(Enum1::Enum1Enum prop1)
@@ -136,22 +143,50 @@ const QString& MqttSameEnum1Interface::interfaceName()
 {
     return InterfaceName;
 }
+
+void MqttSameEnum1Interface::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
+    }
+}
 void MqttSameEnum1Interface::subscribeForPropertiesChanges()
 {
+        // Subscription may succeed, before finising the function that subscribes it and assigns an id for if it was already added (and succeeded) for same topic,
+        // hence, for pending subscriptions a topic is used, and added before the subscribe function.
         const QString topicprop1 = interfaceName() + "/prop/prop1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
+        m_pendingSubscriptions.push_back(topicprop1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1,
+            [this, topicprop1](auto id, bool hasSucceed){handleOnSubscribed(topicprop1, id, hasSucceed);},
+            [this](auto& value) { setProp1Local(value);}));
 }
 void MqttSameEnum1Interface::subscribeForSignals()
 {
         const QString topicsig1 = interfaceName() + "/sig/sig1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
-            emit sig1(argumentsArray[0].get<Enum1::Enum1Enum>());}));
+        m_pendingSubscriptions.push_back(topicsig1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1,
+            [this, topicsig1](auto id, bool hasSucceed){handleOnSubscribed(topicsig1, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sig1(argumentsArray[0].get<Enum1::Enum1Enum>());}));
 }
 void MqttSameEnum1Interface::subscribeForInvokeResponses()
 {
     const QString topicfunc1 = interfaceName() + "/rpc/func1";
     const QString topicfunc1InvokeResp = interfaceName() + "/rpc/func1"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfunc1InvokeResp);
     auto id_func1 = m_client.subscribeForInvokeResponse(topicfunc1InvokeResp, 
+                        [this, topicfunc1InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfunc1InvokeResp, id, hasSucceed);},
                         [this, topicfunc1InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfunc1InvokeResp);

--- a/goldenmaster/tb_same1/mqtt/mqttsameenum1interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/mqttsameenum1interface.cpp
@@ -138,12 +138,12 @@ const QString& MqttSameEnum1Interface::interfaceName()
 }
 void MqttSameEnum1Interface::subscribeForPropertiesChanges()
 {
-        static const QString topicprop1 = interfaceName() + "/prop/prop1";
+        const QString topicprop1 = interfaceName() + "/prop/prop1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
 }
 void MqttSameEnum1Interface::subscribeForSignals()
 {
-        static const QString topicsig1 = interfaceName() + "/sig/sig1";
+        const QString topicsig1 = interfaceName() + "/sig/sig1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
             emit sig1(argumentsArray[0].get<Enum1::Enum1Enum>());}));
 }

--- a/goldenmaster/tb_same1/mqtt/mqttsameenum1interface.h
+++ b/goldenmaster/tb_same1/mqtt/mqttsameenum1interface.h
@@ -68,12 +68,16 @@ public:
     * Remote call of ISameEnum1Interface::func1 on the SameEnum1Interface service.
     */
     QFuture<Enum1::Enum1Enum> func1Async(Enum1::Enum1Enum param1);
+    /**
+    * Use to check if the MqttSameEnum1Interface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttSameEnum1Interface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -99,9 +103,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttSameEnum1Interface.
     * Handles incoming and outgoing messages.
@@ -129,6 +135,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_same1

--- a/goldenmaster/tb_same1/mqtt/mqttsameenum1interfaceadapter.cpp
+++ b/goldenmaster/tb_same1/mqtt/mqttsameenum1interfaceadapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "tb.same1/SameEnum1Interface";
 MqttSameEnum1InterfaceAdapter::MqttSameEnum1InterfaceAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractSameEnum1Interface> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -53,12 +54,14 @@ MqttSameEnum1InterfaceAdapter::MqttSameEnum1InterfaceAdapter(ApiGear::Mqtt::Serv
         subscribeForInvokeRequests();
         connectServicePropertiesChanges();
         connectServiceSignals();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttSameEnum1InterfaceAdapter::~MqttSameEnum1InterfaceAdapter()
@@ -68,6 +71,12 @@ MqttSameEnum1InterfaceAdapter::~MqttSameEnum1InterfaceAdapter()
     unsubscribeAll();
 }
 
+bool MqttSameEnum1InterfaceAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
+
 const QString& MqttSameEnum1InterfaceAdapter::interfaceName()
 {
     return InterfaceName;
@@ -76,7 +85,9 @@ const QString& MqttSameEnum1InterfaceAdapter::interfaceName()
 void MqttSameEnum1InterfaceAdapter::subscribeForPropertiesChanges()
 {
     const auto setTopic_prop1 = interfaceName() + "/set/prop1";
+    m_pendingSubscriptions.push_back(setTopic_prop1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop1,
+        [this, setTopic_prop1](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop1, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             Enum1::Enum1Enum prop1 = value.get<Enum1::Enum1Enum>();
@@ -87,7 +98,9 @@ void MqttSameEnum1InterfaceAdapter::subscribeForPropertiesChanges()
 void MqttSameEnum1InterfaceAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_func1 = interfaceName() + "/rpc/func1";
+    m_pendingSubscriptions.push_back(invokeTopic_func1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func1,
+        [this, invokeTopic_func1](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func1, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             Enum1::Enum1Enum param1 = arguments.at(0).get<Enum1::Enum1Enum>();
@@ -122,6 +135,25 @@ void MqttSameEnum1InterfaceAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttSameEnum1InterfaceAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/tb_same1/mqtt/mqttsameenum1interfaceadapter.h
+++ b/goldenmaster/tb_same1/mqtt/mqttsameenum1interfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttSameEnum1InterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttSameEnum1InterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a SameEnum1Interface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_same1

--- a/goldenmaster/tb_same1/mqtt/mqttsameenum2interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/mqttsameenum2interface.cpp
@@ -209,17 +209,17 @@ const QString& MqttSameEnum2Interface::interfaceName()
 }
 void MqttSameEnum2Interface::subscribeForPropertiesChanges()
 {
-        static const QString topicprop1 = interfaceName() + "/prop/prop1";
+        const QString topicprop1 = interfaceName() + "/prop/prop1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
-        static const QString topicprop2 = interfaceName() + "/prop/prop2";
+        const QString topicprop2 = interfaceName() + "/prop/prop2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2, [this](auto& value) { setProp2Local(value);}));
 }
 void MqttSameEnum2Interface::subscribeForSignals()
 {
-        static const QString topicsig1 = interfaceName() + "/sig/sig1";
+        const QString topicsig1 = interfaceName() + "/sig/sig1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
             emit sig1(argumentsArray[0].get<Enum1::Enum1Enum>());}));
-        static const QString topicsig2 = interfaceName() + "/sig/sig2";
+        const QString topicsig2 = interfaceName() + "/sig/sig2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2, [this](const nlohmann::json& argumentsArray){
             emit sig2(argumentsArray[0].get<Enum1::Enum1Enum>(),argumentsArray[1].get<Enum2::Enum2Enum>());}));
 }

--- a/goldenmaster/tb_same1/mqtt/mqttsameenum2interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/mqttsameenum2interface.cpp
@@ -34,7 +34,7 @@ MqttSameEnum2Interface::MqttSameEnum2Interface(ApiGear::Mqtt::Client& client, QO
     : AbstractSameEnum2Interface(parent)
     , m_prop1(Enum1::Value1)
     , m_prop2(Enum2::Value1)
-    , m_isReady(false)
+    , m_finishedInitialization(false)
     , m_client(client)
 {
     if (m_client.isReady())
@@ -48,11 +48,13 @@ MqttSameEnum2Interface::MqttSameEnum2Interface(ApiGear::Mqtt::Client& client, QO
             subscribeForPropertiesChanges();
             subscribeForSignals();
             subscribeForInvokeResponses();
+            m_finishedInitialization = true;
     });
     connect(&m_client, &ApiGear::Mqtt::Client::disconnected, [this](){
         m_subscribedIds.clear();
         m_InvokeCallsInfo.clear();
     });
+    m_finishedInitialization = m_client.isReady();
 }
 
 MqttSameEnum2Interface::~MqttSameEnum2Interface()
@@ -60,6 +62,11 @@ MqttSameEnum2Interface::~MqttSameEnum2Interface()
     disconnect(&m_client, &ApiGear::Mqtt::Client::disconnected, 0, 0);
     disconnect(&m_client, &ApiGear::Mqtt::Client::ready, 0, 0);
     unsubscribeAll();
+}
+
+bool MqttSameEnum2Interface::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
 }
 
 void MqttSameEnum2Interface::setProp1(Enum1::Enum1Enum prop1)
@@ -207,27 +214,60 @@ const QString& MqttSameEnum2Interface::interfaceName()
 {
     return InterfaceName;
 }
+
+void MqttSameEnum2Interface::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
+    }
+}
 void MqttSameEnum2Interface::subscribeForPropertiesChanges()
 {
+        // Subscription may succeed, before finising the function that subscribes it and assigns an id for if it was already added (and succeeded) for same topic,
+        // hence, for pending subscriptions a topic is used, and added before the subscribe function.
         const QString topicprop1 = interfaceName() + "/prop/prop1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
+        m_pendingSubscriptions.push_back(topicprop1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1,
+            [this, topicprop1](auto id, bool hasSucceed){handleOnSubscribed(topicprop1, id, hasSucceed);},
+            [this](auto& value) { setProp1Local(value);}));
         const QString topicprop2 = interfaceName() + "/prop/prop2";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2, [this](auto& value) { setProp2Local(value);}));
+        m_pendingSubscriptions.push_back(topicprop2);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2,
+            [this, topicprop2](auto id, bool hasSucceed){handleOnSubscribed(topicprop2, id, hasSucceed);},
+            [this](auto& value) { setProp2Local(value);}));
 }
 void MqttSameEnum2Interface::subscribeForSignals()
 {
         const QString topicsig1 = interfaceName() + "/sig/sig1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
-            emit sig1(argumentsArray[0].get<Enum1::Enum1Enum>());}));
+        m_pendingSubscriptions.push_back(topicsig1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1,
+            [this, topicsig1](auto id, bool hasSucceed){handleOnSubscribed(topicsig1, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sig1(argumentsArray[0].get<Enum1::Enum1Enum>());}));
         const QString topicsig2 = interfaceName() + "/sig/sig2";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2, [this](const nlohmann::json& argumentsArray){
-            emit sig2(argumentsArray[0].get<Enum1::Enum1Enum>(),argumentsArray[1].get<Enum2::Enum2Enum>());}));
+        m_pendingSubscriptions.push_back(topicsig2);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2,
+            [this, topicsig2](auto id, bool hasSucceed){handleOnSubscribed(topicsig2, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sig2(argumentsArray[0].get<Enum1::Enum1Enum>(), argumentsArray[1].get<Enum2::Enum2Enum>());}));
 }
 void MqttSameEnum2Interface::subscribeForInvokeResponses()
 {
     const QString topicfunc1 = interfaceName() + "/rpc/func1";
     const QString topicfunc1InvokeResp = interfaceName() + "/rpc/func1"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfunc1InvokeResp);
     auto id_func1 = m_client.subscribeForInvokeResponse(topicfunc1InvokeResp, 
+                        [this, topicfunc1InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfunc1InvokeResp, id, hasSucceed);},
                         [this, topicfunc1InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfunc1InvokeResp);
@@ -235,7 +275,9 @@ void MqttSameEnum2Interface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfunc1] = std::make_pair(topicfunc1InvokeResp, id_func1);
     const QString topicfunc2 = interfaceName() + "/rpc/func2";
     const QString topicfunc2InvokeResp = interfaceName() + "/rpc/func2"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfunc2InvokeResp);
     auto id_func2 = m_client.subscribeForInvokeResponse(topicfunc2InvokeResp, 
+                        [this, topicfunc2InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfunc2InvokeResp, id, hasSucceed);},
                         [this, topicfunc2InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfunc2InvokeResp);

--- a/goldenmaster/tb_same1/mqtt/mqttsameenum2interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/mqttsameenum2interface.cpp
@@ -137,11 +137,14 @@ QFuture<Enum1::Enum1Enum> MqttSameEnum2Interface::func1Async(Enum1::Enum1Enum pa
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func1");
     auto promise = std::make_shared<QPromise<Enum1::Enum1Enum>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(Enum1::Value1);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -149,7 +152,9 @@ QFuture<Enum1::Enum1Enum> MqttSameEnum2Interface::func1Async(Enum1::Enum1Enum pa
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(Enum1::Value1);
+        promise->addResult(Enum1::Value1);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1 });       
@@ -158,6 +163,7 @@ QFuture<Enum1::Enum1Enum> MqttSameEnum2Interface::func1Async(Enum1::Enum1Enum pa
         {
             Enum1::Enum1Enum value = arg.get<Enum1::Enum1Enum>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -180,11 +186,14 @@ QFuture<Enum1::Enum1Enum> MqttSameEnum2Interface::func2Async(Enum1::Enum1Enum pa
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func2");
     auto promise = std::make_shared<QPromise<Enum1::Enum1Enum>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(Enum1::Value1);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -192,7 +201,9 @@ QFuture<Enum1::Enum1Enum> MqttSameEnum2Interface::func2Async(Enum1::Enum1Enum pa
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(Enum1::Value1);
+        promise->addResult(Enum1::Value1);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1, param2 });       
@@ -201,6 +212,7 @@ QFuture<Enum1::Enum1Enum> MqttSameEnum2Interface::func2Async(Enum1::Enum1Enum pa
         {
             Enum1::Enum1Enum value = arg.get<Enum1::Enum1Enum>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/tb_same1/mqtt/mqttsameenum2interface.h
+++ b/goldenmaster/tb_same1/mqtt/mqttsameenum2interface.h
@@ -87,12 +87,16 @@ public:
     * Remote call of ISameEnum2Interface::func2 on the SameEnum2Interface service.
     */
     QFuture<Enum1::Enum1Enum> func2Async(Enum1::Enum1Enum param1, Enum2::Enum2Enum param2);
+    /**
+    * Use to check if the MqttSameEnum2Interface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttSameEnum2Interface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -122,9 +126,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttSameEnum2Interface.
     * Handles incoming and outgoing messages.
@@ -152,6 +158,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_same1

--- a/goldenmaster/tb_same1/mqtt/mqttsameenum2interfaceadapter.h
+++ b/goldenmaster/tb_same1/mqtt/mqttsameenum2interfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttSameEnum2InterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttSameEnum2InterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a SameEnum2Interface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_same1

--- a/goldenmaster/tb_same1/mqtt/mqttsamestruct1interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/mqttsamestruct1interface.cpp
@@ -109,11 +109,14 @@ QFuture<Struct1> MqttSameStruct1Interface::func1Async(const Struct1& param1)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func1");
     auto promise = std::make_shared<QPromise<Struct1>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(Struct1());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -121,7 +124,9 @@ QFuture<Struct1> MqttSameStruct1Interface::func1Async(const Struct1& param1)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(Struct1());
+        promise->addResult(Struct1());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1 });       
@@ -130,6 +135,7 @@ QFuture<Struct1> MqttSameStruct1Interface::func1Async(const Struct1& param1)
         {
             Struct1 value = arg.get<Struct1>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/tb_same1/mqtt/mqttsamestruct1interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/mqttsamestruct1interface.cpp
@@ -33,7 +33,7 @@ const QString InterfaceName = "tb.same1/SameStruct1Interface";
 MqttSameStruct1Interface::MqttSameStruct1Interface(ApiGear::Mqtt::Client& client, QObject *parent)
     : AbstractSameStruct1Interface(parent)
     , m_prop1(Struct1())
-    , m_isReady(false)
+    , m_finishedInitialization(false)
     , m_client(client)
 {
     if (m_client.isReady())
@@ -47,11 +47,13 @@ MqttSameStruct1Interface::MqttSameStruct1Interface(ApiGear::Mqtt::Client& client
             subscribeForPropertiesChanges();
             subscribeForSignals();
             subscribeForInvokeResponses();
+            m_finishedInitialization = true;
     });
     connect(&m_client, &ApiGear::Mqtt::Client::disconnected, [this](){
         m_subscribedIds.clear();
         m_InvokeCallsInfo.clear();
     });
+    m_finishedInitialization = m_client.isReady();
 }
 
 MqttSameStruct1Interface::~MqttSameStruct1Interface()
@@ -59,6 +61,11 @@ MqttSameStruct1Interface::~MqttSameStruct1Interface()
     disconnect(&m_client, &ApiGear::Mqtt::Client::disconnected, 0, 0);
     disconnect(&m_client, &ApiGear::Mqtt::Client::ready, 0, 0);
     unsubscribeAll();
+}
+
+bool MqttSameStruct1Interface::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
 }
 
 void MqttSameStruct1Interface::setProp1(const Struct1& prop1)
@@ -136,22 +143,50 @@ const QString& MqttSameStruct1Interface::interfaceName()
 {
     return InterfaceName;
 }
+
+void MqttSameStruct1Interface::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
+    }
+}
 void MqttSameStruct1Interface::subscribeForPropertiesChanges()
 {
+        // Subscription may succeed, before finising the function that subscribes it and assigns an id for if it was already added (and succeeded) for same topic,
+        // hence, for pending subscriptions a topic is used, and added before the subscribe function.
         const QString topicprop1 = interfaceName() + "/prop/prop1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
+        m_pendingSubscriptions.push_back(topicprop1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1,
+            [this, topicprop1](auto id, bool hasSucceed){handleOnSubscribed(topicprop1, id, hasSucceed);},
+            [this](auto& value) { setProp1Local(value);}));
 }
 void MqttSameStruct1Interface::subscribeForSignals()
 {
         const QString topicsig1 = interfaceName() + "/sig/sig1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
-            emit sig1(argumentsArray[0].get<Struct1>());}));
+        m_pendingSubscriptions.push_back(topicsig1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1,
+            [this, topicsig1](auto id, bool hasSucceed){handleOnSubscribed(topicsig1, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sig1(argumentsArray[0].get<Struct1>());}));
 }
 void MqttSameStruct1Interface::subscribeForInvokeResponses()
 {
     const QString topicfunc1 = interfaceName() + "/rpc/func1";
     const QString topicfunc1InvokeResp = interfaceName() + "/rpc/func1"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfunc1InvokeResp);
     auto id_func1 = m_client.subscribeForInvokeResponse(topicfunc1InvokeResp, 
+                        [this, topicfunc1InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfunc1InvokeResp, id, hasSucceed);},
                         [this, topicfunc1InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfunc1InvokeResp);

--- a/goldenmaster/tb_same1/mqtt/mqttsamestruct1interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/mqttsamestruct1interface.cpp
@@ -138,12 +138,12 @@ const QString& MqttSameStruct1Interface::interfaceName()
 }
 void MqttSameStruct1Interface::subscribeForPropertiesChanges()
 {
-        static const QString topicprop1 = interfaceName() + "/prop/prop1";
+        const QString topicprop1 = interfaceName() + "/prop/prop1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
 }
 void MqttSameStruct1Interface::subscribeForSignals()
 {
-        static const QString topicsig1 = interfaceName() + "/sig/sig1";
+        const QString topicsig1 = interfaceName() + "/sig/sig1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
             emit sig1(argumentsArray[0].get<Struct1>());}));
 }

--- a/goldenmaster/tb_same1/mqtt/mqttsamestruct1interface.h
+++ b/goldenmaster/tb_same1/mqtt/mqttsamestruct1interface.h
@@ -68,12 +68,16 @@ public:
     * Remote call of ISameStruct1Interface::func1 on the SameStruct1Interface service.
     */
     QFuture<Struct1> func1Async(const Struct1& param1);
+    /**
+    * Use to check if the MqttSameStruct1Interface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttSameStruct1Interface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -99,9 +103,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttSameStruct1Interface.
     * Handles incoming and outgoing messages.
@@ -129,6 +135,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_same1

--- a/goldenmaster/tb_same1/mqtt/mqttsamestruct1interfaceadapter.cpp
+++ b/goldenmaster/tb_same1/mqtt/mqttsamestruct1interfaceadapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "tb.same1/SameStruct1Interface";
 MqttSameStruct1InterfaceAdapter::MqttSameStruct1InterfaceAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractSameStruct1Interface> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -53,12 +54,14 @@ MqttSameStruct1InterfaceAdapter::MqttSameStruct1InterfaceAdapter(ApiGear::Mqtt::
         subscribeForInvokeRequests();
         connectServicePropertiesChanges();
         connectServiceSignals();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttSameStruct1InterfaceAdapter::~MqttSameStruct1InterfaceAdapter()
@@ -68,6 +71,12 @@ MqttSameStruct1InterfaceAdapter::~MqttSameStruct1InterfaceAdapter()
     unsubscribeAll();
 }
 
+bool MqttSameStruct1InterfaceAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
+
 const QString& MqttSameStruct1InterfaceAdapter::interfaceName()
 {
     return InterfaceName;
@@ -76,7 +85,9 @@ const QString& MqttSameStruct1InterfaceAdapter::interfaceName()
 void MqttSameStruct1InterfaceAdapter::subscribeForPropertiesChanges()
 {
     const auto setTopic_prop1 = interfaceName() + "/set/prop1";
+    m_pendingSubscriptions.push_back(setTopic_prop1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop1,
+        [this, setTopic_prop1](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop1, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             Struct1 prop1 = value.get<Struct1>();
@@ -87,7 +98,9 @@ void MqttSameStruct1InterfaceAdapter::subscribeForPropertiesChanges()
 void MqttSameStruct1InterfaceAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_func1 = interfaceName() + "/rpc/func1";
+    m_pendingSubscriptions.push_back(invokeTopic_func1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func1,
+        [this, invokeTopic_func1](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func1, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             Struct1 param1 = arguments.at(0).get<Struct1>();
@@ -122,6 +135,25 @@ void MqttSameStruct1InterfaceAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttSameStruct1InterfaceAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/tb_same1/mqtt/mqttsamestruct1interfaceadapter.h
+++ b/goldenmaster/tb_same1/mqtt/mqttsamestruct1interfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttSameStruct1InterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttSameStruct1InterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a SameStruct1Interface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_same1

--- a/goldenmaster/tb_same1/mqtt/mqttsamestruct2interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/mqttsamestruct2interface.cpp
@@ -34,7 +34,7 @@ MqttSameStruct2Interface::MqttSameStruct2Interface(ApiGear::Mqtt::Client& client
     : AbstractSameStruct2Interface(parent)
     , m_prop1(Struct2())
     , m_prop2(Struct2())
-    , m_isReady(false)
+    , m_finishedInitialization(false)
     , m_client(client)
 {
     if (m_client.isReady())
@@ -48,11 +48,13 @@ MqttSameStruct2Interface::MqttSameStruct2Interface(ApiGear::Mqtt::Client& client
             subscribeForPropertiesChanges();
             subscribeForSignals();
             subscribeForInvokeResponses();
+            m_finishedInitialization = true;
     });
     connect(&m_client, &ApiGear::Mqtt::Client::disconnected, [this](){
         m_subscribedIds.clear();
         m_InvokeCallsInfo.clear();
     });
+    m_finishedInitialization = m_client.isReady();
 }
 
 MqttSameStruct2Interface::~MqttSameStruct2Interface()
@@ -60,6 +62,11 @@ MqttSameStruct2Interface::~MqttSameStruct2Interface()
     disconnect(&m_client, &ApiGear::Mqtt::Client::disconnected, 0, 0);
     disconnect(&m_client, &ApiGear::Mqtt::Client::ready, 0, 0);
     unsubscribeAll();
+}
+
+bool MqttSameStruct2Interface::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
 }
 
 void MqttSameStruct2Interface::setProp1(const Struct2& prop1)
@@ -207,27 +214,60 @@ const QString& MqttSameStruct2Interface::interfaceName()
 {
     return InterfaceName;
 }
+
+void MqttSameStruct2Interface::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
+    }
+}
 void MqttSameStruct2Interface::subscribeForPropertiesChanges()
 {
+        // Subscription may succeed, before finising the function that subscribes it and assigns an id for if it was already added (and succeeded) for same topic,
+        // hence, for pending subscriptions a topic is used, and added before the subscribe function.
         const QString topicprop1 = interfaceName() + "/prop/prop1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
+        m_pendingSubscriptions.push_back(topicprop1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1,
+            [this, topicprop1](auto id, bool hasSucceed){handleOnSubscribed(topicprop1, id, hasSucceed);},
+            [this](auto& value) { setProp1Local(value);}));
         const QString topicprop2 = interfaceName() + "/prop/prop2";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2, [this](auto& value) { setProp2Local(value);}));
+        m_pendingSubscriptions.push_back(topicprop2);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2,
+            [this, topicprop2](auto id, bool hasSucceed){handleOnSubscribed(topicprop2, id, hasSucceed);},
+            [this](auto& value) { setProp2Local(value);}));
 }
 void MqttSameStruct2Interface::subscribeForSignals()
 {
         const QString topicsig1 = interfaceName() + "/sig/sig1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
-            emit sig1(argumentsArray[0].get<Struct1>());}));
+        m_pendingSubscriptions.push_back(topicsig1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1,
+            [this, topicsig1](auto id, bool hasSucceed){handleOnSubscribed(topicsig1, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sig1(argumentsArray[0].get<Struct1>());}));
         const QString topicsig2 = interfaceName() + "/sig/sig2";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2, [this](const nlohmann::json& argumentsArray){
-            emit sig2(argumentsArray[0].get<Struct1>(),argumentsArray[1].get<Struct2>());}));
+        m_pendingSubscriptions.push_back(topicsig2);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2,
+            [this, topicsig2](auto id, bool hasSucceed){handleOnSubscribed(topicsig2, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sig2(argumentsArray[0].get<Struct1>(), argumentsArray[1].get<Struct2>());}));
 }
 void MqttSameStruct2Interface::subscribeForInvokeResponses()
 {
     const QString topicfunc1 = interfaceName() + "/rpc/func1";
     const QString topicfunc1InvokeResp = interfaceName() + "/rpc/func1"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfunc1InvokeResp);
     auto id_func1 = m_client.subscribeForInvokeResponse(topicfunc1InvokeResp, 
+                        [this, topicfunc1InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfunc1InvokeResp, id, hasSucceed);},
                         [this, topicfunc1InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfunc1InvokeResp);
@@ -235,7 +275,9 @@ void MqttSameStruct2Interface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfunc1] = std::make_pair(topicfunc1InvokeResp, id_func1);
     const QString topicfunc2 = interfaceName() + "/rpc/func2";
     const QString topicfunc2InvokeResp = interfaceName() + "/rpc/func2"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfunc2InvokeResp);
     auto id_func2 = m_client.subscribeForInvokeResponse(topicfunc2InvokeResp, 
+                        [this, topicfunc2InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfunc2InvokeResp, id, hasSucceed);},
                         [this, topicfunc2InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfunc2InvokeResp);

--- a/goldenmaster/tb_same1/mqtt/mqttsamestruct2interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/mqttsamestruct2interface.cpp
@@ -137,11 +137,14 @@ QFuture<Struct1> MqttSameStruct2Interface::func1Async(const Struct1& param1)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func1");
     auto promise = std::make_shared<QPromise<Struct1>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(Struct1());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -149,7 +152,9 @@ QFuture<Struct1> MqttSameStruct2Interface::func1Async(const Struct1& param1)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(Struct1());
+        promise->addResult(Struct1());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1 });       
@@ -158,6 +163,7 @@ QFuture<Struct1> MqttSameStruct2Interface::func1Async(const Struct1& param1)
         {
             Struct1 value = arg.get<Struct1>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -180,11 +186,14 @@ QFuture<Struct1> MqttSameStruct2Interface::func2Async(const Struct1& param1, con
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func2");
     auto promise = std::make_shared<QPromise<Struct1>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(Struct1());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -192,7 +201,9 @@ QFuture<Struct1> MqttSameStruct2Interface::func2Async(const Struct1& param1, con
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(Struct1());
+        promise->addResult(Struct1());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1, param2 });       
@@ -201,6 +212,7 @@ QFuture<Struct1> MqttSameStruct2Interface::func2Async(const Struct1& param1, con
         {
             Struct1 value = arg.get<Struct1>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/tb_same1/mqtt/mqttsamestruct2interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/mqttsamestruct2interface.cpp
@@ -209,17 +209,17 @@ const QString& MqttSameStruct2Interface::interfaceName()
 }
 void MqttSameStruct2Interface::subscribeForPropertiesChanges()
 {
-        static const QString topicprop1 = interfaceName() + "/prop/prop1";
+        const QString topicprop1 = interfaceName() + "/prop/prop1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
-        static const QString topicprop2 = interfaceName() + "/prop/prop2";
+        const QString topicprop2 = interfaceName() + "/prop/prop2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2, [this](auto& value) { setProp2Local(value);}));
 }
 void MqttSameStruct2Interface::subscribeForSignals()
 {
-        static const QString topicsig1 = interfaceName() + "/sig/sig1";
+        const QString topicsig1 = interfaceName() + "/sig/sig1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
             emit sig1(argumentsArray[0].get<Struct1>());}));
-        static const QString topicsig2 = interfaceName() + "/sig/sig2";
+        const QString topicsig2 = interfaceName() + "/sig/sig2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2, [this](const nlohmann::json& argumentsArray){
             emit sig2(argumentsArray[0].get<Struct1>(),argumentsArray[1].get<Struct2>());}));
 }

--- a/goldenmaster/tb_same1/mqtt/mqttsamestruct2interface.h
+++ b/goldenmaster/tb_same1/mqtt/mqttsamestruct2interface.h
@@ -87,12 +87,16 @@ public:
     * Remote call of ISameStruct2Interface::func2 on the SameStruct2Interface service.
     */
     QFuture<Struct1> func2Async(const Struct1& param1, const Struct2& param2);
+    /**
+    * Use to check if the MqttSameStruct2Interface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttSameStruct2Interface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -122,9 +126,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttSameStruct2Interface.
     * Handles incoming and outgoing messages.
@@ -152,6 +158,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_same1

--- a/goldenmaster/tb_same1/mqtt/mqttsamestruct2interfaceadapter.cpp
+++ b/goldenmaster/tb_same1/mqtt/mqttsamestruct2interfaceadapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "tb.same1/SameStruct2Interface";
 MqttSameStruct2InterfaceAdapter::MqttSameStruct2InterfaceAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractSameStruct2Interface> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -53,12 +54,14 @@ MqttSameStruct2InterfaceAdapter::MqttSameStruct2InterfaceAdapter(ApiGear::Mqtt::
         subscribeForInvokeRequests();
         connectServicePropertiesChanges();
         connectServiceSignals();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttSameStruct2InterfaceAdapter::~MqttSameStruct2InterfaceAdapter()
@@ -68,6 +71,12 @@ MqttSameStruct2InterfaceAdapter::~MqttSameStruct2InterfaceAdapter()
     unsubscribeAll();
 }
 
+bool MqttSameStruct2InterfaceAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
+
 const QString& MqttSameStruct2InterfaceAdapter::interfaceName()
 {
     return InterfaceName;
@@ -76,14 +85,18 @@ const QString& MqttSameStruct2InterfaceAdapter::interfaceName()
 void MqttSameStruct2InterfaceAdapter::subscribeForPropertiesChanges()
 {
     const auto setTopic_prop1 = interfaceName() + "/set/prop1";
+    m_pendingSubscriptions.push_back(setTopic_prop1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop1,
+        [this, setTopic_prop1](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop1, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             Struct2 prop1 = value.get<Struct2>();
             m_impl->setProp1(prop1);
         }));
     const auto setTopic_prop2 = interfaceName() + "/set/prop2";
+    m_pendingSubscriptions.push_back(setTopic_prop2);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop2,
+        [this, setTopic_prop2](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop2, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             Struct2 prop2 = value.get<Struct2>();
@@ -94,7 +107,9 @@ void MqttSameStruct2InterfaceAdapter::subscribeForPropertiesChanges()
 void MqttSameStruct2InterfaceAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_func1 = interfaceName() + "/rpc/func1";
+    m_pendingSubscriptions.push_back(invokeTopic_func1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func1,
+        [this, invokeTopic_func1](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func1, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             Struct1 param1 = arguments.at(0).get<Struct1>();
@@ -102,7 +117,9 @@ void MqttSameStruct2InterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_func2 = interfaceName() + "/rpc/func2";
+    m_pendingSubscriptions.push_back(invokeTopic_func2);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func2,
+        [this, invokeTopic_func2](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func2, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             Struct1 param1 = arguments.at(0).get<Struct1>();
@@ -151,6 +168,25 @@ void MqttSameStruct2InterfaceAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttSameStruct2InterfaceAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/tb_same1/mqtt/mqttsamestruct2interfaceadapter.h
+++ b/goldenmaster/tb_same1/mqtt/mqttsamestruct2interfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttSameStruct2InterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttSameStruct2InterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a SameStruct2Interface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_same1

--- a/goldenmaster/tb_same1/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/tb_same1/mqtt/tests/CMakeLists.txt
@@ -1,0 +1,60 @@
+
+cmake_minimum_required(VERSION 3.20)
+project(test_tb_same1_generated_mqtt)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(BUILD_TESTING)
+include(CTest)
+enable_testing()
+
+find_package(Qt6 REQUIRED COMPONENTS Test Core)
+find_package(apigear QUIET COMPONENTS apigear_mqtt)
+find_package(tb_same1 QUIET COMPONENTS tb_same1_impl tb_same1_mqtt)
+
+find_package(Catch2 REQUIRED)
+
+set(CMAKE_CTEST_COMMAND ctest -V)
+if(NOT TARGET check)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+set(TEST_TB_SAME1_GENERATED_MQTT_SOURCES
+    test_main.cpp
+    )
+
+include_directories(test_tb_same1_generated_mqtt
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+add_executable(test_tb_same1_generated_mqtt ${TEST_TB_SAME1_GENERATED_MQTT_SOURCES})
+add_test(NAME test_tb_same1_generated_mqtt COMMAND $<TARGET_FILE:test_tb_same1_generated_mqtt>)
+add_dependencies(check test_tb_same1_generated_mqtt)
+
+target_link_libraries(test_tb_same1_generated_mqtt PRIVATE
+    apigear_mqtt
+    tb_same1_impl
+    tb_same1_mqtt
+    Catch2::Catch2
+    Qt::Test)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_tb_same1_generated_mqtt
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+
+endif() # BUILD_TESTING

--- a/goldenmaster/tb_same1/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/tb_same1/mqtt/tests/CMakeLists.txt
@@ -29,6 +29,10 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 endif()
 
 set(TEST_TB_SAME1_GENERATED_MQTT_SOURCES
+    test_mqttsamestruct1interface.cpp
+    test_mqttsamestruct2interface.cpp
+    test_mqttsameenum1interface.cpp
+    test_mqttsameenum2interface.cpp
     test_main.cpp
     )
 

--- a/goldenmaster/tb_same1/mqtt/tests/test_main.cpp
+++ b/goldenmaster/tb_same1/mqtt/tests/test_main.cpp
@@ -1,0 +1,12 @@
+#define CATCH_CONFIG_RUNNER
+
+#include <QCoreApplication>
+#include <catch2/catch.hpp>
+
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv); // -platform offscreen
+    int result = Catch::Session().run(argc, argv); // --break
+    return result;
+}

--- a/goldenmaster/tb_same1/mqtt/tests/test_mqttsameenum1interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/tests/test_mqttsameenum1interface.cpp
@@ -1,0 +1,117 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/sameenum1interface.h"
+#include "mqtt/mqttsameenum1interface.h"
+#include "mqtt/mqttsameenum1interfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.same1 SameEnum1Interface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientSameEnum1Interface = std::make_shared<tb_same1::MqttSameEnum1Interface >(client);
+    auto implSameEnum1Interface = std::make_shared<tb_same1::SameEnum1Interface>();
+    auto serviceSameEnum1Interface = std::make_shared<tb_same1::MqttSameEnum1InterfaceAdapter>(service, implSameEnum1Interface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientSameEnum1Interface, &serviceSameEnum1Interface]() {return clientSameEnum1Interface->isReady() && serviceSameEnum1Interface->isReady(); }, timeout));
+    SECTION("Test setting prop1")
+    {
+        std::atomic<bool> isprop1Changed = false;
+        clientSameEnum1Interface->connect(clientSameEnum1Interface.get(), &tb_same1::AbstractSameEnum1Interface::prop1Changed, [&isprop1Changed ](auto value){isprop1Changed  = true;});
+        auto test_value = tb_same1::Enum1::Value2;
+        clientSameEnum1Interface->setProp1(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop1Changed]() {return isprop1Changed  == true; }, timeout));
+        REQUIRE(implSameEnum1Interface->prop1() == test_value);
+        REQUIRE(clientSameEnum1Interface->prop1() == test_value);
+    }
+    SECTION("Test emit sig1")
+    {
+        std::atomic<bool> issig1Emitted = false;
+
+        clientSameEnum1Interface->connect(clientSameEnum1Interface.get(), &tb_same1::AbstractSameEnum1Interface::sig1,
+        [&issig1Emitted](tb_same1::Enum1::Enum1Enum param1)
+        {
+            REQUIRE(param1 == tb_same1::Enum1::Value2);
+            issig1Emitted  = true;
+        });
+
+        emit implSameEnum1Interface->sig1(tb_same1::Enum1::Value2);
+        REQUIRE(QTest::qWaitFor([&issig1Emitted ]() {return issig1Emitted   == true; }, timeout));
+    }
+    SECTION("Test method func1")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSameEnum1Interface, &finished](){
+            [[maybe_unused]] auto result = clientSameEnum1Interface->func1(tb_same1::Enum1::Value1);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func1 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSameEnum1Interface->func1Async(tb_same1::Enum1::Value1);
+        resultFuture.then([&finished](tb_same1::Enum1::Enum1Enum /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_same1::Enum1::Value1);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientSameEnum1Interface.reset();
+    serviceSameEnum1Interface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_same1/mqtt/tests/test_mqttsameenum2interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/tests/test_mqttsameenum2interface.cpp
@@ -1,0 +1,166 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/sameenum2interface.h"
+#include "mqtt/mqttsameenum2interface.h"
+#include "mqtt/mqttsameenum2interfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.same1 SameEnum2Interface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientSameEnum2Interface = std::make_shared<tb_same1::MqttSameEnum2Interface >(client);
+    auto implSameEnum2Interface = std::make_shared<tb_same1::SameEnum2Interface>();
+    auto serviceSameEnum2Interface = std::make_shared<tb_same1::MqttSameEnum2InterfaceAdapter>(service, implSameEnum2Interface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientSameEnum2Interface, &serviceSameEnum2Interface]() {return clientSameEnum2Interface->isReady() && serviceSameEnum2Interface->isReady(); }, timeout));
+    SECTION("Test setting prop1")
+    {
+        std::atomic<bool> isprop1Changed = false;
+        clientSameEnum2Interface->connect(clientSameEnum2Interface.get(), &tb_same1::AbstractSameEnum2Interface::prop1Changed, [&isprop1Changed ](auto value){isprop1Changed  = true;});
+        auto test_value = tb_same1::Enum1::Value2;
+        clientSameEnum2Interface->setProp1(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop1Changed]() {return isprop1Changed  == true; }, timeout));
+        REQUIRE(implSameEnum2Interface->prop1() == test_value);
+        REQUIRE(clientSameEnum2Interface->prop1() == test_value);
+    }
+    SECTION("Test setting prop2")
+    {
+        std::atomic<bool> isprop2Changed = false;
+        clientSameEnum2Interface->connect(clientSameEnum2Interface.get(), &tb_same1::AbstractSameEnum2Interface::prop2Changed, [&isprop2Changed ](auto value){isprop2Changed  = true;});
+        auto test_value = tb_same1::Enum2::Value2;
+        clientSameEnum2Interface->setProp2(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop2Changed]() {return isprop2Changed  == true; }, timeout));
+        REQUIRE(implSameEnum2Interface->prop2() == test_value);
+        REQUIRE(clientSameEnum2Interface->prop2() == test_value);
+    }
+    SECTION("Test emit sig1")
+    {
+        std::atomic<bool> issig1Emitted = false;
+
+        clientSameEnum2Interface->connect(clientSameEnum2Interface.get(), &tb_same1::AbstractSameEnum2Interface::sig1,
+        [&issig1Emitted](tb_same1::Enum1::Enum1Enum param1)
+        {
+            REQUIRE(param1 == tb_same1::Enum1::Value2);
+            issig1Emitted  = true;
+        });
+
+        emit implSameEnum2Interface->sig1(tb_same1::Enum1::Value2);
+        REQUIRE(QTest::qWaitFor([&issig1Emitted ]() {return issig1Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sig2")
+    {
+        std::atomic<bool> issig2Emitted = false;
+
+        clientSameEnum2Interface->connect(clientSameEnum2Interface.get(), &tb_same1::AbstractSameEnum2Interface::sig2,
+        [&issig2Emitted](tb_same1::Enum1::Enum1Enum param1, tb_same1::Enum2::Enum2Enum param2)
+        {
+            REQUIRE(param1 == tb_same1::Enum1::Value2);
+            REQUIRE(param2 == tb_same1::Enum2::Value2);
+            issig2Emitted  = true;
+        });
+
+        emit implSameEnum2Interface->sig2(tb_same1::Enum1::Value2, tb_same1::Enum2::Value2);
+        REQUIRE(QTest::qWaitFor([&issig2Emitted ]() {return issig2Emitted   == true; }, timeout));
+    }
+    SECTION("Test method func1")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSameEnum2Interface, &finished](){
+            [[maybe_unused]] auto result = clientSameEnum2Interface->func1(tb_same1::Enum1::Value1);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func1 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSameEnum2Interface->func1Async(tb_same1::Enum1::Value1);
+        resultFuture.then([&finished](tb_same1::Enum1::Enum1Enum /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_same1::Enum1::Value1);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method func2")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSameEnum2Interface, &finished](){
+            [[maybe_unused]] auto result = clientSameEnum2Interface->func2(tb_same1::Enum1::Value1, tb_same1::Enum2::Value1);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func2 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSameEnum2Interface->func2Async(tb_same1::Enum1::Value1, tb_same1::Enum2::Value1);
+        resultFuture.then([&finished](tb_same1::Enum1::Enum1Enum /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_same1::Enum1::Value1);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientSameEnum2Interface.reset();
+    serviceSameEnum2Interface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_same1/mqtt/tests/test_mqttsamestruct1interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/tests/test_mqttsamestruct1interface.cpp
@@ -1,0 +1,120 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/samestruct1interface.h"
+#include "mqtt/mqttsamestruct1interface.h"
+#include "mqtt/mqttsamestruct1interfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.same1 SameStruct1Interface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientSameStruct1Interface = std::make_shared<tb_same1::MqttSameStruct1Interface >(client);
+    auto implSameStruct1Interface = std::make_shared<tb_same1::SameStruct1Interface>();
+    auto serviceSameStruct1Interface = std::make_shared<tb_same1::MqttSameStruct1InterfaceAdapter>(service, implSameStruct1Interface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientSameStruct1Interface, &serviceSameStruct1Interface]() {return clientSameStruct1Interface->isReady() && serviceSameStruct1Interface->isReady(); }, timeout));
+    SECTION("Test setting prop1")
+    {
+        std::atomic<bool> isprop1Changed = false;
+        clientSameStruct1Interface->connect(clientSameStruct1Interface.get(), &tb_same1::AbstractSameStruct1Interface::prop1Changed, [&isprop1Changed ](auto value){isprop1Changed  = true;});
+        auto test_value = tb_same1::Struct1();
+        tb_same1::fillTestStruct1(test_value);
+        clientSameStruct1Interface->setProp1(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop1Changed]() {return isprop1Changed  == true; }, timeout));
+        REQUIRE(implSameStruct1Interface->prop1() == test_value);
+        REQUIRE(clientSameStruct1Interface->prop1() == test_value);
+    }
+    SECTION("Test emit sig1")
+    {
+        std::atomic<bool> issig1Emitted = false;
+        auto local_param1_struct = tb_same1::Struct1();
+        tb_same1::fillTestStruct1(local_param1_struct);
+
+        clientSameStruct1Interface->connect(clientSameStruct1Interface.get(), &tb_same1::AbstractSameStruct1Interface::sig1,
+        [&issig1Emitted, &local_param1_struct](const tb_same1::Struct1& param1)
+        {
+            REQUIRE(param1 ==local_param1_struct);
+            issig1Emitted  = true;
+        });
+
+        emit implSameStruct1Interface->sig1(local_param1_struct);
+        REQUIRE(QTest::qWaitFor([&issig1Emitted ]() {return issig1Emitted   == true; }, timeout));
+    }
+    SECTION("Test method func1")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSameStruct1Interface, &finished](){
+            [[maybe_unused]] auto result = clientSameStruct1Interface->func1(tb_same1::Struct1());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func1 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSameStruct1Interface->func1Async(tb_same1::Struct1());
+        resultFuture.then([&finished](tb_same1::Struct1 /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_same1::Struct1());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientSameStruct1Interface.reset();
+    serviceSameStruct1Interface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_same1/mqtt/tests/test_mqttsamestruct2interface.cpp
+++ b/goldenmaster/tb_same1/mqtt/tests/test_mqttsamestruct2interface.cpp
@@ -1,0 +1,174 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/samestruct2interface.h"
+#include "mqtt/mqttsamestruct2interface.h"
+#include "mqtt/mqttsamestruct2interfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.same1 SameStruct2Interface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientSameStruct2Interface = std::make_shared<tb_same1::MqttSameStruct2Interface >(client);
+    auto implSameStruct2Interface = std::make_shared<tb_same1::SameStruct2Interface>();
+    auto serviceSameStruct2Interface = std::make_shared<tb_same1::MqttSameStruct2InterfaceAdapter>(service, implSameStruct2Interface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientSameStruct2Interface, &serviceSameStruct2Interface]() {return clientSameStruct2Interface->isReady() && serviceSameStruct2Interface->isReady(); }, timeout));
+    SECTION("Test setting prop1")
+    {
+        std::atomic<bool> isprop1Changed = false;
+        clientSameStruct2Interface->connect(clientSameStruct2Interface.get(), &tb_same1::AbstractSameStruct2Interface::prop1Changed, [&isprop1Changed ](auto value){isprop1Changed  = true;});
+        auto test_value = tb_same1::Struct2();
+        tb_same1::fillTestStruct2(test_value);
+        clientSameStruct2Interface->setProp1(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop1Changed]() {return isprop1Changed  == true; }, timeout));
+        REQUIRE(implSameStruct2Interface->prop1() == test_value);
+        REQUIRE(clientSameStruct2Interface->prop1() == test_value);
+    }
+    SECTION("Test setting prop2")
+    {
+        std::atomic<bool> isprop2Changed = false;
+        clientSameStruct2Interface->connect(clientSameStruct2Interface.get(), &tb_same1::AbstractSameStruct2Interface::prop2Changed, [&isprop2Changed ](auto value){isprop2Changed  = true;});
+        auto test_value = tb_same1::Struct2();
+        tb_same1::fillTestStruct2(test_value);
+        clientSameStruct2Interface->setProp2(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop2Changed]() {return isprop2Changed  == true; }, timeout));
+        REQUIRE(implSameStruct2Interface->prop2() == test_value);
+        REQUIRE(clientSameStruct2Interface->prop2() == test_value);
+    }
+    SECTION("Test emit sig1")
+    {
+        std::atomic<bool> issig1Emitted = false;
+        auto local_param1_struct = tb_same1::Struct1();
+        tb_same1::fillTestStruct1(local_param1_struct);
+
+        clientSameStruct2Interface->connect(clientSameStruct2Interface.get(), &tb_same1::AbstractSameStruct2Interface::sig1,
+        [&issig1Emitted, &local_param1_struct](const tb_same1::Struct1& param1)
+        {
+            REQUIRE(param1 ==local_param1_struct);
+            issig1Emitted  = true;
+        });
+
+        emit implSameStruct2Interface->sig1(local_param1_struct);
+        REQUIRE(QTest::qWaitFor([&issig1Emitted ]() {return issig1Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sig2")
+    {
+        std::atomic<bool> issig2Emitted = false;
+        auto local_param1_struct = tb_same1::Struct1();
+        tb_same1::fillTestStruct1(local_param1_struct);
+        auto local_param2_struct = tb_same1::Struct2();
+        tb_same1::fillTestStruct2(local_param2_struct);
+
+        clientSameStruct2Interface->connect(clientSameStruct2Interface.get(), &tb_same1::AbstractSameStruct2Interface::sig2,
+        [&issig2Emitted, &local_param1_struct, &local_param2_struct](const tb_same1::Struct1& param1, const tb_same1::Struct2& param2)
+        {
+            REQUIRE(param1 ==local_param1_struct);
+            REQUIRE(param2 ==local_param2_struct);
+            issig2Emitted  = true;
+        });
+
+        emit implSameStruct2Interface->sig2(local_param1_struct, local_param2_struct);
+        REQUIRE(QTest::qWaitFor([&issig2Emitted ]() {return issig2Emitted   == true; }, timeout));
+    }
+    SECTION("Test method func1")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSameStruct2Interface, &finished](){
+            [[maybe_unused]] auto result = clientSameStruct2Interface->func1(tb_same1::Struct1());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func1 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSameStruct2Interface->func1Async(tb_same1::Struct1());
+        resultFuture.then([&finished](tb_same1::Struct1 /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_same1::Struct1());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method func2")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSameStruct2Interface, &finished](){
+            [[maybe_unused]] auto result = clientSameStruct2Interface->func2(tb_same1::Struct1(), tb_same1::Struct2());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func2 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSameStruct2Interface->func2Async(tb_same1::Struct1(), tb_same1::Struct2());
+        resultFuture.then([&finished](tb_same1::Struct1 /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_same1::Struct1());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientSameStruct2Interface.reset();
+    serviceSameStruct2Interface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_same2/mqtt/CMakeLists.txt
+++ b/goldenmaster/tb_same2/mqtt/CMakeLists.txt
@@ -37,6 +37,10 @@ target_include_directories(tb_same2_mqtt
     $<INSTALL_INTERFACE:include/tb_same2>
 )
 
+if (ENABLE_MQTT_TEST_FOR_NON_LINUX_OS OR ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")))
+add_subdirectory(tests)
+endif()
+
 target_link_libraries(tb_same2_mqtt PUBLIC tb_same2::tb_same2_api apigear::apigear_mqtt Qt6::Concurrent)
 target_compile_definitions(tb_same2_mqtt PRIVATE TB_SAME2_MQTT_LIBRARY)
 

--- a/goldenmaster/tb_same2/mqtt/mqttsameenum1interface.cpp
+++ b/goldenmaster/tb_same2/mqtt/mqttsameenum1interface.cpp
@@ -138,12 +138,12 @@ const QString& MqttSameEnum1Interface::interfaceName()
 }
 void MqttSameEnum1Interface::subscribeForPropertiesChanges()
 {
-        static const QString topicprop1 = interfaceName() + "/prop/prop1";
+        const QString topicprop1 = interfaceName() + "/prop/prop1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
 }
 void MqttSameEnum1Interface::subscribeForSignals()
 {
-        static const QString topicsig1 = interfaceName() + "/sig/sig1";
+        const QString topicsig1 = interfaceName() + "/sig/sig1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
             emit sig1(argumentsArray[0].get<Enum1::Enum1Enum>());}));
 }

--- a/goldenmaster/tb_same2/mqtt/mqttsameenum1interface.cpp
+++ b/goldenmaster/tb_same2/mqtt/mqttsameenum1interface.cpp
@@ -33,7 +33,7 @@ const QString InterfaceName = "tb.same2/SameEnum1Interface";
 MqttSameEnum1Interface::MqttSameEnum1Interface(ApiGear::Mqtt::Client& client, QObject *parent)
     : AbstractSameEnum1Interface(parent)
     , m_prop1(Enum1::Value1)
-    , m_isReady(false)
+    , m_finishedInitialization(false)
     , m_client(client)
 {
     if (m_client.isReady())
@@ -47,11 +47,13 @@ MqttSameEnum1Interface::MqttSameEnum1Interface(ApiGear::Mqtt::Client& client, QO
             subscribeForPropertiesChanges();
             subscribeForSignals();
             subscribeForInvokeResponses();
+            m_finishedInitialization = true;
     });
     connect(&m_client, &ApiGear::Mqtt::Client::disconnected, [this](){
         m_subscribedIds.clear();
         m_InvokeCallsInfo.clear();
     });
+    m_finishedInitialization = m_client.isReady();
 }
 
 MqttSameEnum1Interface::~MqttSameEnum1Interface()
@@ -59,6 +61,11 @@ MqttSameEnum1Interface::~MqttSameEnum1Interface()
     disconnect(&m_client, &ApiGear::Mqtt::Client::disconnected, 0, 0);
     disconnect(&m_client, &ApiGear::Mqtt::Client::ready, 0, 0);
     unsubscribeAll();
+}
+
+bool MqttSameEnum1Interface::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
 }
 
 void MqttSameEnum1Interface::setProp1(Enum1::Enum1Enum prop1)
@@ -136,22 +143,50 @@ const QString& MqttSameEnum1Interface::interfaceName()
 {
     return InterfaceName;
 }
+
+void MqttSameEnum1Interface::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
+    }
+}
 void MqttSameEnum1Interface::subscribeForPropertiesChanges()
 {
+        // Subscription may succeed, before finising the function that subscribes it and assigns an id for if it was already added (and succeeded) for same topic,
+        // hence, for pending subscriptions a topic is used, and added before the subscribe function.
         const QString topicprop1 = interfaceName() + "/prop/prop1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
+        m_pendingSubscriptions.push_back(topicprop1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1,
+            [this, topicprop1](auto id, bool hasSucceed){handleOnSubscribed(topicprop1, id, hasSucceed);},
+            [this](auto& value) { setProp1Local(value);}));
 }
 void MqttSameEnum1Interface::subscribeForSignals()
 {
         const QString topicsig1 = interfaceName() + "/sig/sig1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
-            emit sig1(argumentsArray[0].get<Enum1::Enum1Enum>());}));
+        m_pendingSubscriptions.push_back(topicsig1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1,
+            [this, topicsig1](auto id, bool hasSucceed){handleOnSubscribed(topicsig1, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sig1(argumentsArray[0].get<Enum1::Enum1Enum>());}));
 }
 void MqttSameEnum1Interface::subscribeForInvokeResponses()
 {
     const QString topicfunc1 = interfaceName() + "/rpc/func1";
     const QString topicfunc1InvokeResp = interfaceName() + "/rpc/func1"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfunc1InvokeResp);
     auto id_func1 = m_client.subscribeForInvokeResponse(topicfunc1InvokeResp, 
+                        [this, topicfunc1InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfunc1InvokeResp, id, hasSucceed);},
                         [this, topicfunc1InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfunc1InvokeResp);

--- a/goldenmaster/tb_same2/mqtt/mqttsameenum1interface.h
+++ b/goldenmaster/tb_same2/mqtt/mqttsameenum1interface.h
@@ -68,12 +68,16 @@ public:
     * Remote call of ISameEnum1Interface::func1 on the SameEnum1Interface service.
     */
     QFuture<Enum1::Enum1Enum> func1Async(Enum1::Enum1Enum param1);
+    /**
+    * Use to check if the MqttSameEnum1Interface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttSameEnum1Interface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -99,9 +103,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttSameEnum1Interface.
     * Handles incoming and outgoing messages.
@@ -129,6 +135,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_same2

--- a/goldenmaster/tb_same2/mqtt/mqttsameenum1interfaceadapter.cpp
+++ b/goldenmaster/tb_same2/mqtt/mqttsameenum1interfaceadapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "tb.same2/SameEnum1Interface";
 MqttSameEnum1InterfaceAdapter::MqttSameEnum1InterfaceAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractSameEnum1Interface> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -53,12 +54,14 @@ MqttSameEnum1InterfaceAdapter::MqttSameEnum1InterfaceAdapter(ApiGear::Mqtt::Serv
         subscribeForInvokeRequests();
         connectServicePropertiesChanges();
         connectServiceSignals();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttSameEnum1InterfaceAdapter::~MqttSameEnum1InterfaceAdapter()
@@ -68,6 +71,12 @@ MqttSameEnum1InterfaceAdapter::~MqttSameEnum1InterfaceAdapter()
     unsubscribeAll();
 }
 
+bool MqttSameEnum1InterfaceAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
+
 const QString& MqttSameEnum1InterfaceAdapter::interfaceName()
 {
     return InterfaceName;
@@ -76,7 +85,9 @@ const QString& MqttSameEnum1InterfaceAdapter::interfaceName()
 void MqttSameEnum1InterfaceAdapter::subscribeForPropertiesChanges()
 {
     const auto setTopic_prop1 = interfaceName() + "/set/prop1";
+    m_pendingSubscriptions.push_back(setTopic_prop1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop1,
+        [this, setTopic_prop1](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop1, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             Enum1::Enum1Enum prop1 = value.get<Enum1::Enum1Enum>();
@@ -87,7 +98,9 @@ void MqttSameEnum1InterfaceAdapter::subscribeForPropertiesChanges()
 void MqttSameEnum1InterfaceAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_func1 = interfaceName() + "/rpc/func1";
+    m_pendingSubscriptions.push_back(invokeTopic_func1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func1,
+        [this, invokeTopic_func1](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func1, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             Enum1::Enum1Enum param1 = arguments.at(0).get<Enum1::Enum1Enum>();
@@ -122,6 +135,25 @@ void MqttSameEnum1InterfaceAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttSameEnum1InterfaceAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/tb_same2/mqtt/mqttsameenum1interfaceadapter.h
+++ b/goldenmaster/tb_same2/mqtt/mqttsameenum1interfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttSameEnum1InterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttSameEnum1InterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a SameEnum1Interface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_same2

--- a/goldenmaster/tb_same2/mqtt/mqttsameenum2interface.cpp
+++ b/goldenmaster/tb_same2/mqtt/mqttsameenum2interface.cpp
@@ -209,17 +209,17 @@ const QString& MqttSameEnum2Interface::interfaceName()
 }
 void MqttSameEnum2Interface::subscribeForPropertiesChanges()
 {
-        static const QString topicprop1 = interfaceName() + "/prop/prop1";
+        const QString topicprop1 = interfaceName() + "/prop/prop1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
-        static const QString topicprop2 = interfaceName() + "/prop/prop2";
+        const QString topicprop2 = interfaceName() + "/prop/prop2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2, [this](auto& value) { setProp2Local(value);}));
 }
 void MqttSameEnum2Interface::subscribeForSignals()
 {
-        static const QString topicsig1 = interfaceName() + "/sig/sig1";
+        const QString topicsig1 = interfaceName() + "/sig/sig1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
             emit sig1(argumentsArray[0].get<Enum1::Enum1Enum>());}));
-        static const QString topicsig2 = interfaceName() + "/sig/sig2";
+        const QString topicsig2 = interfaceName() + "/sig/sig2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2, [this](const nlohmann::json& argumentsArray){
             emit sig2(argumentsArray[0].get<Enum1::Enum1Enum>(),argumentsArray[1].get<Enum2::Enum2Enum>());}));
 }

--- a/goldenmaster/tb_same2/mqtt/mqttsameenum2interface.cpp
+++ b/goldenmaster/tb_same2/mqtt/mqttsameenum2interface.cpp
@@ -34,7 +34,7 @@ MqttSameEnum2Interface::MqttSameEnum2Interface(ApiGear::Mqtt::Client& client, QO
     : AbstractSameEnum2Interface(parent)
     , m_prop1(Enum1::Value1)
     , m_prop2(Enum2::Value1)
-    , m_isReady(false)
+    , m_finishedInitialization(false)
     , m_client(client)
 {
     if (m_client.isReady())
@@ -48,11 +48,13 @@ MqttSameEnum2Interface::MqttSameEnum2Interface(ApiGear::Mqtt::Client& client, QO
             subscribeForPropertiesChanges();
             subscribeForSignals();
             subscribeForInvokeResponses();
+            m_finishedInitialization = true;
     });
     connect(&m_client, &ApiGear::Mqtt::Client::disconnected, [this](){
         m_subscribedIds.clear();
         m_InvokeCallsInfo.clear();
     });
+    m_finishedInitialization = m_client.isReady();
 }
 
 MqttSameEnum2Interface::~MqttSameEnum2Interface()
@@ -60,6 +62,11 @@ MqttSameEnum2Interface::~MqttSameEnum2Interface()
     disconnect(&m_client, &ApiGear::Mqtt::Client::disconnected, 0, 0);
     disconnect(&m_client, &ApiGear::Mqtt::Client::ready, 0, 0);
     unsubscribeAll();
+}
+
+bool MqttSameEnum2Interface::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
 }
 
 void MqttSameEnum2Interface::setProp1(Enum1::Enum1Enum prop1)
@@ -207,27 +214,60 @@ const QString& MqttSameEnum2Interface::interfaceName()
 {
     return InterfaceName;
 }
+
+void MqttSameEnum2Interface::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
+    }
+}
 void MqttSameEnum2Interface::subscribeForPropertiesChanges()
 {
+        // Subscription may succeed, before finising the function that subscribes it and assigns an id for if it was already added (and succeeded) for same topic,
+        // hence, for pending subscriptions a topic is used, and added before the subscribe function.
         const QString topicprop1 = interfaceName() + "/prop/prop1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
+        m_pendingSubscriptions.push_back(topicprop1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1,
+            [this, topicprop1](auto id, bool hasSucceed){handleOnSubscribed(topicprop1, id, hasSucceed);},
+            [this](auto& value) { setProp1Local(value);}));
         const QString topicprop2 = interfaceName() + "/prop/prop2";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2, [this](auto& value) { setProp2Local(value);}));
+        m_pendingSubscriptions.push_back(topicprop2);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2,
+            [this, topicprop2](auto id, bool hasSucceed){handleOnSubscribed(topicprop2, id, hasSucceed);},
+            [this](auto& value) { setProp2Local(value);}));
 }
 void MqttSameEnum2Interface::subscribeForSignals()
 {
         const QString topicsig1 = interfaceName() + "/sig/sig1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
-            emit sig1(argumentsArray[0].get<Enum1::Enum1Enum>());}));
+        m_pendingSubscriptions.push_back(topicsig1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1,
+            [this, topicsig1](auto id, bool hasSucceed){handleOnSubscribed(topicsig1, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sig1(argumentsArray[0].get<Enum1::Enum1Enum>());}));
         const QString topicsig2 = interfaceName() + "/sig/sig2";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2, [this](const nlohmann::json& argumentsArray){
-            emit sig2(argumentsArray[0].get<Enum1::Enum1Enum>(),argumentsArray[1].get<Enum2::Enum2Enum>());}));
+        m_pendingSubscriptions.push_back(topicsig2);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2,
+            [this, topicsig2](auto id, bool hasSucceed){handleOnSubscribed(topicsig2, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sig2(argumentsArray[0].get<Enum1::Enum1Enum>(), argumentsArray[1].get<Enum2::Enum2Enum>());}));
 }
 void MqttSameEnum2Interface::subscribeForInvokeResponses()
 {
     const QString topicfunc1 = interfaceName() + "/rpc/func1";
     const QString topicfunc1InvokeResp = interfaceName() + "/rpc/func1"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfunc1InvokeResp);
     auto id_func1 = m_client.subscribeForInvokeResponse(topicfunc1InvokeResp, 
+                        [this, topicfunc1InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfunc1InvokeResp, id, hasSucceed);},
                         [this, topicfunc1InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfunc1InvokeResp);
@@ -235,7 +275,9 @@ void MqttSameEnum2Interface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfunc1] = std::make_pair(topicfunc1InvokeResp, id_func1);
     const QString topicfunc2 = interfaceName() + "/rpc/func2";
     const QString topicfunc2InvokeResp = interfaceName() + "/rpc/func2"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfunc2InvokeResp);
     auto id_func2 = m_client.subscribeForInvokeResponse(topicfunc2InvokeResp, 
+                        [this, topicfunc2InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfunc2InvokeResp, id, hasSucceed);},
                         [this, topicfunc2InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfunc2InvokeResp);

--- a/goldenmaster/tb_same2/mqtt/mqttsameenum2interface.cpp
+++ b/goldenmaster/tb_same2/mqtt/mqttsameenum2interface.cpp
@@ -137,11 +137,14 @@ QFuture<Enum1::Enum1Enum> MqttSameEnum2Interface::func1Async(Enum1::Enum1Enum pa
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func1");
     auto promise = std::make_shared<QPromise<Enum1::Enum1Enum>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(Enum1::Value1);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -149,7 +152,9 @@ QFuture<Enum1::Enum1Enum> MqttSameEnum2Interface::func1Async(Enum1::Enum1Enum pa
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(Enum1::Value1);
+        promise->addResult(Enum1::Value1);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1 });       
@@ -158,6 +163,7 @@ QFuture<Enum1::Enum1Enum> MqttSameEnum2Interface::func1Async(Enum1::Enum1Enum pa
         {
             Enum1::Enum1Enum value = arg.get<Enum1::Enum1Enum>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -180,11 +186,14 @@ QFuture<Enum1::Enum1Enum> MqttSameEnum2Interface::func2Async(Enum1::Enum1Enum pa
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func2");
     auto promise = std::make_shared<QPromise<Enum1::Enum1Enum>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(Enum1::Value1);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -192,7 +201,9 @@ QFuture<Enum1::Enum1Enum> MqttSameEnum2Interface::func2Async(Enum1::Enum1Enum pa
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(Enum1::Value1);
+        promise->addResult(Enum1::Value1);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1, param2 });       
@@ -201,6 +212,7 @@ QFuture<Enum1::Enum1Enum> MqttSameEnum2Interface::func2Async(Enum1::Enum1Enum pa
         {
             Enum1::Enum1Enum value = arg.get<Enum1::Enum1Enum>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/tb_same2/mqtt/mqttsameenum2interface.h
+++ b/goldenmaster/tb_same2/mqtt/mqttsameenum2interface.h
@@ -87,12 +87,16 @@ public:
     * Remote call of ISameEnum2Interface::func2 on the SameEnum2Interface service.
     */
     QFuture<Enum1::Enum1Enum> func2Async(Enum1::Enum1Enum param1, Enum2::Enum2Enum param2);
+    /**
+    * Use to check if the MqttSameEnum2Interface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttSameEnum2Interface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -122,9 +126,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttSameEnum2Interface.
     * Handles incoming and outgoing messages.
@@ -152,6 +158,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_same2

--- a/goldenmaster/tb_same2/mqtt/mqttsameenum2interfaceadapter.cpp
+++ b/goldenmaster/tb_same2/mqtt/mqttsameenum2interfaceadapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "tb.same2/SameEnum2Interface";
 MqttSameEnum2InterfaceAdapter::MqttSameEnum2InterfaceAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractSameEnum2Interface> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -53,12 +54,14 @@ MqttSameEnum2InterfaceAdapter::MqttSameEnum2InterfaceAdapter(ApiGear::Mqtt::Serv
         subscribeForInvokeRequests();
         connectServicePropertiesChanges();
         connectServiceSignals();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttSameEnum2InterfaceAdapter::~MqttSameEnum2InterfaceAdapter()
@@ -68,6 +71,12 @@ MqttSameEnum2InterfaceAdapter::~MqttSameEnum2InterfaceAdapter()
     unsubscribeAll();
 }
 
+bool MqttSameEnum2InterfaceAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
+
 const QString& MqttSameEnum2InterfaceAdapter::interfaceName()
 {
     return InterfaceName;
@@ -76,14 +85,18 @@ const QString& MqttSameEnum2InterfaceAdapter::interfaceName()
 void MqttSameEnum2InterfaceAdapter::subscribeForPropertiesChanges()
 {
     const auto setTopic_prop1 = interfaceName() + "/set/prop1";
+    m_pendingSubscriptions.push_back(setTopic_prop1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop1,
+        [this, setTopic_prop1](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop1, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             Enum1::Enum1Enum prop1 = value.get<Enum1::Enum1Enum>();
             m_impl->setProp1(prop1);
         }));
     const auto setTopic_prop2 = interfaceName() + "/set/prop2";
+    m_pendingSubscriptions.push_back(setTopic_prop2);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop2,
+        [this, setTopic_prop2](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop2, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             Enum2::Enum2Enum prop2 = value.get<Enum2::Enum2Enum>();
@@ -94,7 +107,9 @@ void MqttSameEnum2InterfaceAdapter::subscribeForPropertiesChanges()
 void MqttSameEnum2InterfaceAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_func1 = interfaceName() + "/rpc/func1";
+    m_pendingSubscriptions.push_back(invokeTopic_func1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func1,
+        [this, invokeTopic_func1](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func1, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             Enum1::Enum1Enum param1 = arguments.at(0).get<Enum1::Enum1Enum>();
@@ -102,7 +117,9 @@ void MqttSameEnum2InterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_func2 = interfaceName() + "/rpc/func2";
+    m_pendingSubscriptions.push_back(invokeTopic_func2);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func2,
+        [this, invokeTopic_func2](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func2, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             Enum1::Enum1Enum param1 = arguments.at(0).get<Enum1::Enum1Enum>();
@@ -151,6 +168,25 @@ void MqttSameEnum2InterfaceAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttSameEnum2InterfaceAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/tb_same2/mqtt/mqttsameenum2interfaceadapter.h
+++ b/goldenmaster/tb_same2/mqtt/mqttsameenum2interfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttSameEnum2InterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttSameEnum2InterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a SameEnum2Interface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_same2

--- a/goldenmaster/tb_same2/mqtt/mqttsamestruct1interface.cpp
+++ b/goldenmaster/tb_same2/mqtt/mqttsamestruct1interface.cpp
@@ -109,11 +109,14 @@ QFuture<Struct1> MqttSameStruct1Interface::func1Async(const Struct1& param1)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func1");
     auto promise = std::make_shared<QPromise<Struct1>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(Struct1());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -121,7 +124,9 @@ QFuture<Struct1> MqttSameStruct1Interface::func1Async(const Struct1& param1)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(Struct1());
+        promise->addResult(Struct1());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1 });       
@@ -130,6 +135,7 @@ QFuture<Struct1> MqttSameStruct1Interface::func1Async(const Struct1& param1)
         {
             Struct1 value = arg.get<Struct1>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/tb_same2/mqtt/mqttsamestruct1interface.cpp
+++ b/goldenmaster/tb_same2/mqtt/mqttsamestruct1interface.cpp
@@ -138,12 +138,12 @@ const QString& MqttSameStruct1Interface::interfaceName()
 }
 void MqttSameStruct1Interface::subscribeForPropertiesChanges()
 {
-        static const QString topicprop1 = interfaceName() + "/prop/prop1";
+        const QString topicprop1 = interfaceName() + "/prop/prop1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
 }
 void MqttSameStruct1Interface::subscribeForSignals()
 {
-        static const QString topicsig1 = interfaceName() + "/sig/sig1";
+        const QString topicsig1 = interfaceName() + "/sig/sig1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
             emit sig1(argumentsArray[0].get<Struct1>());}));
 }

--- a/goldenmaster/tb_same2/mqtt/mqttsamestruct1interface.h
+++ b/goldenmaster/tb_same2/mqtt/mqttsamestruct1interface.h
@@ -68,12 +68,16 @@ public:
     * Remote call of ISameStruct1Interface::func1 on the SameStruct1Interface service.
     */
     QFuture<Struct1> func1Async(const Struct1& param1);
+    /**
+    * Use to check if the MqttSameStruct1Interface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttSameStruct1Interface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -99,9 +103,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttSameStruct1Interface.
     * Handles incoming and outgoing messages.
@@ -129,6 +135,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_same2

--- a/goldenmaster/tb_same2/mqtt/mqttsamestruct1interfaceadapter.cpp
+++ b/goldenmaster/tb_same2/mqtt/mqttsamestruct1interfaceadapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "tb.same2/SameStruct1Interface";
 MqttSameStruct1InterfaceAdapter::MqttSameStruct1InterfaceAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractSameStruct1Interface> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -53,12 +54,14 @@ MqttSameStruct1InterfaceAdapter::MqttSameStruct1InterfaceAdapter(ApiGear::Mqtt::
         subscribeForInvokeRequests();
         connectServicePropertiesChanges();
         connectServiceSignals();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttSameStruct1InterfaceAdapter::~MqttSameStruct1InterfaceAdapter()
@@ -68,6 +71,12 @@ MqttSameStruct1InterfaceAdapter::~MqttSameStruct1InterfaceAdapter()
     unsubscribeAll();
 }
 
+bool MqttSameStruct1InterfaceAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
+
 const QString& MqttSameStruct1InterfaceAdapter::interfaceName()
 {
     return InterfaceName;
@@ -76,7 +85,9 @@ const QString& MqttSameStruct1InterfaceAdapter::interfaceName()
 void MqttSameStruct1InterfaceAdapter::subscribeForPropertiesChanges()
 {
     const auto setTopic_prop1 = interfaceName() + "/set/prop1";
+    m_pendingSubscriptions.push_back(setTopic_prop1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop1,
+        [this, setTopic_prop1](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop1, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             Struct1 prop1 = value.get<Struct1>();
@@ -87,7 +98,9 @@ void MqttSameStruct1InterfaceAdapter::subscribeForPropertiesChanges()
 void MqttSameStruct1InterfaceAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_func1 = interfaceName() + "/rpc/func1";
+    m_pendingSubscriptions.push_back(invokeTopic_func1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func1,
+        [this, invokeTopic_func1](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func1, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             Struct1 param1 = arguments.at(0).get<Struct1>();
@@ -122,6 +135,25 @@ void MqttSameStruct1InterfaceAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttSameStruct1InterfaceAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/tb_same2/mqtt/mqttsamestruct1interfaceadapter.h
+++ b/goldenmaster/tb_same2/mqtt/mqttsamestruct1interfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttSameStruct1InterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttSameStruct1InterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a SameStruct1Interface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_same2

--- a/goldenmaster/tb_same2/mqtt/mqttsamestruct2interface.cpp
+++ b/goldenmaster/tb_same2/mqtt/mqttsamestruct2interface.cpp
@@ -34,7 +34,7 @@ MqttSameStruct2Interface::MqttSameStruct2Interface(ApiGear::Mqtt::Client& client
     : AbstractSameStruct2Interface(parent)
     , m_prop1(Struct2())
     , m_prop2(Struct2())
-    , m_isReady(false)
+    , m_finishedInitialization(false)
     , m_client(client)
 {
     if (m_client.isReady())
@@ -48,11 +48,13 @@ MqttSameStruct2Interface::MqttSameStruct2Interface(ApiGear::Mqtt::Client& client
             subscribeForPropertiesChanges();
             subscribeForSignals();
             subscribeForInvokeResponses();
+            m_finishedInitialization = true;
     });
     connect(&m_client, &ApiGear::Mqtt::Client::disconnected, [this](){
         m_subscribedIds.clear();
         m_InvokeCallsInfo.clear();
     });
+    m_finishedInitialization = m_client.isReady();
 }
 
 MqttSameStruct2Interface::~MqttSameStruct2Interface()
@@ -60,6 +62,11 @@ MqttSameStruct2Interface::~MqttSameStruct2Interface()
     disconnect(&m_client, &ApiGear::Mqtt::Client::disconnected, 0, 0);
     disconnect(&m_client, &ApiGear::Mqtt::Client::ready, 0, 0);
     unsubscribeAll();
+}
+
+bool MqttSameStruct2Interface::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
 }
 
 void MqttSameStruct2Interface::setProp1(const Struct2& prop1)
@@ -207,27 +214,60 @@ const QString& MqttSameStruct2Interface::interfaceName()
 {
     return InterfaceName;
 }
+
+void MqttSameStruct2Interface::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
+    }
+}
 void MqttSameStruct2Interface::subscribeForPropertiesChanges()
 {
+        // Subscription may succeed, before finising the function that subscribes it and assigns an id for if it was already added (and succeeded) for same topic,
+        // hence, for pending subscriptions a topic is used, and added before the subscribe function.
         const QString topicprop1 = interfaceName() + "/prop/prop1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
+        m_pendingSubscriptions.push_back(topicprop1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1,
+            [this, topicprop1](auto id, bool hasSucceed){handleOnSubscribed(topicprop1, id, hasSucceed);},
+            [this](auto& value) { setProp1Local(value);}));
         const QString topicprop2 = interfaceName() + "/prop/prop2";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2, [this](auto& value) { setProp2Local(value);}));
+        m_pendingSubscriptions.push_back(topicprop2);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2,
+            [this, topicprop2](auto id, bool hasSucceed){handleOnSubscribed(topicprop2, id, hasSucceed);},
+            [this](auto& value) { setProp2Local(value);}));
 }
 void MqttSameStruct2Interface::subscribeForSignals()
 {
         const QString topicsig1 = interfaceName() + "/sig/sig1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
-            emit sig1(argumentsArray[0].get<Struct1>());}));
+        m_pendingSubscriptions.push_back(topicsig1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1,
+            [this, topicsig1](auto id, bool hasSucceed){handleOnSubscribed(topicsig1, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sig1(argumentsArray[0].get<Struct1>());}));
         const QString topicsig2 = interfaceName() + "/sig/sig2";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2, [this](const nlohmann::json& argumentsArray){
-            emit sig2(argumentsArray[0].get<Struct1>(),argumentsArray[1].get<Struct2>());}));
+        m_pendingSubscriptions.push_back(topicsig2);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2,
+            [this, topicsig2](auto id, bool hasSucceed){handleOnSubscribed(topicsig2, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sig2(argumentsArray[0].get<Struct1>(), argumentsArray[1].get<Struct2>());}));
 }
 void MqttSameStruct2Interface::subscribeForInvokeResponses()
 {
     const QString topicfunc1 = interfaceName() + "/rpc/func1";
     const QString topicfunc1InvokeResp = interfaceName() + "/rpc/func1"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfunc1InvokeResp);
     auto id_func1 = m_client.subscribeForInvokeResponse(topicfunc1InvokeResp, 
+                        [this, topicfunc1InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfunc1InvokeResp, id, hasSucceed);},
                         [this, topicfunc1InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfunc1InvokeResp);
@@ -235,7 +275,9 @@ void MqttSameStruct2Interface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfunc1] = std::make_pair(topicfunc1InvokeResp, id_func1);
     const QString topicfunc2 = interfaceName() + "/rpc/func2";
     const QString topicfunc2InvokeResp = interfaceName() + "/rpc/func2"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfunc2InvokeResp);
     auto id_func2 = m_client.subscribeForInvokeResponse(topicfunc2InvokeResp, 
+                        [this, topicfunc2InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfunc2InvokeResp, id, hasSucceed);},
                         [this, topicfunc2InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfunc2InvokeResp);

--- a/goldenmaster/tb_same2/mqtt/mqttsamestruct2interface.cpp
+++ b/goldenmaster/tb_same2/mqtt/mqttsamestruct2interface.cpp
@@ -137,11 +137,14 @@ QFuture<Struct1> MqttSameStruct2Interface::func1Async(const Struct1& param1)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func1");
     auto promise = std::make_shared<QPromise<Struct1>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(Struct1());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -149,7 +152,9 @@ QFuture<Struct1> MqttSameStruct2Interface::func1Async(const Struct1& param1)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(Struct1());
+        promise->addResult(Struct1());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1 });       
@@ -158,6 +163,7 @@ QFuture<Struct1> MqttSameStruct2Interface::func1Async(const Struct1& param1)
         {
             Struct1 value = arg.get<Struct1>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -180,11 +186,14 @@ QFuture<Struct1> MqttSameStruct2Interface::func2Async(const Struct1& param1, con
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func2");
     auto promise = std::make_shared<QPromise<Struct1>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(Struct1());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -192,7 +201,9 @@ QFuture<Struct1> MqttSameStruct2Interface::func2Async(const Struct1& param1, con
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(Struct1());
+        promise->addResult(Struct1());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1, param2 });       
@@ -201,6 +212,7 @@ QFuture<Struct1> MqttSameStruct2Interface::func2Async(const Struct1& param1, con
         {
             Struct1 value = arg.get<Struct1>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/tb_same2/mqtt/mqttsamestruct2interface.cpp
+++ b/goldenmaster/tb_same2/mqtt/mqttsamestruct2interface.cpp
@@ -209,17 +209,17 @@ const QString& MqttSameStruct2Interface::interfaceName()
 }
 void MqttSameStruct2Interface::subscribeForPropertiesChanges()
 {
-        static const QString topicprop1 = interfaceName() + "/prop/prop1";
+        const QString topicprop1 = interfaceName() + "/prop/prop1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
-        static const QString topicprop2 = interfaceName() + "/prop/prop2";
+        const QString topicprop2 = interfaceName() + "/prop/prop2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2, [this](auto& value) { setProp2Local(value);}));
 }
 void MqttSameStruct2Interface::subscribeForSignals()
 {
-        static const QString topicsig1 = interfaceName() + "/sig/sig1";
+        const QString topicsig1 = interfaceName() + "/sig/sig1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
             emit sig1(argumentsArray[0].get<Struct1>());}));
-        static const QString topicsig2 = interfaceName() + "/sig/sig2";
+        const QString topicsig2 = interfaceName() + "/sig/sig2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2, [this](const nlohmann::json& argumentsArray){
             emit sig2(argumentsArray[0].get<Struct1>(),argumentsArray[1].get<Struct2>());}));
 }

--- a/goldenmaster/tb_same2/mqtt/mqttsamestruct2interface.h
+++ b/goldenmaster/tb_same2/mqtt/mqttsamestruct2interface.h
@@ -87,12 +87,16 @@ public:
     * Remote call of ISameStruct2Interface::func2 on the SameStruct2Interface service.
     */
     QFuture<Struct1> func2Async(const Struct1& param1, const Struct2& param2);
+    /**
+    * Use to check if the MqttSameStruct2Interface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttSameStruct2Interface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -122,9 +126,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttSameStruct2Interface.
     * Handles incoming and outgoing messages.
@@ -152,6 +158,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_same2

--- a/goldenmaster/tb_same2/mqtt/mqttsamestruct2interfaceadapter.h
+++ b/goldenmaster/tb_same2/mqtt/mqttsamestruct2interfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttSameStruct2InterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttSameStruct2InterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a SameStruct2Interface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_same2

--- a/goldenmaster/tb_same2/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/tb_same2/mqtt/tests/CMakeLists.txt
@@ -29,6 +29,10 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 endif()
 
 set(TEST_TB_SAME2_GENERATED_MQTT_SOURCES
+    test_mqttsamestruct1interface.cpp
+    test_mqttsamestruct2interface.cpp
+    test_mqttsameenum1interface.cpp
+    test_mqttsameenum2interface.cpp
     test_main.cpp
     )
 

--- a/goldenmaster/tb_same2/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/tb_same2/mqtt/tests/CMakeLists.txt
@@ -1,0 +1,60 @@
+
+cmake_minimum_required(VERSION 3.20)
+project(test_tb_same2_generated_mqtt)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(BUILD_TESTING)
+include(CTest)
+enable_testing()
+
+find_package(Qt6 REQUIRED COMPONENTS Test Core)
+find_package(apigear QUIET COMPONENTS apigear_mqtt)
+find_package(tb_same2 QUIET COMPONENTS tb_same2_impl tb_same2_mqtt)
+
+find_package(Catch2 REQUIRED)
+
+set(CMAKE_CTEST_COMMAND ctest -V)
+if(NOT TARGET check)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+set(TEST_TB_SAME2_GENERATED_MQTT_SOURCES
+    test_main.cpp
+    )
+
+include_directories(test_tb_same2_generated_mqtt
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+add_executable(test_tb_same2_generated_mqtt ${TEST_TB_SAME2_GENERATED_MQTT_SOURCES})
+add_test(NAME test_tb_same2_generated_mqtt COMMAND $<TARGET_FILE:test_tb_same2_generated_mqtt>)
+add_dependencies(check test_tb_same2_generated_mqtt)
+
+target_link_libraries(test_tb_same2_generated_mqtt PRIVATE
+    apigear_mqtt
+    tb_same2_impl
+    tb_same2_mqtt
+    Catch2::Catch2
+    Qt::Test)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_tb_same2_generated_mqtt
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+
+endif() # BUILD_TESTING

--- a/goldenmaster/tb_same2/mqtt/tests/test_main.cpp
+++ b/goldenmaster/tb_same2/mqtt/tests/test_main.cpp
@@ -1,0 +1,12 @@
+#define CATCH_CONFIG_RUNNER
+
+#include <QCoreApplication>
+#include <catch2/catch.hpp>
+
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv); // -platform offscreen
+    int result = Catch::Session().run(argc, argv); // --break
+    return result;
+}

--- a/goldenmaster/tb_same2/mqtt/tests/test_mqttsameenum1interface.cpp
+++ b/goldenmaster/tb_same2/mqtt/tests/test_mqttsameenum1interface.cpp
@@ -1,0 +1,117 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/sameenum1interface.h"
+#include "mqtt/mqttsameenum1interface.h"
+#include "mqtt/mqttsameenum1interfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.same2 SameEnum1Interface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientSameEnum1Interface = std::make_shared<tb_same2::MqttSameEnum1Interface >(client);
+    auto implSameEnum1Interface = std::make_shared<tb_same2::SameEnum1Interface>();
+    auto serviceSameEnum1Interface = std::make_shared<tb_same2::MqttSameEnum1InterfaceAdapter>(service, implSameEnum1Interface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientSameEnum1Interface, &serviceSameEnum1Interface]() {return clientSameEnum1Interface->isReady() && serviceSameEnum1Interface->isReady(); }, timeout));
+    SECTION("Test setting prop1")
+    {
+        std::atomic<bool> isprop1Changed = false;
+        clientSameEnum1Interface->connect(clientSameEnum1Interface.get(), &tb_same2::AbstractSameEnum1Interface::prop1Changed, [&isprop1Changed ](auto value){isprop1Changed  = true;});
+        auto test_value = tb_same2::Enum1::Value2;
+        clientSameEnum1Interface->setProp1(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop1Changed]() {return isprop1Changed  == true; }, timeout));
+        REQUIRE(implSameEnum1Interface->prop1() == test_value);
+        REQUIRE(clientSameEnum1Interface->prop1() == test_value);
+    }
+    SECTION("Test emit sig1")
+    {
+        std::atomic<bool> issig1Emitted = false;
+
+        clientSameEnum1Interface->connect(clientSameEnum1Interface.get(), &tb_same2::AbstractSameEnum1Interface::sig1,
+        [&issig1Emitted](tb_same2::Enum1::Enum1Enum param1)
+        {
+            REQUIRE(param1 == tb_same2::Enum1::Value2);
+            issig1Emitted  = true;
+        });
+
+        emit implSameEnum1Interface->sig1(tb_same2::Enum1::Value2);
+        REQUIRE(QTest::qWaitFor([&issig1Emitted ]() {return issig1Emitted   == true; }, timeout));
+    }
+    SECTION("Test method func1")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSameEnum1Interface, &finished](){
+            [[maybe_unused]] auto result = clientSameEnum1Interface->func1(tb_same2::Enum1::Value1);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func1 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSameEnum1Interface->func1Async(tb_same2::Enum1::Value1);
+        resultFuture.then([&finished](tb_same2::Enum1::Enum1Enum /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_same2::Enum1::Value1);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientSameEnum1Interface.reset();
+    serviceSameEnum1Interface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_same2/mqtt/tests/test_mqttsameenum2interface.cpp
+++ b/goldenmaster/tb_same2/mqtt/tests/test_mqttsameenum2interface.cpp
@@ -1,0 +1,166 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/sameenum2interface.h"
+#include "mqtt/mqttsameenum2interface.h"
+#include "mqtt/mqttsameenum2interfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.same2 SameEnum2Interface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientSameEnum2Interface = std::make_shared<tb_same2::MqttSameEnum2Interface >(client);
+    auto implSameEnum2Interface = std::make_shared<tb_same2::SameEnum2Interface>();
+    auto serviceSameEnum2Interface = std::make_shared<tb_same2::MqttSameEnum2InterfaceAdapter>(service, implSameEnum2Interface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientSameEnum2Interface, &serviceSameEnum2Interface]() {return clientSameEnum2Interface->isReady() && serviceSameEnum2Interface->isReady(); }, timeout));
+    SECTION("Test setting prop1")
+    {
+        std::atomic<bool> isprop1Changed = false;
+        clientSameEnum2Interface->connect(clientSameEnum2Interface.get(), &tb_same2::AbstractSameEnum2Interface::prop1Changed, [&isprop1Changed ](auto value){isprop1Changed  = true;});
+        auto test_value = tb_same2::Enum1::Value2;
+        clientSameEnum2Interface->setProp1(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop1Changed]() {return isprop1Changed  == true; }, timeout));
+        REQUIRE(implSameEnum2Interface->prop1() == test_value);
+        REQUIRE(clientSameEnum2Interface->prop1() == test_value);
+    }
+    SECTION("Test setting prop2")
+    {
+        std::atomic<bool> isprop2Changed = false;
+        clientSameEnum2Interface->connect(clientSameEnum2Interface.get(), &tb_same2::AbstractSameEnum2Interface::prop2Changed, [&isprop2Changed ](auto value){isprop2Changed  = true;});
+        auto test_value = tb_same2::Enum2::Value2;
+        clientSameEnum2Interface->setProp2(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop2Changed]() {return isprop2Changed  == true; }, timeout));
+        REQUIRE(implSameEnum2Interface->prop2() == test_value);
+        REQUIRE(clientSameEnum2Interface->prop2() == test_value);
+    }
+    SECTION("Test emit sig1")
+    {
+        std::atomic<bool> issig1Emitted = false;
+
+        clientSameEnum2Interface->connect(clientSameEnum2Interface.get(), &tb_same2::AbstractSameEnum2Interface::sig1,
+        [&issig1Emitted](tb_same2::Enum1::Enum1Enum param1)
+        {
+            REQUIRE(param1 == tb_same2::Enum1::Value2);
+            issig1Emitted  = true;
+        });
+
+        emit implSameEnum2Interface->sig1(tb_same2::Enum1::Value2);
+        REQUIRE(QTest::qWaitFor([&issig1Emitted ]() {return issig1Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sig2")
+    {
+        std::atomic<bool> issig2Emitted = false;
+
+        clientSameEnum2Interface->connect(clientSameEnum2Interface.get(), &tb_same2::AbstractSameEnum2Interface::sig2,
+        [&issig2Emitted](tb_same2::Enum1::Enum1Enum param1, tb_same2::Enum2::Enum2Enum param2)
+        {
+            REQUIRE(param1 == tb_same2::Enum1::Value2);
+            REQUIRE(param2 == tb_same2::Enum2::Value2);
+            issig2Emitted  = true;
+        });
+
+        emit implSameEnum2Interface->sig2(tb_same2::Enum1::Value2, tb_same2::Enum2::Value2);
+        REQUIRE(QTest::qWaitFor([&issig2Emitted ]() {return issig2Emitted   == true; }, timeout));
+    }
+    SECTION("Test method func1")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSameEnum2Interface, &finished](){
+            [[maybe_unused]] auto result = clientSameEnum2Interface->func1(tb_same2::Enum1::Value1);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func1 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSameEnum2Interface->func1Async(tb_same2::Enum1::Value1);
+        resultFuture.then([&finished](tb_same2::Enum1::Enum1Enum /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_same2::Enum1::Value1);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method func2")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSameEnum2Interface, &finished](){
+            [[maybe_unused]] auto result = clientSameEnum2Interface->func2(tb_same2::Enum1::Value1, tb_same2::Enum2::Value1);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func2 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSameEnum2Interface->func2Async(tb_same2::Enum1::Value1, tb_same2::Enum2::Value1);
+        resultFuture.then([&finished](tb_same2::Enum1::Enum1Enum /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_same2::Enum1::Value1);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientSameEnum2Interface.reset();
+    serviceSameEnum2Interface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_same2/mqtt/tests/test_mqttsamestruct1interface.cpp
+++ b/goldenmaster/tb_same2/mqtt/tests/test_mqttsamestruct1interface.cpp
@@ -1,0 +1,120 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/samestruct1interface.h"
+#include "mqtt/mqttsamestruct1interface.h"
+#include "mqtt/mqttsamestruct1interfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.same2 SameStruct1Interface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientSameStruct1Interface = std::make_shared<tb_same2::MqttSameStruct1Interface >(client);
+    auto implSameStruct1Interface = std::make_shared<tb_same2::SameStruct1Interface>();
+    auto serviceSameStruct1Interface = std::make_shared<tb_same2::MqttSameStruct1InterfaceAdapter>(service, implSameStruct1Interface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientSameStruct1Interface, &serviceSameStruct1Interface]() {return clientSameStruct1Interface->isReady() && serviceSameStruct1Interface->isReady(); }, timeout));
+    SECTION("Test setting prop1")
+    {
+        std::atomic<bool> isprop1Changed = false;
+        clientSameStruct1Interface->connect(clientSameStruct1Interface.get(), &tb_same2::AbstractSameStruct1Interface::prop1Changed, [&isprop1Changed ](auto value){isprop1Changed  = true;});
+        auto test_value = tb_same2::Struct1();
+        tb_same2::fillTestStruct1(test_value);
+        clientSameStruct1Interface->setProp1(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop1Changed]() {return isprop1Changed  == true; }, timeout));
+        REQUIRE(implSameStruct1Interface->prop1() == test_value);
+        REQUIRE(clientSameStruct1Interface->prop1() == test_value);
+    }
+    SECTION("Test emit sig1")
+    {
+        std::atomic<bool> issig1Emitted = false;
+        auto local_param1_struct = tb_same2::Struct1();
+        tb_same2::fillTestStruct1(local_param1_struct);
+
+        clientSameStruct1Interface->connect(clientSameStruct1Interface.get(), &tb_same2::AbstractSameStruct1Interface::sig1,
+        [&issig1Emitted, &local_param1_struct](const tb_same2::Struct1& param1)
+        {
+            REQUIRE(param1 ==local_param1_struct);
+            issig1Emitted  = true;
+        });
+
+        emit implSameStruct1Interface->sig1(local_param1_struct);
+        REQUIRE(QTest::qWaitFor([&issig1Emitted ]() {return issig1Emitted   == true; }, timeout));
+    }
+    SECTION("Test method func1")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSameStruct1Interface, &finished](){
+            [[maybe_unused]] auto result = clientSameStruct1Interface->func1(tb_same2::Struct1());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func1 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSameStruct1Interface->func1Async(tb_same2::Struct1());
+        resultFuture.then([&finished](tb_same2::Struct1 /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_same2::Struct1());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientSameStruct1Interface.reset();
+    serviceSameStruct1Interface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_same2/mqtt/tests/test_mqttsamestruct2interface.cpp
+++ b/goldenmaster/tb_same2/mqtt/tests/test_mqttsamestruct2interface.cpp
@@ -1,0 +1,174 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/samestruct2interface.h"
+#include "mqtt/mqttsamestruct2interface.h"
+#include "mqtt/mqttsamestruct2interfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.same2 SameStruct2Interface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientSameStruct2Interface = std::make_shared<tb_same2::MqttSameStruct2Interface >(client);
+    auto implSameStruct2Interface = std::make_shared<tb_same2::SameStruct2Interface>();
+    auto serviceSameStruct2Interface = std::make_shared<tb_same2::MqttSameStruct2InterfaceAdapter>(service, implSameStruct2Interface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientSameStruct2Interface, &serviceSameStruct2Interface]() {return clientSameStruct2Interface->isReady() && serviceSameStruct2Interface->isReady(); }, timeout));
+    SECTION("Test setting prop1")
+    {
+        std::atomic<bool> isprop1Changed = false;
+        clientSameStruct2Interface->connect(clientSameStruct2Interface.get(), &tb_same2::AbstractSameStruct2Interface::prop1Changed, [&isprop1Changed ](auto value){isprop1Changed  = true;});
+        auto test_value = tb_same2::Struct2();
+        tb_same2::fillTestStruct2(test_value);
+        clientSameStruct2Interface->setProp1(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop1Changed]() {return isprop1Changed  == true; }, timeout));
+        REQUIRE(implSameStruct2Interface->prop1() == test_value);
+        REQUIRE(clientSameStruct2Interface->prop1() == test_value);
+    }
+    SECTION("Test setting prop2")
+    {
+        std::atomic<bool> isprop2Changed = false;
+        clientSameStruct2Interface->connect(clientSameStruct2Interface.get(), &tb_same2::AbstractSameStruct2Interface::prop2Changed, [&isprop2Changed ](auto value){isprop2Changed  = true;});
+        auto test_value = tb_same2::Struct2();
+        tb_same2::fillTestStruct2(test_value);
+        clientSameStruct2Interface->setProp2(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop2Changed]() {return isprop2Changed  == true; }, timeout));
+        REQUIRE(implSameStruct2Interface->prop2() == test_value);
+        REQUIRE(clientSameStruct2Interface->prop2() == test_value);
+    }
+    SECTION("Test emit sig1")
+    {
+        std::atomic<bool> issig1Emitted = false;
+        auto local_param1_struct = tb_same2::Struct1();
+        tb_same2::fillTestStruct1(local_param1_struct);
+
+        clientSameStruct2Interface->connect(clientSameStruct2Interface.get(), &tb_same2::AbstractSameStruct2Interface::sig1,
+        [&issig1Emitted, &local_param1_struct](const tb_same2::Struct1& param1)
+        {
+            REQUIRE(param1 ==local_param1_struct);
+            issig1Emitted  = true;
+        });
+
+        emit implSameStruct2Interface->sig1(local_param1_struct);
+        REQUIRE(QTest::qWaitFor([&issig1Emitted ]() {return issig1Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sig2")
+    {
+        std::atomic<bool> issig2Emitted = false;
+        auto local_param1_struct = tb_same2::Struct1();
+        tb_same2::fillTestStruct1(local_param1_struct);
+        auto local_param2_struct = tb_same2::Struct2();
+        tb_same2::fillTestStruct2(local_param2_struct);
+
+        clientSameStruct2Interface->connect(clientSameStruct2Interface.get(), &tb_same2::AbstractSameStruct2Interface::sig2,
+        [&issig2Emitted, &local_param1_struct, &local_param2_struct](const tb_same2::Struct1& param1, const tb_same2::Struct2& param2)
+        {
+            REQUIRE(param1 ==local_param1_struct);
+            REQUIRE(param2 ==local_param2_struct);
+            issig2Emitted  = true;
+        });
+
+        emit implSameStruct2Interface->sig2(local_param1_struct, local_param2_struct);
+        REQUIRE(QTest::qWaitFor([&issig2Emitted ]() {return issig2Emitted   == true; }, timeout));
+    }
+    SECTION("Test method func1")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSameStruct2Interface, &finished](){
+            [[maybe_unused]] auto result = clientSameStruct2Interface->func1(tb_same2::Struct1());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func1 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSameStruct2Interface->func1Async(tb_same2::Struct1());
+        resultFuture.then([&finished](tb_same2::Struct1 /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_same2::Struct1());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method func2")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSameStruct2Interface, &finished](){
+            [[maybe_unused]] auto result = clientSameStruct2Interface->func2(tb_same2::Struct1(), tb_same2::Struct2());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func2 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSameStruct2Interface->func2Async(tb_same2::Struct1(), tb_same2::Struct2());
+        resultFuture.then([&finished](tb_same2::Struct1 /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == tb_same2::Struct1());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientSameStruct2Interface.reset();
+    serviceSameStruct2Interface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_simple/mqtt/CMakeLists.txt
+++ b/goldenmaster/tb_simple/mqtt/CMakeLists.txt
@@ -41,6 +41,10 @@ target_include_directories(tb_simple_mqtt
     $<INSTALL_INTERFACE:include/tb_simple>
 )
 
+if (ENABLE_MQTT_TEST_FOR_NON_LINUX_OS OR ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")))
+add_subdirectory(tests)
+endif()
+
 target_link_libraries(tb_simple_mqtt PUBLIC tb_simple::tb_simple_api apigear::apigear_mqtt Qt6::Concurrent)
 target_compile_definitions(tb_simple_mqtt PRIVATE TB_SIMPLE_MQTT_LIBRARY)
 

--- a/goldenmaster/tb_simple/mqtt/mqttnooperationsinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttnooperationsinterface.cpp
@@ -121,17 +121,17 @@ const QString& MqttNoOperationsInterface::interfaceName()
 }
 void MqttNoOperationsInterface::subscribeForPropertiesChanges()
 {
-        static const QString topicpropBool = interfaceName() + "/prop/propBool";
+        const QString topicpropBool = interfaceName() + "/prop/propBool";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropBool, [this](auto& value) { setPropBoolLocal(value);}));
-        static const QString topicpropInt = interfaceName() + "/prop/propInt";
+        const QString topicpropInt = interfaceName() + "/prop/propInt";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt, [this](auto& value) { setPropIntLocal(value);}));
 }
 void MqttNoOperationsInterface::subscribeForSignals()
 {
-        static const QString topicsigVoid = interfaceName() + "/sig/sigVoid";
+        const QString topicsigVoid = interfaceName() + "/sig/sigVoid";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigVoid, [this](const nlohmann::json& argumentsArray){
             emit sigVoid();}));
-        static const QString topicsigBool = interfaceName() + "/sig/sigBool";
+        const QString topicsigBool = interfaceName() + "/sig/sigBool";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigBool, [this](const nlohmann::json& argumentsArray){
             emit sigBool(argumentsArray[0].get<bool>());}));
 }

--- a/goldenmaster/tb_simple/mqtt/mqttnooperationsinterface.h
+++ b/goldenmaster/tb_simple/mqtt/mqttnooperationsinterface.h
@@ -69,12 +69,16 @@ public:
     * @param The value to which set request is send for the PropInt.
     */
     void setPropInt(int propInt) override;
+    /**
+    * Use to check if the MqttNoOperationsInterface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttNoOperationsInterface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -102,9 +106,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttNoOperationsInterface.
     * Handles incoming and outgoing messages.
@@ -132,6 +138,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_simple

--- a/goldenmaster/tb_simple/mqtt/mqttnooperationsinterfaceadapter.h
+++ b/goldenmaster/tb_simple/mqtt/mqttnooperationsinterfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttNoOperationsInterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttNoOperationsInterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -66,6 +75,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a NoOperationsInterface that gets adapted to be a service in mqtt network.
@@ -76,8 +87,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_simple

--- a/goldenmaster/tb_simple/mqtt/mqttnopropertiesinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttnopropertiesinterface.cpp
@@ -150,10 +150,10 @@ const QString& MqttNoPropertiesInterface::interfaceName()
 }
 void MqttNoPropertiesInterface::subscribeForSignals()
 {
-        static const QString topicsigVoid = interfaceName() + "/sig/sigVoid";
+        const QString topicsigVoid = interfaceName() + "/sig/sigVoid";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigVoid, [this](const nlohmann::json& argumentsArray){
             emit sigVoid();}));
-        static const QString topicsigBool = interfaceName() + "/sig/sigBool";
+        const QString topicsigBool = interfaceName() + "/sig/sigBool";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigBool, [this](const nlohmann::json& argumentsArray){
             emit sigBool(argumentsArray[0].get<bool>());}));
 }

--- a/goldenmaster/tb_simple/mqtt/mqttnopropertiesinterface.h
+++ b/goldenmaster/tb_simple/mqtt/mqttnopropertiesinterface.h
@@ -67,12 +67,16 @@ public:
     * Remote call of INoPropertiesInterface::funcBool on the NoPropertiesInterface service.
     */
     QFuture<bool> funcBoolAsync(bool paramBool);
+    /**
+    * Use to check if the MqttNoPropertiesInterface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttNoPropertiesInterface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -92,9 +96,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttNoPropertiesInterface.
     * Handles incoming and outgoing messages.
@@ -122,6 +128,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_simple

--- a/goldenmaster/tb_simple/mqtt/mqttnopropertiesinterfaceadapter.h
+++ b/goldenmaster/tb_simple/mqtt/mqttnopropertiesinterfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttNoPropertiesInterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttNoPropertiesInterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for methods invoke requests from remote clients.
     void subscribeForInvokeRequests();
@@ -64,6 +73,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a NoPropertiesInterface that gets adapted to be a service in mqtt network.
@@ -74,8 +85,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_simple

--- a/goldenmaster/tb_simple/mqtt/mqttnosignalsinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttnosignalsinterface.cpp
@@ -135,11 +135,13 @@ QFuture<void> MqttNoSignalsInterface::funcVoidAsync()
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcVoid");
     auto promise = std::make_shared<QPromise<void>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->finish();
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -147,7 +149,8 @@ QFuture<void> MqttNoSignalsInterface::funcVoidAsync()
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->finish();
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({ });       
@@ -177,11 +180,14 @@ QFuture<bool> MqttNoSignalsInterface::funcBoolAsync(bool paramBool)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcBool");
     auto promise = std::make_shared<QPromise<bool>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(false);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -189,7 +195,9 @@ QFuture<bool> MqttNoSignalsInterface::funcBoolAsync(bool paramBool)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(false);
+        promise->addResult(false);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramBool });       
@@ -198,6 +206,7 @@ QFuture<bool> MqttNoSignalsInterface::funcBoolAsync(bool paramBool)
         {
             bool value = arg.get<bool>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/tb_simple/mqtt/mqttnosignalsinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttnosignalsinterface.cpp
@@ -206,9 +206,9 @@ const QString& MqttNoSignalsInterface::interfaceName()
 }
 void MqttNoSignalsInterface::subscribeForPropertiesChanges()
 {
-        static const QString topicpropBool = interfaceName() + "/prop/propBool";
+        const QString topicpropBool = interfaceName() + "/prop/propBool";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropBool, [this](auto& value) { setPropBoolLocal(value);}));
-        static const QString topicpropInt = interfaceName() + "/prop/propInt";
+        const QString topicpropInt = interfaceName() + "/prop/propInt";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt, [this](auto& value) { setPropIntLocal(value);}));
 }
 void MqttNoSignalsInterface::subscribeForInvokeResponses()

--- a/goldenmaster/tb_simple/mqtt/mqttnosignalsinterface.h
+++ b/goldenmaster/tb_simple/mqtt/mqttnosignalsinterface.h
@@ -87,12 +87,16 @@ public:
     * Remote call of INoSignalsInterface::funcBool on the NoSignalsInterface service.
     */
     QFuture<bool> funcBoolAsync(bool paramBool);
+    /**
+    * Use to check if the MqttNoSignalsInterface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttNoSignalsInterface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -120,9 +124,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttNoSignalsInterface.
     * Handles incoming and outgoing messages.
@@ -150,6 +156,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_simple

--- a/goldenmaster/tb_simple/mqtt/mqttnosignalsinterfaceadapter.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttnosignalsinterfaceadapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "tb.simple/NoSignalsInterface";
 MqttNoSignalsInterfaceAdapter::MqttNoSignalsInterfaceAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractNoSignalsInterface> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -51,12 +52,14 @@ MqttNoSignalsInterfaceAdapter::MqttNoSignalsInterfaceAdapter(ApiGear::Mqtt::Serv
         subscribeForPropertiesChanges();
         subscribeForInvokeRequests();
         connectServicePropertiesChanges();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttNoSignalsInterfaceAdapter::~MqttNoSignalsInterfaceAdapter()
@@ -66,6 +69,12 @@ MqttNoSignalsInterfaceAdapter::~MqttNoSignalsInterfaceAdapter()
     unsubscribeAll();
 }
 
+bool MqttNoSignalsInterfaceAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
+
 const QString& MqttNoSignalsInterfaceAdapter::interfaceName()
 {
     return InterfaceName;
@@ -74,14 +83,18 @@ const QString& MqttNoSignalsInterfaceAdapter::interfaceName()
 void MqttNoSignalsInterfaceAdapter::subscribeForPropertiesChanges()
 {
     const auto setTopic_propBool = interfaceName() + "/set/propBool";
+    m_pendingSubscriptions.push_back(setTopic_propBool);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propBool,
+        [this, setTopic_propBool](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propBool, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             bool propBool = value.get<bool>();
             m_impl->setPropBool(propBool);
         }));
     const auto setTopic_propInt = interfaceName() + "/set/propInt";
+    m_pendingSubscriptions.push_back(setTopic_propInt);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propInt,
+        [this, setTopic_propInt](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propInt, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             int propInt = value.get<int>();
@@ -92,14 +105,18 @@ void MqttNoSignalsInterfaceAdapter::subscribeForPropertiesChanges()
 void MqttNoSignalsInterfaceAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_funcVoid = interfaceName() + "/rpc/funcVoid";
+    m_pendingSubscriptions.push_back(invokeTopic_funcVoid);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcVoid,
+        [this, invokeTopic_funcVoid](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcVoid, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             m_impl->funcVoid( );
             return nlohmann::json {};
         }));
     const auto invokeTopic_funcBool = interfaceName() + "/rpc/funcBool";
+    m_pendingSubscriptions.push_back(invokeTopic_funcBool);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcBool,
+        [this, invokeTopic_funcBool](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcBool, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             bool paramBool = arguments.at(0).get<bool>();
@@ -130,6 +147,25 @@ void MqttNoSignalsInterfaceAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttNoSignalsInterfaceAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/tb_simple/mqtt/mqttnosignalsinterfaceadapter.h
+++ b/goldenmaster/tb_simple/mqtt/mqttnosignalsinterfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttNoSignalsInterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttNoSignalsInterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -66,6 +75,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a NoSignalsInterface that gets adapted to be a service in mqtt network.
@@ -76,8 +87,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_simple

--- a/goldenmaster/tb_simple/mqtt/mqttsimplearrayinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttsimplearrayinterface.cpp
@@ -663,49 +663,49 @@ const QString& MqttSimpleArrayInterface::interfaceName()
 }
 void MqttSimpleArrayInterface::subscribeForPropertiesChanges()
 {
-        static const QString topicpropBool = interfaceName() + "/prop/propBool";
+        const QString topicpropBool = interfaceName() + "/prop/propBool";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropBool, [this](auto& value) { setPropBoolLocal(value);}));
-        static const QString topicpropInt = interfaceName() + "/prop/propInt";
+        const QString topicpropInt = interfaceName() + "/prop/propInt";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt, [this](auto& value) { setPropIntLocal(value);}));
-        static const QString topicpropInt32 = interfaceName() + "/prop/propInt32";
+        const QString topicpropInt32 = interfaceName() + "/prop/propInt32";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt32, [this](auto& value) { setPropInt32Local(value);}));
-        static const QString topicpropInt64 = interfaceName() + "/prop/propInt64";
+        const QString topicpropInt64 = interfaceName() + "/prop/propInt64";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt64, [this](auto& value) { setPropInt64Local(value);}));
-        static const QString topicpropFloat = interfaceName() + "/prop/propFloat";
+        const QString topicpropFloat = interfaceName() + "/prop/propFloat";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat, [this](auto& value) { setPropFloatLocal(value);}));
-        static const QString topicpropFloat32 = interfaceName() + "/prop/propFloat32";
+        const QString topicpropFloat32 = interfaceName() + "/prop/propFloat32";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat32, [this](auto& value) { setPropFloat32Local(value);}));
-        static const QString topicpropFloat64 = interfaceName() + "/prop/propFloat64";
+        const QString topicpropFloat64 = interfaceName() + "/prop/propFloat64";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat64, [this](auto& value) { setPropFloat64Local(value);}));
-        static const QString topicpropString = interfaceName() + "/prop/propString";
+        const QString topicpropString = interfaceName() + "/prop/propString";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropString, [this](auto& value) { setPropStringLocal(value);}));
-        static const QString topicpropReadOnlyString = interfaceName() + "/prop/propReadOnlyString";
+        const QString topicpropReadOnlyString = interfaceName() + "/prop/propReadOnlyString";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropReadOnlyString, [this](auto& value) { setPropReadOnlyStringLocal(value);}));
 }
 void MqttSimpleArrayInterface::subscribeForSignals()
 {
-        static const QString topicsigBool = interfaceName() + "/sig/sigBool";
+        const QString topicsigBool = interfaceName() + "/sig/sigBool";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigBool, [this](const nlohmann::json& argumentsArray){
             emit sigBool(argumentsArray[0].get<QList<bool>>());}));
-        static const QString topicsigInt = interfaceName() + "/sig/sigInt";
+        const QString topicsigInt = interfaceName() + "/sig/sigInt";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt, [this](const nlohmann::json& argumentsArray){
             emit sigInt(argumentsArray[0].get<QList<int>>());}));
-        static const QString topicsigInt32 = interfaceName() + "/sig/sigInt32";
+        const QString topicsigInt32 = interfaceName() + "/sig/sigInt32";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt32, [this](const nlohmann::json& argumentsArray){
             emit sigInt32(argumentsArray[0].get<QList<qint32>>());}));
-        static const QString topicsigInt64 = interfaceName() + "/sig/sigInt64";
+        const QString topicsigInt64 = interfaceName() + "/sig/sigInt64";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt64, [this](const nlohmann::json& argumentsArray){
             emit sigInt64(argumentsArray[0].get<QList<qint64>>());}));
-        static const QString topicsigFloat = interfaceName() + "/sig/sigFloat";
+        const QString topicsigFloat = interfaceName() + "/sig/sigFloat";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat, [this](const nlohmann::json& argumentsArray){
             emit sigFloat(argumentsArray[0].get<QList<qreal>>());}));
-        static const QString topicsigFloat32 = interfaceName() + "/sig/sigFloat32";
+        const QString topicsigFloat32 = interfaceName() + "/sig/sigFloat32";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat32, [this](const nlohmann::json& argumentsArray){
             emit sigFloat32(argumentsArray[0].get<QList<float>>());}));
-        static const QString topicsigFloat64 = interfaceName() + "/sig/sigFloat64";
+        const QString topicsigFloat64 = interfaceName() + "/sig/sigFloat64";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat64, [this](const nlohmann::json& argumentsArray){
             emit sigFloat64(argumentsArray[0].get<QList<double>>());}));
-        static const QString topicsigString = interfaceName() + "/sig/sigString";
+        const QString topicsigString = interfaceName() + "/sig/sigString";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigString, [this](const nlohmann::json& argumentsArray){
             emit sigString(argumentsArray[0].get<QList<QString>>());}));
 }

--- a/goldenmaster/tb_simple/mqtt/mqttsimplearrayinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttsimplearrayinterface.cpp
@@ -41,7 +41,7 @@ MqttSimpleArrayInterface::MqttSimpleArrayInterface(ApiGear::Mqtt::Client& client
     , m_propFloat64(QList<double>())
     , m_propString(QList<QString>())
     , m_propReadOnlyString(QString())
-    , m_isReady(false)
+    , m_finishedInitialization(false)
     , m_client(client)
 {
     if (m_client.isReady())
@@ -55,11 +55,13 @@ MqttSimpleArrayInterface::MqttSimpleArrayInterface(ApiGear::Mqtt::Client& client
             subscribeForPropertiesChanges();
             subscribeForSignals();
             subscribeForInvokeResponses();
+            m_finishedInitialization = true;
     });
     connect(&m_client, &ApiGear::Mqtt::Client::disconnected, [this](){
         m_subscribedIds.clear();
         m_InvokeCallsInfo.clear();
     });
+    m_finishedInitialization = m_client.isReady();
 }
 
 MqttSimpleArrayInterface::~MqttSimpleArrayInterface()
@@ -67,6 +69,11 @@ MqttSimpleArrayInterface::~MqttSimpleArrayInterface()
     disconnect(&m_client, &ApiGear::Mqtt::Client::disconnected, 0, 0);
     disconnect(&m_client, &ApiGear::Mqtt::Client::ready, 0, 0);
     unsubscribeAll();
+}
+
+bool MqttSimpleArrayInterface::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
 }
 
 void MqttSimpleArrayInterface::setPropBool(const QList<bool>& propBool)
@@ -661,59 +668,125 @@ const QString& MqttSimpleArrayInterface::interfaceName()
 {
     return InterfaceName;
 }
+
+void MqttSimpleArrayInterface::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
+    }
+}
 void MqttSimpleArrayInterface::subscribeForPropertiesChanges()
 {
+        // Subscription may succeed, before finising the function that subscribes it and assigns an id for if it was already added (and succeeded) for same topic,
+        // hence, for pending subscriptions a topic is used, and added before the subscribe function.
         const QString topicpropBool = interfaceName() + "/prop/propBool";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropBool, [this](auto& value) { setPropBoolLocal(value);}));
+        m_pendingSubscriptions.push_back(topicpropBool);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropBool,
+            [this, topicpropBool](auto id, bool hasSucceed){handleOnSubscribed(topicpropBool, id, hasSucceed);},
+            [this](auto& value) { setPropBoolLocal(value);}));
         const QString topicpropInt = interfaceName() + "/prop/propInt";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt, [this](auto& value) { setPropIntLocal(value);}));
+        m_pendingSubscriptions.push_back(topicpropInt);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt,
+            [this, topicpropInt](auto id, bool hasSucceed){handleOnSubscribed(topicpropInt, id, hasSucceed);},
+            [this](auto& value) { setPropIntLocal(value);}));
         const QString topicpropInt32 = interfaceName() + "/prop/propInt32";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt32, [this](auto& value) { setPropInt32Local(value);}));
+        m_pendingSubscriptions.push_back(topicpropInt32);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt32,
+            [this, topicpropInt32](auto id, bool hasSucceed){handleOnSubscribed(topicpropInt32, id, hasSucceed);},
+            [this](auto& value) { setPropInt32Local(value);}));
         const QString topicpropInt64 = interfaceName() + "/prop/propInt64";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt64, [this](auto& value) { setPropInt64Local(value);}));
+        m_pendingSubscriptions.push_back(topicpropInt64);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt64,
+            [this, topicpropInt64](auto id, bool hasSucceed){handleOnSubscribed(topicpropInt64, id, hasSucceed);},
+            [this](auto& value) { setPropInt64Local(value);}));
         const QString topicpropFloat = interfaceName() + "/prop/propFloat";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat, [this](auto& value) { setPropFloatLocal(value);}));
+        m_pendingSubscriptions.push_back(topicpropFloat);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat,
+            [this, topicpropFloat](auto id, bool hasSucceed){handleOnSubscribed(topicpropFloat, id, hasSucceed);},
+            [this](auto& value) { setPropFloatLocal(value);}));
         const QString topicpropFloat32 = interfaceName() + "/prop/propFloat32";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat32, [this](auto& value) { setPropFloat32Local(value);}));
+        m_pendingSubscriptions.push_back(topicpropFloat32);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat32,
+            [this, topicpropFloat32](auto id, bool hasSucceed){handleOnSubscribed(topicpropFloat32, id, hasSucceed);},
+            [this](auto& value) { setPropFloat32Local(value);}));
         const QString topicpropFloat64 = interfaceName() + "/prop/propFloat64";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat64, [this](auto& value) { setPropFloat64Local(value);}));
+        m_pendingSubscriptions.push_back(topicpropFloat64);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat64,
+            [this, topicpropFloat64](auto id, bool hasSucceed){handleOnSubscribed(topicpropFloat64, id, hasSucceed);},
+            [this](auto& value) { setPropFloat64Local(value);}));
         const QString topicpropString = interfaceName() + "/prop/propString";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropString, [this](auto& value) { setPropStringLocal(value);}));
+        m_pendingSubscriptions.push_back(topicpropString);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropString,
+            [this, topicpropString](auto id, bool hasSucceed){handleOnSubscribed(topicpropString, id, hasSucceed);},
+            [this](auto& value) { setPropStringLocal(value);}));
         const QString topicpropReadOnlyString = interfaceName() + "/prop/propReadOnlyString";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropReadOnlyString, [this](auto& value) { setPropReadOnlyStringLocal(value);}));
+        m_pendingSubscriptions.push_back(topicpropReadOnlyString);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropReadOnlyString,
+            [this, topicpropReadOnlyString](auto id, bool hasSucceed){handleOnSubscribed(topicpropReadOnlyString, id, hasSucceed);},
+            [this](auto& value) { setPropReadOnlyStringLocal(value);}));
 }
 void MqttSimpleArrayInterface::subscribeForSignals()
 {
         const QString topicsigBool = interfaceName() + "/sig/sigBool";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigBool, [this](const nlohmann::json& argumentsArray){
-            emit sigBool(argumentsArray[0].get<QList<bool>>());}));
+        m_pendingSubscriptions.push_back(topicsigBool);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigBool,
+            [this, topicsigBool](auto id, bool hasSucceed){handleOnSubscribed(topicsigBool, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigBool(argumentsArray[0].get<QList<bool>>());}));
         const QString topicsigInt = interfaceName() + "/sig/sigInt";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt, [this](const nlohmann::json& argumentsArray){
-            emit sigInt(argumentsArray[0].get<QList<int>>());}));
+        m_pendingSubscriptions.push_back(topicsigInt);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt,
+            [this, topicsigInt](auto id, bool hasSucceed){handleOnSubscribed(topicsigInt, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigInt(argumentsArray[0].get<QList<int>>());}));
         const QString topicsigInt32 = interfaceName() + "/sig/sigInt32";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt32, [this](const nlohmann::json& argumentsArray){
-            emit sigInt32(argumentsArray[0].get<QList<qint32>>());}));
+        m_pendingSubscriptions.push_back(topicsigInt32);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt32,
+            [this, topicsigInt32](auto id, bool hasSucceed){handleOnSubscribed(topicsigInt32, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigInt32(argumentsArray[0].get<QList<qint32>>());}));
         const QString topicsigInt64 = interfaceName() + "/sig/sigInt64";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt64, [this](const nlohmann::json& argumentsArray){
-            emit sigInt64(argumentsArray[0].get<QList<qint64>>());}));
+        m_pendingSubscriptions.push_back(topicsigInt64);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt64,
+            [this, topicsigInt64](auto id, bool hasSucceed){handleOnSubscribed(topicsigInt64, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigInt64(argumentsArray[0].get<QList<qint64>>());}));
         const QString topicsigFloat = interfaceName() + "/sig/sigFloat";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat, [this](const nlohmann::json& argumentsArray){
-            emit sigFloat(argumentsArray[0].get<QList<qreal>>());}));
+        m_pendingSubscriptions.push_back(topicsigFloat);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat,
+            [this, topicsigFloat](auto id, bool hasSucceed){handleOnSubscribed(topicsigFloat, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigFloat(argumentsArray[0].get<QList<qreal>>());}));
         const QString topicsigFloat32 = interfaceName() + "/sig/sigFloat32";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat32, [this](const nlohmann::json& argumentsArray){
-            emit sigFloat32(argumentsArray[0].get<QList<float>>());}));
+        m_pendingSubscriptions.push_back(topicsigFloat32);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat32,
+            [this, topicsigFloat32](auto id, bool hasSucceed){handleOnSubscribed(topicsigFloat32, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigFloat32(argumentsArray[0].get<QList<float>>());}));
         const QString topicsigFloat64 = interfaceName() + "/sig/sigFloat64";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat64, [this](const nlohmann::json& argumentsArray){
-            emit sigFloat64(argumentsArray[0].get<QList<double>>());}));
+        m_pendingSubscriptions.push_back(topicsigFloat64);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat64,
+            [this, topicsigFloat64](auto id, bool hasSucceed){handleOnSubscribed(topicsigFloat64, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigFloat64(argumentsArray[0].get<QList<double>>());}));
         const QString topicsigString = interfaceName() + "/sig/sigString";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigString, [this](const nlohmann::json& argumentsArray){
-            emit sigString(argumentsArray[0].get<QList<QString>>());}));
+        m_pendingSubscriptions.push_back(topicsigString);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigString,
+            [this, topicsigString](auto id, bool hasSucceed){handleOnSubscribed(topicsigString, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigString(argumentsArray[0].get<QList<QString>>());}));
 }
 void MqttSimpleArrayInterface::subscribeForInvokeResponses()
 {
     const QString topicfuncBool = interfaceName() + "/rpc/funcBool";
     const QString topicfuncBoolInvokeResp = interfaceName() + "/rpc/funcBool"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncBoolInvokeResp);
     auto id_funcBool = m_client.subscribeForInvokeResponse(topicfuncBoolInvokeResp, 
+                        [this, topicfuncBoolInvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncBoolInvokeResp, id, hasSucceed);},
                         [this, topicfuncBoolInvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncBoolInvokeResp);
@@ -721,7 +794,9 @@ void MqttSimpleArrayInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncBool] = std::make_pair(topicfuncBoolInvokeResp, id_funcBool);
     const QString topicfuncInt = interfaceName() + "/rpc/funcInt";
     const QString topicfuncIntInvokeResp = interfaceName() + "/rpc/funcInt"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncIntInvokeResp);
     auto id_funcInt = m_client.subscribeForInvokeResponse(topicfuncIntInvokeResp, 
+                        [this, topicfuncIntInvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncIntInvokeResp, id, hasSucceed);},
                         [this, topicfuncIntInvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncIntInvokeResp);
@@ -729,7 +804,9 @@ void MqttSimpleArrayInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncInt] = std::make_pair(topicfuncIntInvokeResp, id_funcInt);
     const QString topicfuncInt32 = interfaceName() + "/rpc/funcInt32";
     const QString topicfuncInt32InvokeResp = interfaceName() + "/rpc/funcInt32"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncInt32InvokeResp);
     auto id_funcInt32 = m_client.subscribeForInvokeResponse(topicfuncInt32InvokeResp, 
+                        [this, topicfuncInt32InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncInt32InvokeResp, id, hasSucceed);},
                         [this, topicfuncInt32InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncInt32InvokeResp);
@@ -737,7 +814,9 @@ void MqttSimpleArrayInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncInt32] = std::make_pair(topicfuncInt32InvokeResp, id_funcInt32);
     const QString topicfuncInt64 = interfaceName() + "/rpc/funcInt64";
     const QString topicfuncInt64InvokeResp = interfaceName() + "/rpc/funcInt64"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncInt64InvokeResp);
     auto id_funcInt64 = m_client.subscribeForInvokeResponse(topicfuncInt64InvokeResp, 
+                        [this, topicfuncInt64InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncInt64InvokeResp, id, hasSucceed);},
                         [this, topicfuncInt64InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncInt64InvokeResp);
@@ -745,7 +824,9 @@ void MqttSimpleArrayInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncInt64] = std::make_pair(topicfuncInt64InvokeResp, id_funcInt64);
     const QString topicfuncFloat = interfaceName() + "/rpc/funcFloat";
     const QString topicfuncFloatInvokeResp = interfaceName() + "/rpc/funcFloat"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncFloatInvokeResp);
     auto id_funcFloat = m_client.subscribeForInvokeResponse(topicfuncFloatInvokeResp, 
+                        [this, topicfuncFloatInvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncFloatInvokeResp, id, hasSucceed);},
                         [this, topicfuncFloatInvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncFloatInvokeResp);
@@ -753,7 +834,9 @@ void MqttSimpleArrayInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncFloat] = std::make_pair(topicfuncFloatInvokeResp, id_funcFloat);
     const QString topicfuncFloat32 = interfaceName() + "/rpc/funcFloat32";
     const QString topicfuncFloat32InvokeResp = interfaceName() + "/rpc/funcFloat32"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncFloat32InvokeResp);
     auto id_funcFloat32 = m_client.subscribeForInvokeResponse(topicfuncFloat32InvokeResp, 
+                        [this, topicfuncFloat32InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncFloat32InvokeResp, id, hasSucceed);},
                         [this, topicfuncFloat32InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncFloat32InvokeResp);
@@ -761,7 +844,9 @@ void MqttSimpleArrayInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncFloat32] = std::make_pair(topicfuncFloat32InvokeResp, id_funcFloat32);
     const QString topicfuncFloat64 = interfaceName() + "/rpc/funcFloat64";
     const QString topicfuncFloat64InvokeResp = interfaceName() + "/rpc/funcFloat64"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncFloat64InvokeResp);
     auto id_funcFloat64 = m_client.subscribeForInvokeResponse(topicfuncFloat64InvokeResp, 
+                        [this, topicfuncFloat64InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncFloat64InvokeResp, id, hasSucceed);},
                         [this, topicfuncFloat64InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncFloat64InvokeResp);
@@ -769,7 +854,9 @@ void MqttSimpleArrayInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncFloat64] = std::make_pair(topicfuncFloat64InvokeResp, id_funcFloat64);
     const QString topicfuncString = interfaceName() + "/rpc/funcString";
     const QString topicfuncStringInvokeResp = interfaceName() + "/rpc/funcString"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncStringInvokeResp);
     auto id_funcString = m_client.subscribeForInvokeResponse(topicfuncStringInvokeResp, 
+                        [this, topicfuncStringInvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncStringInvokeResp, id, hasSucceed);},
                         [this, topicfuncStringInvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncStringInvokeResp);

--- a/goldenmaster/tb_simple/mqtt/mqttsimplearrayinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttsimplearrayinterface.cpp
@@ -333,11 +333,14 @@ QFuture<QList<bool>> MqttSimpleArrayInterface::funcBoolAsync(const QList<bool>& 
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcBool");
     auto promise = std::make_shared<QPromise<QList<bool>>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(QList<bool>());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -345,7 +348,9 @@ QFuture<QList<bool>> MqttSimpleArrayInterface::funcBoolAsync(const QList<bool>& 
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(QList<bool>());
+        promise->addResult(QList<bool>());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramBool });       
@@ -354,6 +359,7 @@ QFuture<QList<bool>> MqttSimpleArrayInterface::funcBoolAsync(const QList<bool>& 
         {
             QList<bool> value = arg.get<QList<bool>>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -376,11 +382,14 @@ QFuture<QList<int>> MqttSimpleArrayInterface::funcIntAsync(const QList<int>& par
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcInt");
     auto promise = std::make_shared<QPromise<QList<int>>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(QList<int>());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -388,7 +397,9 @@ QFuture<QList<int>> MqttSimpleArrayInterface::funcIntAsync(const QList<int>& par
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(QList<int>());
+        promise->addResult(QList<int>());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramInt });       
@@ -397,6 +408,7 @@ QFuture<QList<int>> MqttSimpleArrayInterface::funcIntAsync(const QList<int>& par
         {
             QList<int> value = arg.get<QList<int>>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -419,11 +431,14 @@ QFuture<QList<qint32>> MqttSimpleArrayInterface::funcInt32Async(const QList<qint
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcInt32");
     auto promise = std::make_shared<QPromise<QList<qint32>>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(QList<qint32>());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -431,7 +446,9 @@ QFuture<QList<qint32>> MqttSimpleArrayInterface::funcInt32Async(const QList<qint
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(QList<qint32>());
+        promise->addResult(QList<qint32>());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramInt32 });       
@@ -440,6 +457,7 @@ QFuture<QList<qint32>> MqttSimpleArrayInterface::funcInt32Async(const QList<qint
         {
             QList<qint32> value = arg.get<QList<qint32>>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -462,11 +480,14 @@ QFuture<QList<qint64>> MqttSimpleArrayInterface::funcInt64Async(const QList<qint
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcInt64");
     auto promise = std::make_shared<QPromise<QList<qint64>>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(QList<qint64>());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -474,7 +495,9 @@ QFuture<QList<qint64>> MqttSimpleArrayInterface::funcInt64Async(const QList<qint
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(QList<qint64>());
+        promise->addResult(QList<qint64>());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramInt64 });       
@@ -483,6 +506,7 @@ QFuture<QList<qint64>> MqttSimpleArrayInterface::funcInt64Async(const QList<qint
         {
             QList<qint64> value = arg.get<QList<qint64>>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -505,11 +529,14 @@ QFuture<QList<qreal>> MqttSimpleArrayInterface::funcFloatAsync(const QList<qreal
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcFloat");
     auto promise = std::make_shared<QPromise<QList<qreal>>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(QList<qreal>());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -517,7 +544,9 @@ QFuture<QList<qreal>> MqttSimpleArrayInterface::funcFloatAsync(const QList<qreal
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(QList<qreal>());
+        promise->addResult(QList<qreal>());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramFloat });       
@@ -526,6 +555,7 @@ QFuture<QList<qreal>> MqttSimpleArrayInterface::funcFloatAsync(const QList<qreal
         {
             QList<qreal> value = arg.get<QList<qreal>>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -548,11 +578,14 @@ QFuture<QList<float>> MqttSimpleArrayInterface::funcFloat32Async(const QList<flo
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcFloat32");
     auto promise = std::make_shared<QPromise<QList<float>>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(QList<float>());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -560,7 +593,9 @@ QFuture<QList<float>> MqttSimpleArrayInterface::funcFloat32Async(const QList<flo
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(QList<float>());
+        promise->addResult(QList<float>());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramFloat32 });       
@@ -569,6 +604,7 @@ QFuture<QList<float>> MqttSimpleArrayInterface::funcFloat32Async(const QList<flo
         {
             QList<float> value = arg.get<QList<float>>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -591,11 +627,14 @@ QFuture<QList<double>> MqttSimpleArrayInterface::funcFloat64Async(const QList<do
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcFloat64");
     auto promise = std::make_shared<QPromise<QList<double>>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(QList<double>());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -603,7 +642,9 @@ QFuture<QList<double>> MqttSimpleArrayInterface::funcFloat64Async(const QList<do
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(QList<double>());
+        promise->addResult(QList<double>());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramFloat });       
@@ -612,6 +653,7 @@ QFuture<QList<double>> MqttSimpleArrayInterface::funcFloat64Async(const QList<do
         {
             QList<double> value = arg.get<QList<double>>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -634,11 +676,14 @@ QFuture<QList<QString>> MqttSimpleArrayInterface::funcStringAsync(const QList<QS
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcString");
     auto promise = std::make_shared<QPromise<QList<QString>>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(QList<QString>());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -646,7 +691,9 @@ QFuture<QList<QString>> MqttSimpleArrayInterface::funcStringAsync(const QList<QS
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(QList<QString>());
+        promise->addResult(QList<QString>());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramString });       
@@ -655,6 +702,7 @@ QFuture<QList<QString>> MqttSimpleArrayInterface::funcStringAsync(const QList<QS
         {
             QList<QString> value = arg.get<QList<QString>>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/tb_simple/mqtt/mqttsimplearrayinterface.h
+++ b/goldenmaster/tb_simple/mqtt/mqttsimplearrayinterface.h
@@ -211,12 +211,16 @@ public:
     * Remote call of ISimpleArrayInterface::funcString on the SimpleArrayInterface service.
     */
     QFuture<QList<QString>> funcStringAsync(const QList<QString>& paramString);
+    /**
+    * Use to check if the MqttSimpleArrayInterface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttSimpleArrayInterface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -274,9 +278,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttSimpleArrayInterface.
     * Handles incoming and outgoing messages.
@@ -304,6 +310,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_simple

--- a/goldenmaster/tb_simple/mqtt/mqttsimplearrayinterfaceadapter.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttsimplearrayinterfaceadapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "tb.simple/SimpleArrayInterface";
 MqttSimpleArrayInterfaceAdapter::MqttSimpleArrayInterfaceAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractSimpleArrayInterface> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -53,12 +54,14 @@ MqttSimpleArrayInterfaceAdapter::MqttSimpleArrayInterfaceAdapter(ApiGear::Mqtt::
         subscribeForInvokeRequests();
         connectServicePropertiesChanges();
         connectServiceSignals();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttSimpleArrayInterfaceAdapter::~MqttSimpleArrayInterfaceAdapter()
@@ -68,6 +71,12 @@ MqttSimpleArrayInterfaceAdapter::~MqttSimpleArrayInterfaceAdapter()
     unsubscribeAll();
 }
 
+bool MqttSimpleArrayInterfaceAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
+
 const QString& MqttSimpleArrayInterfaceAdapter::interfaceName()
 {
     return InterfaceName;
@@ -76,63 +85,81 @@ const QString& MqttSimpleArrayInterfaceAdapter::interfaceName()
 void MqttSimpleArrayInterfaceAdapter::subscribeForPropertiesChanges()
 {
     const auto setTopic_propBool = interfaceName() + "/set/propBool";
+    m_pendingSubscriptions.push_back(setTopic_propBool);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propBool,
+        [this, setTopic_propBool](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propBool, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             QList<bool> propBool = value.get<QList<bool>>();
             m_impl->setPropBool(propBool);
         }));
     const auto setTopic_propInt = interfaceName() + "/set/propInt";
+    m_pendingSubscriptions.push_back(setTopic_propInt);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propInt,
+        [this, setTopic_propInt](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propInt, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             QList<int> propInt = value.get<QList<int>>();
             m_impl->setPropInt(propInt);
         }));
     const auto setTopic_propInt32 = interfaceName() + "/set/propInt32";
+    m_pendingSubscriptions.push_back(setTopic_propInt32);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propInt32,
+        [this, setTopic_propInt32](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propInt32, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             QList<qint32> propInt32 = value.get<QList<qint32>>();
             m_impl->setPropInt32(propInt32);
         }));
     const auto setTopic_propInt64 = interfaceName() + "/set/propInt64";
+    m_pendingSubscriptions.push_back(setTopic_propInt64);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propInt64,
+        [this, setTopic_propInt64](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propInt64, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             QList<qint64> propInt64 = value.get<QList<qint64>>();
             m_impl->setPropInt64(propInt64);
         }));
     const auto setTopic_propFloat = interfaceName() + "/set/propFloat";
+    m_pendingSubscriptions.push_back(setTopic_propFloat);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propFloat,
+        [this, setTopic_propFloat](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propFloat, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             QList<qreal> propFloat = value.get<QList<qreal>>();
             m_impl->setPropFloat(propFloat);
         }));
     const auto setTopic_propFloat32 = interfaceName() + "/set/propFloat32";
+    m_pendingSubscriptions.push_back(setTopic_propFloat32);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propFloat32,
+        [this, setTopic_propFloat32](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propFloat32, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             QList<float> propFloat32 = value.get<QList<float>>();
             m_impl->setPropFloat32(propFloat32);
         }));
     const auto setTopic_propFloat64 = interfaceName() + "/set/propFloat64";
+    m_pendingSubscriptions.push_back(setTopic_propFloat64);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propFloat64,
+        [this, setTopic_propFloat64](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propFloat64, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             QList<double> propFloat64 = value.get<QList<double>>();
             m_impl->setPropFloat64(propFloat64);
         }));
     const auto setTopic_propString = interfaceName() + "/set/propString";
+    m_pendingSubscriptions.push_back(setTopic_propString);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propString,
+        [this, setTopic_propString](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propString, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             QList<QString> propString = value.get<QList<QString>>();
             m_impl->setPropString(propString);
         }));
     const auto setTopic_propReadOnlyString = interfaceName() + "/set/propReadOnlyString";
+    m_pendingSubscriptions.push_back(setTopic_propReadOnlyString);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propReadOnlyString,
+        [this, setTopic_propReadOnlyString](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propReadOnlyString, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             QString propReadOnlyString = value.get<QString>();
@@ -143,7 +170,9 @@ void MqttSimpleArrayInterfaceAdapter::subscribeForPropertiesChanges()
 void MqttSimpleArrayInterfaceAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_funcBool = interfaceName() + "/rpc/funcBool";
+    m_pendingSubscriptions.push_back(invokeTopic_funcBool);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcBool,
+        [this, invokeTopic_funcBool](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcBool, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             QList<bool> paramBool = arguments.at(0).get<QList<bool>>();
@@ -151,7 +180,9 @@ void MqttSimpleArrayInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_funcInt = interfaceName() + "/rpc/funcInt";
+    m_pendingSubscriptions.push_back(invokeTopic_funcInt);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcInt,
+        [this, invokeTopic_funcInt](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcInt, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             QList<int> paramInt = arguments.at(0).get<QList<int>>();
@@ -159,7 +190,9 @@ void MqttSimpleArrayInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_funcInt32 = interfaceName() + "/rpc/funcInt32";
+    m_pendingSubscriptions.push_back(invokeTopic_funcInt32);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcInt32,
+        [this, invokeTopic_funcInt32](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcInt32, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             QList<qint32> paramInt32 = arguments.at(0).get<QList<qint32>>();
@@ -167,7 +200,9 @@ void MqttSimpleArrayInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_funcInt64 = interfaceName() + "/rpc/funcInt64";
+    m_pendingSubscriptions.push_back(invokeTopic_funcInt64);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcInt64,
+        [this, invokeTopic_funcInt64](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcInt64, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             QList<qint64> paramInt64 = arguments.at(0).get<QList<qint64>>();
@@ -175,7 +210,9 @@ void MqttSimpleArrayInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_funcFloat = interfaceName() + "/rpc/funcFloat";
+    m_pendingSubscriptions.push_back(invokeTopic_funcFloat);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcFloat,
+        [this, invokeTopic_funcFloat](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcFloat, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             QList<qreal> paramFloat = arguments.at(0).get<QList<qreal>>();
@@ -183,7 +220,9 @@ void MqttSimpleArrayInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_funcFloat32 = interfaceName() + "/rpc/funcFloat32";
+    m_pendingSubscriptions.push_back(invokeTopic_funcFloat32);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcFloat32,
+        [this, invokeTopic_funcFloat32](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcFloat32, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             QList<float> paramFloat32 = arguments.at(0).get<QList<float>>();
@@ -191,7 +230,9 @@ void MqttSimpleArrayInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_funcFloat64 = interfaceName() + "/rpc/funcFloat64";
+    m_pendingSubscriptions.push_back(invokeTopic_funcFloat64);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcFloat64,
+        [this, invokeTopic_funcFloat64](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcFloat64, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             QList<double> paramFloat = arguments.at(0).get<QList<double>>();
@@ -199,7 +240,9 @@ void MqttSimpleArrayInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_funcString = interfaceName() + "/rpc/funcString";
+    m_pendingSubscriptions.push_back(invokeTopic_funcString);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcString,
+        [this, invokeTopic_funcString](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcString, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             QList<QString> paramString = arguments.at(0).get<QList<QString>>();
@@ -331,6 +374,25 @@ void MqttSimpleArrayInterfaceAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttSimpleArrayInterfaceAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/tb_simple/mqtt/mqttsimplearrayinterfaceadapter.h
+++ b/goldenmaster/tb_simple/mqtt/mqttsimplearrayinterfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttSimpleArrayInterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttSimpleArrayInterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a SimpleArrayInterface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_simple

--- a/goldenmaster/tb_simple/mqtt/mqttsimpleinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttsimpleinterface.cpp
@@ -677,47 +677,47 @@ const QString& MqttSimpleInterface::interfaceName()
 }
 void MqttSimpleInterface::subscribeForPropertiesChanges()
 {
-        static const QString topicpropBool = interfaceName() + "/prop/propBool";
+        const QString topicpropBool = interfaceName() + "/prop/propBool";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropBool, [this](auto& value) { setPropBoolLocal(value);}));
-        static const QString topicpropInt = interfaceName() + "/prop/propInt";
+        const QString topicpropInt = interfaceName() + "/prop/propInt";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt, [this](auto& value) { setPropIntLocal(value);}));
-        static const QString topicpropInt32 = interfaceName() + "/prop/propInt32";
+        const QString topicpropInt32 = interfaceName() + "/prop/propInt32";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt32, [this](auto& value) { setPropInt32Local(value);}));
-        static const QString topicpropInt64 = interfaceName() + "/prop/propInt64";
+        const QString topicpropInt64 = interfaceName() + "/prop/propInt64";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt64, [this](auto& value) { setPropInt64Local(value);}));
-        static const QString topicpropFloat = interfaceName() + "/prop/propFloat";
+        const QString topicpropFloat = interfaceName() + "/prop/propFloat";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat, [this](auto& value) { setPropFloatLocal(value);}));
-        static const QString topicpropFloat32 = interfaceName() + "/prop/propFloat32";
+        const QString topicpropFloat32 = interfaceName() + "/prop/propFloat32";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat32, [this](auto& value) { setPropFloat32Local(value);}));
-        static const QString topicpropFloat64 = interfaceName() + "/prop/propFloat64";
+        const QString topicpropFloat64 = interfaceName() + "/prop/propFloat64";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat64, [this](auto& value) { setPropFloat64Local(value);}));
-        static const QString topicpropString = interfaceName() + "/prop/propString";
+        const QString topicpropString = interfaceName() + "/prop/propString";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropString, [this](auto& value) { setPropStringLocal(value);}));
 }
 void MqttSimpleInterface::subscribeForSignals()
 {
-        static const QString topicsigBool = interfaceName() + "/sig/sigBool";
+        const QString topicsigBool = interfaceName() + "/sig/sigBool";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigBool, [this](const nlohmann::json& argumentsArray){
             emit sigBool(argumentsArray[0].get<bool>());}));
-        static const QString topicsigInt = interfaceName() + "/sig/sigInt";
+        const QString topicsigInt = interfaceName() + "/sig/sigInt";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt, [this](const nlohmann::json& argumentsArray){
             emit sigInt(argumentsArray[0].get<int>());}));
-        static const QString topicsigInt32 = interfaceName() + "/sig/sigInt32";
+        const QString topicsigInt32 = interfaceName() + "/sig/sigInt32";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt32, [this](const nlohmann::json& argumentsArray){
             emit sigInt32(argumentsArray[0].get<qint32>());}));
-        static const QString topicsigInt64 = interfaceName() + "/sig/sigInt64";
+        const QString topicsigInt64 = interfaceName() + "/sig/sigInt64";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt64, [this](const nlohmann::json& argumentsArray){
             emit sigInt64(argumentsArray[0].get<qint64>());}));
-        static const QString topicsigFloat = interfaceName() + "/sig/sigFloat";
+        const QString topicsigFloat = interfaceName() + "/sig/sigFloat";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat, [this](const nlohmann::json& argumentsArray){
             emit sigFloat(argumentsArray[0].get<qreal>());}));
-        static const QString topicsigFloat32 = interfaceName() + "/sig/sigFloat32";
+        const QString topicsigFloat32 = interfaceName() + "/sig/sigFloat32";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat32, [this](const nlohmann::json& argumentsArray){
             emit sigFloat32(argumentsArray[0].get<float>());}));
-        static const QString topicsigFloat64 = interfaceName() + "/sig/sigFloat64";
+        const QString topicsigFloat64 = interfaceName() + "/sig/sigFloat64";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat64, [this](const nlohmann::json& argumentsArray){
             emit sigFloat64(argumentsArray[0].get<double>());}));
-        static const QString topicsigString = interfaceName() + "/sig/sigString";
+        const QString topicsigString = interfaceName() + "/sig/sigString";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigString, [this](const nlohmann::json& argumentsArray){
             emit sigString(argumentsArray[0].get<QString>());}));
 }

--- a/goldenmaster/tb_simple/mqtt/mqttsimpleinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttsimpleinterface.cpp
@@ -305,11 +305,13 @@ QFuture<void> MqttSimpleInterface::funcNoReturnValueAsync(bool paramBool)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcNoReturnValue");
     auto promise = std::make_shared<QPromise<void>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->finish();
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -317,7 +319,8 @@ QFuture<void> MqttSimpleInterface::funcNoReturnValueAsync(bool paramBool)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->finish();
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramBool });       
@@ -347,11 +350,14 @@ QFuture<bool> MqttSimpleInterface::funcBoolAsync(bool paramBool)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcBool");
     auto promise = std::make_shared<QPromise<bool>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(false);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -359,7 +365,9 @@ QFuture<bool> MqttSimpleInterface::funcBoolAsync(bool paramBool)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(false);
+        promise->addResult(false);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramBool });       
@@ -368,6 +376,7 @@ QFuture<bool> MqttSimpleInterface::funcBoolAsync(bool paramBool)
         {
             bool value = arg.get<bool>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -390,11 +399,14 @@ QFuture<int> MqttSimpleInterface::funcIntAsync(int paramInt)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcInt");
     auto promise = std::make_shared<QPromise<int>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(0);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -402,7 +414,9 @@ QFuture<int> MqttSimpleInterface::funcIntAsync(int paramInt)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(0);
+        promise->addResult(0);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramInt });       
@@ -411,6 +425,7 @@ QFuture<int> MqttSimpleInterface::funcIntAsync(int paramInt)
         {
             int value = arg.get<int>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -433,11 +448,14 @@ QFuture<qint32> MqttSimpleInterface::funcInt32Async(qint32 paramInt32)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcInt32");
     auto promise = std::make_shared<QPromise<qint32>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(0);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -445,7 +463,9 @@ QFuture<qint32> MqttSimpleInterface::funcInt32Async(qint32 paramInt32)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(0);
+        promise->addResult(0);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramInt32 });       
@@ -454,6 +474,7 @@ QFuture<qint32> MqttSimpleInterface::funcInt32Async(qint32 paramInt32)
         {
             qint32 value = arg.get<qint32>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -476,11 +497,14 @@ QFuture<qint64> MqttSimpleInterface::funcInt64Async(qint64 paramInt64)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcInt64");
     auto promise = std::make_shared<QPromise<qint64>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(0LL);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -488,7 +512,9 @@ QFuture<qint64> MqttSimpleInterface::funcInt64Async(qint64 paramInt64)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(0LL);
+        promise->addResult(0LL);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramInt64 });       
@@ -497,6 +523,7 @@ QFuture<qint64> MqttSimpleInterface::funcInt64Async(qint64 paramInt64)
         {
             qint64 value = arg.get<qint64>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -519,11 +546,14 @@ QFuture<qreal> MqttSimpleInterface::funcFloatAsync(qreal paramFloat)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcFloat");
     auto promise = std::make_shared<QPromise<qreal>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(0.0f);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -531,7 +561,9 @@ QFuture<qreal> MqttSimpleInterface::funcFloatAsync(qreal paramFloat)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(0.0f);
+        promise->addResult(0.0f);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramFloat });       
@@ -540,6 +572,7 @@ QFuture<qreal> MqttSimpleInterface::funcFloatAsync(qreal paramFloat)
         {
             qreal value = arg.get<qreal>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -562,11 +595,14 @@ QFuture<float> MqttSimpleInterface::funcFloat32Async(float paramFloat32)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcFloat32");
     auto promise = std::make_shared<QPromise<float>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(0.0f);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -574,7 +610,9 @@ QFuture<float> MqttSimpleInterface::funcFloat32Async(float paramFloat32)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(0.0f);
+        promise->addResult(0.0f);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramFloat32 });       
@@ -583,6 +621,7 @@ QFuture<float> MqttSimpleInterface::funcFloat32Async(float paramFloat32)
         {
             float value = arg.get<float>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -605,11 +644,14 @@ QFuture<double> MqttSimpleInterface::funcFloat64Async(double paramFloat)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcFloat64");
     auto promise = std::make_shared<QPromise<double>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(0.0);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -617,7 +659,9 @@ QFuture<double> MqttSimpleInterface::funcFloat64Async(double paramFloat)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(0.0);
+        promise->addResult(0.0);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramFloat });       
@@ -626,6 +670,7 @@ QFuture<double> MqttSimpleInterface::funcFloat64Async(double paramFloat)
         {
             double value = arg.get<double>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -648,11 +693,14 @@ QFuture<QString> MqttSimpleInterface::funcStringAsync(const QString& paramString
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcString");
     auto promise = std::make_shared<QPromise<QString>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(QString());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -660,7 +708,9 @@ QFuture<QString> MqttSimpleInterface::funcStringAsync(const QString& paramString
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(QString());
+        promise->addResult(QString());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramString });       
@@ -669,6 +719,7 @@ QFuture<QString> MqttSimpleInterface::funcStringAsync(const QString& paramString
         {
             QString value = arg.get<QString>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/tb_simple/mqtt/mqttsimpleinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttsimpleinterface.cpp
@@ -40,7 +40,7 @@ MqttSimpleInterface::MqttSimpleInterface(ApiGear::Mqtt::Client& client, QObject 
     , m_propFloat32(0.0f)
     , m_propFloat64(0.0)
     , m_propString(QString())
-    , m_isReady(false)
+    , m_finishedInitialization(false)
     , m_client(client)
 {
     if (m_client.isReady())
@@ -54,11 +54,13 @@ MqttSimpleInterface::MqttSimpleInterface(ApiGear::Mqtt::Client& client, QObject 
             subscribeForPropertiesChanges();
             subscribeForSignals();
             subscribeForInvokeResponses();
+            m_finishedInitialization = true;
     });
     connect(&m_client, &ApiGear::Mqtt::Client::disconnected, [this](){
         m_subscribedIds.clear();
         m_InvokeCallsInfo.clear();
     });
+    m_finishedInitialization = m_client.isReady();
 }
 
 MqttSimpleInterface::~MqttSimpleInterface()
@@ -66,6 +68,11 @@ MqttSimpleInterface::~MqttSimpleInterface()
     disconnect(&m_client, &ApiGear::Mqtt::Client::disconnected, 0, 0);
     disconnect(&m_client, &ApiGear::Mqtt::Client::ready, 0, 0);
     unsubscribeAll();
+}
+
+bool MqttSimpleInterface::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
 }
 
 void MqttSimpleInterface::setPropBool(bool propBool)
@@ -675,57 +682,120 @@ const QString& MqttSimpleInterface::interfaceName()
 {
     return InterfaceName;
 }
+
+void MqttSimpleInterface::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
+    }
+}
 void MqttSimpleInterface::subscribeForPropertiesChanges()
 {
+        // Subscription may succeed, before finising the function that subscribes it and assigns an id for if it was already added (and succeeded) for same topic,
+        // hence, for pending subscriptions a topic is used, and added before the subscribe function.
         const QString topicpropBool = interfaceName() + "/prop/propBool";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropBool, [this](auto& value) { setPropBoolLocal(value);}));
+        m_pendingSubscriptions.push_back(topicpropBool);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropBool,
+            [this, topicpropBool](auto id, bool hasSucceed){handleOnSubscribed(topicpropBool, id, hasSucceed);},
+            [this](auto& value) { setPropBoolLocal(value);}));
         const QString topicpropInt = interfaceName() + "/prop/propInt";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt, [this](auto& value) { setPropIntLocal(value);}));
+        m_pendingSubscriptions.push_back(topicpropInt);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt,
+            [this, topicpropInt](auto id, bool hasSucceed){handleOnSubscribed(topicpropInt, id, hasSucceed);},
+            [this](auto& value) { setPropIntLocal(value);}));
         const QString topicpropInt32 = interfaceName() + "/prop/propInt32";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt32, [this](auto& value) { setPropInt32Local(value);}));
+        m_pendingSubscriptions.push_back(topicpropInt32);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt32,
+            [this, topicpropInt32](auto id, bool hasSucceed){handleOnSubscribed(topicpropInt32, id, hasSucceed);},
+            [this](auto& value) { setPropInt32Local(value);}));
         const QString topicpropInt64 = interfaceName() + "/prop/propInt64";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt64, [this](auto& value) { setPropInt64Local(value);}));
+        m_pendingSubscriptions.push_back(topicpropInt64);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt64,
+            [this, topicpropInt64](auto id, bool hasSucceed){handleOnSubscribed(topicpropInt64, id, hasSucceed);},
+            [this](auto& value) { setPropInt64Local(value);}));
         const QString topicpropFloat = interfaceName() + "/prop/propFloat";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat, [this](auto& value) { setPropFloatLocal(value);}));
+        m_pendingSubscriptions.push_back(topicpropFloat);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat,
+            [this, topicpropFloat](auto id, bool hasSucceed){handleOnSubscribed(topicpropFloat, id, hasSucceed);},
+            [this](auto& value) { setPropFloatLocal(value);}));
         const QString topicpropFloat32 = interfaceName() + "/prop/propFloat32";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat32, [this](auto& value) { setPropFloat32Local(value);}));
+        m_pendingSubscriptions.push_back(topicpropFloat32);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat32,
+            [this, topicpropFloat32](auto id, bool hasSucceed){handleOnSubscribed(topicpropFloat32, id, hasSucceed);},
+            [this](auto& value) { setPropFloat32Local(value);}));
         const QString topicpropFloat64 = interfaceName() + "/prop/propFloat64";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat64, [this](auto& value) { setPropFloat64Local(value);}));
+        m_pendingSubscriptions.push_back(topicpropFloat64);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat64,
+            [this, topicpropFloat64](auto id, bool hasSucceed){handleOnSubscribed(topicpropFloat64, id, hasSucceed);},
+            [this](auto& value) { setPropFloat64Local(value);}));
         const QString topicpropString = interfaceName() + "/prop/propString";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropString, [this](auto& value) { setPropStringLocal(value);}));
+        m_pendingSubscriptions.push_back(topicpropString);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropString,
+            [this, topicpropString](auto id, bool hasSucceed){handleOnSubscribed(topicpropString, id, hasSucceed);},
+            [this](auto& value) { setPropStringLocal(value);}));
 }
 void MqttSimpleInterface::subscribeForSignals()
 {
         const QString topicsigBool = interfaceName() + "/sig/sigBool";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigBool, [this](const nlohmann::json& argumentsArray){
-            emit sigBool(argumentsArray[0].get<bool>());}));
+        m_pendingSubscriptions.push_back(topicsigBool);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigBool,
+            [this, topicsigBool](auto id, bool hasSucceed){handleOnSubscribed(topicsigBool, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigBool(argumentsArray[0].get<bool>());}));
         const QString topicsigInt = interfaceName() + "/sig/sigInt";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt, [this](const nlohmann::json& argumentsArray){
-            emit sigInt(argumentsArray[0].get<int>());}));
+        m_pendingSubscriptions.push_back(topicsigInt);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt,
+            [this, topicsigInt](auto id, bool hasSucceed){handleOnSubscribed(topicsigInt, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigInt(argumentsArray[0].get<int>());}));
         const QString topicsigInt32 = interfaceName() + "/sig/sigInt32";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt32, [this](const nlohmann::json& argumentsArray){
-            emit sigInt32(argumentsArray[0].get<qint32>());}));
+        m_pendingSubscriptions.push_back(topicsigInt32);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt32,
+            [this, topicsigInt32](auto id, bool hasSucceed){handleOnSubscribed(topicsigInt32, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigInt32(argumentsArray[0].get<qint32>());}));
         const QString topicsigInt64 = interfaceName() + "/sig/sigInt64";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt64, [this](const nlohmann::json& argumentsArray){
-            emit sigInt64(argumentsArray[0].get<qint64>());}));
+        m_pendingSubscriptions.push_back(topicsigInt64);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt64,
+            [this, topicsigInt64](auto id, bool hasSucceed){handleOnSubscribed(topicsigInt64, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigInt64(argumentsArray[0].get<qint64>());}));
         const QString topicsigFloat = interfaceName() + "/sig/sigFloat";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat, [this](const nlohmann::json& argumentsArray){
-            emit sigFloat(argumentsArray[0].get<qreal>());}));
+        m_pendingSubscriptions.push_back(topicsigFloat);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat,
+            [this, topicsigFloat](auto id, bool hasSucceed){handleOnSubscribed(topicsigFloat, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigFloat(argumentsArray[0].get<qreal>());}));
         const QString topicsigFloat32 = interfaceName() + "/sig/sigFloat32";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat32, [this](const nlohmann::json& argumentsArray){
-            emit sigFloat32(argumentsArray[0].get<float>());}));
+        m_pendingSubscriptions.push_back(topicsigFloat32);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat32,
+            [this, topicsigFloat32](auto id, bool hasSucceed){handleOnSubscribed(topicsigFloat32, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigFloat32(argumentsArray[0].get<float>());}));
         const QString topicsigFloat64 = interfaceName() + "/sig/sigFloat64";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat64, [this](const nlohmann::json& argumentsArray){
-            emit sigFloat64(argumentsArray[0].get<double>());}));
+        m_pendingSubscriptions.push_back(topicsigFloat64);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat64,
+            [this, topicsigFloat64](auto id, bool hasSucceed){handleOnSubscribed(topicsigFloat64, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigFloat64(argumentsArray[0].get<double>());}));
         const QString topicsigString = interfaceName() + "/sig/sigString";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigString, [this](const nlohmann::json& argumentsArray){
-            emit sigString(argumentsArray[0].get<QString>());}));
+        m_pendingSubscriptions.push_back(topicsigString);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigString,
+            [this, topicsigString](auto id, bool hasSucceed){handleOnSubscribed(topicsigString, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigString(argumentsArray[0].get<QString>());}));
 }
 void MqttSimpleInterface::subscribeForInvokeResponses()
 {
     const QString topicfuncNoReturnValue = interfaceName() + "/rpc/funcNoReturnValue";
     const QString topicfuncNoReturnValueInvokeResp = interfaceName() + "/rpc/funcNoReturnValue"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncNoReturnValueInvokeResp);
     auto id_funcNoReturnValue = m_client.subscribeForInvokeResponse(topicfuncNoReturnValueInvokeResp, 
+                        [this, topicfuncNoReturnValueInvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncNoReturnValueInvokeResp, id, hasSucceed);},
                         [this, topicfuncNoReturnValueInvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncNoReturnValueInvokeResp);
@@ -733,7 +803,9 @@ void MqttSimpleInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncNoReturnValue] = std::make_pair(topicfuncNoReturnValueInvokeResp, id_funcNoReturnValue);
     const QString topicfuncBool = interfaceName() + "/rpc/funcBool";
     const QString topicfuncBoolInvokeResp = interfaceName() + "/rpc/funcBool"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncBoolInvokeResp);
     auto id_funcBool = m_client.subscribeForInvokeResponse(topicfuncBoolInvokeResp, 
+                        [this, topicfuncBoolInvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncBoolInvokeResp, id, hasSucceed);},
                         [this, topicfuncBoolInvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncBoolInvokeResp);
@@ -741,7 +813,9 @@ void MqttSimpleInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncBool] = std::make_pair(topicfuncBoolInvokeResp, id_funcBool);
     const QString topicfuncInt = interfaceName() + "/rpc/funcInt";
     const QString topicfuncIntInvokeResp = interfaceName() + "/rpc/funcInt"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncIntInvokeResp);
     auto id_funcInt = m_client.subscribeForInvokeResponse(topicfuncIntInvokeResp, 
+                        [this, topicfuncIntInvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncIntInvokeResp, id, hasSucceed);},
                         [this, topicfuncIntInvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncIntInvokeResp);
@@ -749,7 +823,9 @@ void MqttSimpleInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncInt] = std::make_pair(topicfuncIntInvokeResp, id_funcInt);
     const QString topicfuncInt32 = interfaceName() + "/rpc/funcInt32";
     const QString topicfuncInt32InvokeResp = interfaceName() + "/rpc/funcInt32"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncInt32InvokeResp);
     auto id_funcInt32 = m_client.subscribeForInvokeResponse(topicfuncInt32InvokeResp, 
+                        [this, topicfuncInt32InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncInt32InvokeResp, id, hasSucceed);},
                         [this, topicfuncInt32InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncInt32InvokeResp);
@@ -757,7 +833,9 @@ void MqttSimpleInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncInt32] = std::make_pair(topicfuncInt32InvokeResp, id_funcInt32);
     const QString topicfuncInt64 = interfaceName() + "/rpc/funcInt64";
     const QString topicfuncInt64InvokeResp = interfaceName() + "/rpc/funcInt64"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncInt64InvokeResp);
     auto id_funcInt64 = m_client.subscribeForInvokeResponse(topicfuncInt64InvokeResp, 
+                        [this, topicfuncInt64InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncInt64InvokeResp, id, hasSucceed);},
                         [this, topicfuncInt64InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncInt64InvokeResp);
@@ -765,7 +843,9 @@ void MqttSimpleInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncInt64] = std::make_pair(topicfuncInt64InvokeResp, id_funcInt64);
     const QString topicfuncFloat = interfaceName() + "/rpc/funcFloat";
     const QString topicfuncFloatInvokeResp = interfaceName() + "/rpc/funcFloat"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncFloatInvokeResp);
     auto id_funcFloat = m_client.subscribeForInvokeResponse(topicfuncFloatInvokeResp, 
+                        [this, topicfuncFloatInvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncFloatInvokeResp, id, hasSucceed);},
                         [this, topicfuncFloatInvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncFloatInvokeResp);
@@ -773,7 +853,9 @@ void MqttSimpleInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncFloat] = std::make_pair(topicfuncFloatInvokeResp, id_funcFloat);
     const QString topicfuncFloat32 = interfaceName() + "/rpc/funcFloat32";
     const QString topicfuncFloat32InvokeResp = interfaceName() + "/rpc/funcFloat32"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncFloat32InvokeResp);
     auto id_funcFloat32 = m_client.subscribeForInvokeResponse(topicfuncFloat32InvokeResp, 
+                        [this, topicfuncFloat32InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncFloat32InvokeResp, id, hasSucceed);},
                         [this, topicfuncFloat32InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncFloat32InvokeResp);
@@ -781,7 +863,9 @@ void MqttSimpleInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncFloat32] = std::make_pair(topicfuncFloat32InvokeResp, id_funcFloat32);
     const QString topicfuncFloat64 = interfaceName() + "/rpc/funcFloat64";
     const QString topicfuncFloat64InvokeResp = interfaceName() + "/rpc/funcFloat64"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncFloat64InvokeResp);
     auto id_funcFloat64 = m_client.subscribeForInvokeResponse(topicfuncFloat64InvokeResp, 
+                        [this, topicfuncFloat64InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncFloat64InvokeResp, id, hasSucceed);},
                         [this, topicfuncFloat64InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncFloat64InvokeResp);
@@ -789,7 +873,9 @@ void MqttSimpleInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncFloat64] = std::make_pair(topicfuncFloat64InvokeResp, id_funcFloat64);
     const QString topicfuncString = interfaceName() + "/rpc/funcString";
     const QString topicfuncStringInvokeResp = interfaceName() + "/rpc/funcString"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncStringInvokeResp);
     auto id_funcString = m_client.subscribeForInvokeResponse(topicfuncStringInvokeResp, 
+                        [this, topicfuncStringInvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncStringInvokeResp, id, hasSucceed);},
                         [this, topicfuncStringInvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncStringInvokeResp);

--- a/goldenmaster/tb_simple/mqtt/mqttsimpleinterface.h
+++ b/goldenmaster/tb_simple/mqtt/mqttsimpleinterface.h
@@ -210,12 +210,16 @@ public:
     * Remote call of ISimpleInterface::funcString on the SimpleInterface service.
     */
     QFuture<QString> funcStringAsync(const QString& paramString);
+    /**
+    * Use to check if the MqttSimpleInterface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttSimpleInterface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -269,9 +273,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttSimpleInterface.
     * Handles incoming and outgoing messages.
@@ -299,6 +305,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_simple

--- a/goldenmaster/tb_simple/mqtt/mqttsimpleinterfaceadapter.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttsimpleinterfaceadapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "tb.simple/SimpleInterface";
 MqttSimpleInterfaceAdapter::MqttSimpleInterfaceAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractSimpleInterface> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -53,12 +54,14 @@ MqttSimpleInterfaceAdapter::MqttSimpleInterfaceAdapter(ApiGear::Mqtt::ServiceAda
         subscribeForInvokeRequests();
         connectServicePropertiesChanges();
         connectServiceSignals();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttSimpleInterfaceAdapter::~MqttSimpleInterfaceAdapter()
@@ -68,6 +71,12 @@ MqttSimpleInterfaceAdapter::~MqttSimpleInterfaceAdapter()
     unsubscribeAll();
 }
 
+bool MqttSimpleInterfaceAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
+
 const QString& MqttSimpleInterfaceAdapter::interfaceName()
 {
     return InterfaceName;
@@ -76,56 +85,72 @@ const QString& MqttSimpleInterfaceAdapter::interfaceName()
 void MqttSimpleInterfaceAdapter::subscribeForPropertiesChanges()
 {
     const auto setTopic_propBool = interfaceName() + "/set/propBool";
+    m_pendingSubscriptions.push_back(setTopic_propBool);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propBool,
+        [this, setTopic_propBool](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propBool, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             bool propBool = value.get<bool>();
             m_impl->setPropBool(propBool);
         }));
     const auto setTopic_propInt = interfaceName() + "/set/propInt";
+    m_pendingSubscriptions.push_back(setTopic_propInt);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propInt,
+        [this, setTopic_propInt](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propInt, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             int propInt = value.get<int>();
             m_impl->setPropInt(propInt);
         }));
     const auto setTopic_propInt32 = interfaceName() + "/set/propInt32";
+    m_pendingSubscriptions.push_back(setTopic_propInt32);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propInt32,
+        [this, setTopic_propInt32](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propInt32, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             qint32 propInt32 = value.get<qint32>();
             m_impl->setPropInt32(propInt32);
         }));
     const auto setTopic_propInt64 = interfaceName() + "/set/propInt64";
+    m_pendingSubscriptions.push_back(setTopic_propInt64);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propInt64,
+        [this, setTopic_propInt64](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propInt64, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             qint64 propInt64 = value.get<qint64>();
             m_impl->setPropInt64(propInt64);
         }));
     const auto setTopic_propFloat = interfaceName() + "/set/propFloat";
+    m_pendingSubscriptions.push_back(setTopic_propFloat);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propFloat,
+        [this, setTopic_propFloat](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propFloat, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             qreal propFloat = value.get<qreal>();
             m_impl->setPropFloat(propFloat);
         }));
     const auto setTopic_propFloat32 = interfaceName() + "/set/propFloat32";
+    m_pendingSubscriptions.push_back(setTopic_propFloat32);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propFloat32,
+        [this, setTopic_propFloat32](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propFloat32, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             float propFloat32 = value.get<float>();
             m_impl->setPropFloat32(propFloat32);
         }));
     const auto setTopic_propFloat64 = interfaceName() + "/set/propFloat64";
+    m_pendingSubscriptions.push_back(setTopic_propFloat64);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propFloat64,
+        [this, setTopic_propFloat64](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propFloat64, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             double propFloat64 = value.get<double>();
             m_impl->setPropFloat64(propFloat64);
         }));
     const auto setTopic_propString = interfaceName() + "/set/propString";
+    m_pendingSubscriptions.push_back(setTopic_propString);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_propString,
+        [this, setTopic_propString](auto id, bool hasSucceed){handleOnSubscribed(setTopic_propString, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             QString propString = value.get<QString>();
@@ -136,7 +161,9 @@ void MqttSimpleInterfaceAdapter::subscribeForPropertiesChanges()
 void MqttSimpleInterfaceAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_funcNoReturnValue = interfaceName() + "/rpc/funcNoReturnValue";
+    m_pendingSubscriptions.push_back(invokeTopic_funcNoReturnValue);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcNoReturnValue,
+        [this, invokeTopic_funcNoReturnValue](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcNoReturnValue, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             bool paramBool = arguments.at(0).get<bool>();
@@ -144,7 +171,9 @@ void MqttSimpleInterfaceAdapter::subscribeForInvokeRequests()
             return nlohmann::json {};
         }));
     const auto invokeTopic_funcBool = interfaceName() + "/rpc/funcBool";
+    m_pendingSubscriptions.push_back(invokeTopic_funcBool);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcBool,
+        [this, invokeTopic_funcBool](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcBool, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             bool paramBool = arguments.at(0).get<bool>();
@@ -152,7 +181,9 @@ void MqttSimpleInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_funcInt = interfaceName() + "/rpc/funcInt";
+    m_pendingSubscriptions.push_back(invokeTopic_funcInt);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcInt,
+        [this, invokeTopic_funcInt](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcInt, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             int paramInt = arguments.at(0).get<int>();
@@ -160,7 +191,9 @@ void MqttSimpleInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_funcInt32 = interfaceName() + "/rpc/funcInt32";
+    m_pendingSubscriptions.push_back(invokeTopic_funcInt32);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcInt32,
+        [this, invokeTopic_funcInt32](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcInt32, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             qint32 paramInt32 = arguments.at(0).get<qint32>();
@@ -168,7 +201,9 @@ void MqttSimpleInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_funcInt64 = interfaceName() + "/rpc/funcInt64";
+    m_pendingSubscriptions.push_back(invokeTopic_funcInt64);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcInt64,
+        [this, invokeTopic_funcInt64](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcInt64, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             qint64 paramInt64 = arguments.at(0).get<qint64>();
@@ -176,7 +211,9 @@ void MqttSimpleInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_funcFloat = interfaceName() + "/rpc/funcFloat";
+    m_pendingSubscriptions.push_back(invokeTopic_funcFloat);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcFloat,
+        [this, invokeTopic_funcFloat](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcFloat, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             qreal paramFloat = arguments.at(0).get<qreal>();
@@ -184,7 +221,9 @@ void MqttSimpleInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_funcFloat32 = interfaceName() + "/rpc/funcFloat32";
+    m_pendingSubscriptions.push_back(invokeTopic_funcFloat32);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcFloat32,
+        [this, invokeTopic_funcFloat32](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcFloat32, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             float paramFloat32 = arguments.at(0).get<float>();
@@ -192,7 +231,9 @@ void MqttSimpleInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_funcFloat64 = interfaceName() + "/rpc/funcFloat64";
+    m_pendingSubscriptions.push_back(invokeTopic_funcFloat64);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcFloat64,
+        [this, invokeTopic_funcFloat64](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcFloat64, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             double paramFloat = arguments.at(0).get<double>();
@@ -200,7 +241,9 @@ void MqttSimpleInterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_funcString = interfaceName() + "/rpc/funcString";
+    m_pendingSubscriptions.push_back(invokeTopic_funcString);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcString,
+        [this, invokeTopic_funcString](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcString, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             QString paramString = arguments.at(0).get<QString>();
@@ -326,6 +369,25 @@ void MqttSimpleInterfaceAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttSimpleInterfaceAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/tb_simple/mqtt/mqttsimpleinterfaceadapter.h
+++ b/goldenmaster/tb_simple/mqtt/mqttsimpleinterfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttSimpleInterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttSimpleInterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a SimpleInterface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_simple

--- a/goldenmaster/tb_simple/mqtt/mqttvoidinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttvoidinterface.cpp
@@ -107,7 +107,7 @@ const QString& MqttVoidInterface::interfaceName()
 }
 void MqttVoidInterface::subscribeForSignals()
 {
-        static const QString topicsigVoid = interfaceName() + "/sig/sigVoid";
+        const QString topicsigVoid = interfaceName() + "/sig/sigVoid";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigVoid, [this](const nlohmann::json& argumentsArray){
             emit sigVoid();}));
 }

--- a/goldenmaster/tb_simple/mqtt/mqttvoidinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttvoidinterface.cpp
@@ -79,11 +79,13 @@ QFuture<void> MqttVoidInterface::funcVoidAsync()
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcVoid");
     auto promise = std::make_shared<QPromise<void>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->finish();
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -91,7 +93,8 @@ QFuture<void> MqttVoidInterface::funcVoidAsync()
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->finish();
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({ });       

--- a/goldenmaster/tb_simple/mqtt/mqttvoidinterface.h
+++ b/goldenmaster/tb_simple/mqtt/mqttvoidinterface.h
@@ -58,12 +58,16 @@ public:
     * Remote call of IVoidInterface::funcVoid on the VoidInterface service.
     */
     QFuture<void> funcVoidAsync();
+    /**
+    * Use to check if the MqttVoidInterface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttVoidInterface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -83,9 +87,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttVoidInterface.
     * Handles incoming and outgoing messages.
@@ -113,6 +119,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace tb_simple

--- a/goldenmaster/tb_simple/mqtt/mqttvoidinterfaceadapter.cpp
+++ b/goldenmaster/tb_simple/mqtt/mqttvoidinterfaceadapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "tb.simple/VoidInterface";
 MqttVoidInterfaceAdapter::MqttVoidInterfaceAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractVoidInterface> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -49,12 +50,14 @@ MqttVoidInterfaceAdapter::MqttVoidInterfaceAdapter(ApiGear::Mqtt::ServiceAdapter
     {
         subscribeForInvokeRequests();
         connectServiceSignals();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttVoidInterfaceAdapter::~MqttVoidInterfaceAdapter()
@@ -63,6 +66,12 @@ MqttVoidInterfaceAdapter::~MqttVoidInterfaceAdapter()
     disconnect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::ready, 0, 0);
     unsubscribeAll();
 }
+
+bool MqttVoidInterfaceAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
 
 const QString& MqttVoidInterfaceAdapter::interfaceName()
 {
@@ -73,7 +82,9 @@ const QString& MqttVoidInterfaceAdapter::interfaceName()
 void MqttVoidInterfaceAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_funcVoid = interfaceName() + "/rpc/funcVoid";
+    m_pendingSubscriptions.push_back(invokeTopic_funcVoid);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_funcVoid,
+        [this, invokeTopic_funcVoid](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_funcVoid, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             m_impl->funcVoid( );
@@ -98,6 +109,25 @@ void MqttVoidInterfaceAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttVoidInterfaceAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/tb_simple/mqtt/mqttvoidinterfaceadapter.h
+++ b/goldenmaster/tb_simple/mqtt/mqttvoidinterfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttVoidInterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttVoidInterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for methods invoke requests from remote clients.
     void subscribeForInvokeRequests();
@@ -64,6 +73,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a VoidInterface that gets adapted to be a service in mqtt network.
@@ -74,8 +85,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace tb_simple

--- a/goldenmaster/tb_simple/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/tb_simple/mqtt/tests/CMakeLists.txt
@@ -29,6 +29,12 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 endif()
 
 set(TEST_TB_SIMPLE_GENERATED_MQTT_SOURCES
+    test_mqttvoidinterface.cpp
+    test_mqttsimpleinterface.cpp
+    test_mqttsimplearrayinterface.cpp
+    test_mqttnopropertiesinterface.cpp
+    test_mqttnooperationsinterface.cpp
+    test_mqttnosignalsinterface.cpp
     test_main.cpp
     )
 

--- a/goldenmaster/tb_simple/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/tb_simple/mqtt/tests/CMakeLists.txt
@@ -1,0 +1,60 @@
+
+cmake_minimum_required(VERSION 3.20)
+project(test_tb_simple_generated_mqtt)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(BUILD_TESTING)
+include(CTest)
+enable_testing()
+
+find_package(Qt6 REQUIRED COMPONENTS Test Core)
+find_package(apigear QUIET COMPONENTS apigear_mqtt)
+find_package(tb_simple QUIET COMPONENTS tb_simple_impl tb_simple_mqtt)
+
+find_package(Catch2 REQUIRED)
+
+set(CMAKE_CTEST_COMMAND ctest -V)
+if(NOT TARGET check)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+set(TEST_TB_SIMPLE_GENERATED_MQTT_SOURCES
+    test_main.cpp
+    )
+
+include_directories(test_tb_simple_generated_mqtt
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+add_executable(test_tb_simple_generated_mqtt ${TEST_TB_SIMPLE_GENERATED_MQTT_SOURCES})
+add_test(NAME test_tb_simple_generated_mqtt COMMAND $<TARGET_FILE:test_tb_simple_generated_mqtt>)
+add_dependencies(check test_tb_simple_generated_mqtt)
+
+target_link_libraries(test_tb_simple_generated_mqtt PRIVATE
+    apigear_mqtt
+    tb_simple_impl
+    tb_simple_mqtt
+    Catch2::Catch2
+    Qt::Test)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_tb_simple_generated_mqtt
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+
+endif() # BUILD_TESTING

--- a/goldenmaster/tb_simple/mqtt/tests/test_main.cpp
+++ b/goldenmaster/tb_simple/mqtt/tests/test_main.cpp
@@ -1,0 +1,12 @@
+#define CATCH_CONFIG_RUNNER
+
+#include <QCoreApplication>
+#include <catch2/catch.hpp>
+
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv); // -platform offscreen
+    int result = Catch::Session().run(argc, argv); // --break
+    return result;
+}

--- a/goldenmaster/tb_simple/mqtt/tests/test_mqttnooperationsinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/tests/test_mqttnooperationsinterface.cpp
@@ -1,0 +1,113 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/nooperationsinterface.h"
+#include "mqtt/mqttnooperationsinterface.h"
+#include "mqtt/mqttnooperationsinterfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.simple NoOperationsInterface tests")
+{
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientNoOperationsInterface = std::make_shared<tb_simple::MqttNoOperationsInterface >(client);
+    auto implNoOperationsInterface = std::make_shared<tb_simple::NoOperationsInterface>();
+    auto serviceNoOperationsInterface = std::make_shared<tb_simple::MqttNoOperationsInterfaceAdapter>(service, implNoOperationsInterface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientNoOperationsInterface, &serviceNoOperationsInterface]() {return clientNoOperationsInterface->isReady() && serviceNoOperationsInterface->isReady(); }, timeout));
+    SECTION("Test setting propBool")
+    {
+        std::atomic<bool> ispropBoolChanged = false;
+        clientNoOperationsInterface->connect(clientNoOperationsInterface.get(), &tb_simple::AbstractNoOperationsInterface::propBoolChanged, [&ispropBoolChanged ](auto value){ispropBoolChanged  = true;});
+        auto test_value = true;
+        clientNoOperationsInterface->setPropBool(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropBoolChanged]() {return ispropBoolChanged  == true; }, timeout));
+        REQUIRE(implNoOperationsInterface->propBool() == test_value);
+        REQUIRE(clientNoOperationsInterface->propBool() == test_value);
+    }
+    SECTION("Test setting propInt")
+    {
+        std::atomic<bool> ispropIntChanged = false;
+        clientNoOperationsInterface->connect(clientNoOperationsInterface.get(), &tb_simple::AbstractNoOperationsInterface::propIntChanged, [&ispropIntChanged ](auto value){ispropIntChanged  = true;});
+        auto test_value = 1;
+        clientNoOperationsInterface->setPropInt(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropIntChanged]() {return ispropIntChanged  == true; }, timeout));
+        REQUIRE(implNoOperationsInterface->propInt() == test_value);
+        REQUIRE(clientNoOperationsInterface->propInt() == test_value);
+    }
+    SECTION("Test emit sigVoid")
+    {
+        std::atomic<bool> issigVoidEmitted = false;
+
+        clientNoOperationsInterface->connect(clientNoOperationsInterface.get(), &tb_simple::AbstractNoOperationsInterface::sigVoid,
+        [&issigVoidEmitted]()
+        {
+            issigVoidEmitted  = true;
+        });
+
+        emit implNoOperationsInterface->sigVoid();
+        REQUIRE(QTest::qWaitFor([&issigVoidEmitted ]() {return issigVoidEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigBool")
+    {
+        std::atomic<bool> issigBoolEmitted = false;
+
+        clientNoOperationsInterface->connect(clientNoOperationsInterface.get(), &tb_simple::AbstractNoOperationsInterface::sigBool,
+        [&issigBoolEmitted](bool paramBool)
+        {
+            REQUIRE(paramBool == true);
+            issigBoolEmitted  = true;
+        });
+
+        emit implNoOperationsInterface->sigBool(true);
+        REQUIRE(QTest::qWaitFor([&issigBoolEmitted ]() {return issigBoolEmitted   == true; }, timeout));
+    }
+
+    clientNoOperationsInterface.reset();
+    serviceNoOperationsInterface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_simple/mqtt/tests/test_mqttnopropertiesinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/tests/test_mqttnopropertiesinterface.cpp
@@ -1,0 +1,142 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/nopropertiesinterface.h"
+#include "mqtt/mqttnopropertiesinterface.h"
+#include "mqtt/mqttnopropertiesinterfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.simple NoPropertiesInterface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientNoPropertiesInterface = std::make_shared<tb_simple::MqttNoPropertiesInterface >(client);
+    auto implNoPropertiesInterface = std::make_shared<tb_simple::NoPropertiesInterface>();
+    auto serviceNoPropertiesInterface = std::make_shared<tb_simple::MqttNoPropertiesInterfaceAdapter>(service, implNoPropertiesInterface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientNoPropertiesInterface, &serviceNoPropertiesInterface]() {return clientNoPropertiesInterface->isReady() && serviceNoPropertiesInterface->isReady(); }, timeout));
+    SECTION("Test emit sigVoid")
+    {
+        std::atomic<bool> issigVoidEmitted = false;
+
+        clientNoPropertiesInterface->connect(clientNoPropertiesInterface.get(), &tb_simple::AbstractNoPropertiesInterface::sigVoid,
+        [&issigVoidEmitted]()
+        {
+            issigVoidEmitted  = true;
+        });
+
+        emit implNoPropertiesInterface->sigVoid();
+        REQUIRE(QTest::qWaitFor([&issigVoidEmitted ]() {return issigVoidEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigBool")
+    {
+        std::atomic<bool> issigBoolEmitted = false;
+
+        clientNoPropertiesInterface->connect(clientNoPropertiesInterface.get(), &tb_simple::AbstractNoPropertiesInterface::sigBool,
+        [&issigBoolEmitted](bool paramBool)
+        {
+            REQUIRE(paramBool == true);
+            issigBoolEmitted  = true;
+        });
+
+        emit implNoPropertiesInterface->sigBool(true);
+        REQUIRE(QTest::qWaitFor([&issigBoolEmitted ]() {return issigBoolEmitted   == true; }, timeout));
+    }
+    SECTION("Test method funcVoid")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientNoPropertiesInterface, &finished](){
+            clientNoPropertiesInterface->funcVoid();
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcVoid async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNoPropertiesInterface->funcVoidAsync();
+        resultFuture.then([&finished](){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcBool")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientNoPropertiesInterface, &finished](){
+            [[maybe_unused]] auto result = clientNoPropertiesInterface->funcBool(false);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcBool async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNoPropertiesInterface->funcBoolAsync(false);
+        resultFuture.then([&finished](bool /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == false);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientNoPropertiesInterface.reset();
+    serviceNoPropertiesInterface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_simple/mqtt/tests/test_mqttnosignalsinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/tests/test_mqttnosignalsinterface.cpp
@@ -1,0 +1,135 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/nosignalsinterface.h"
+#include "mqtt/mqttnosignalsinterface.h"
+#include "mqtt/mqttnosignalsinterfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.simple NoSignalsInterface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientNoSignalsInterface = std::make_shared<tb_simple::MqttNoSignalsInterface >(client);
+    auto implNoSignalsInterface = std::make_shared<tb_simple::NoSignalsInterface>();
+    auto serviceNoSignalsInterface = std::make_shared<tb_simple::MqttNoSignalsInterfaceAdapter>(service, implNoSignalsInterface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientNoSignalsInterface, &serviceNoSignalsInterface]() {return clientNoSignalsInterface->isReady() && serviceNoSignalsInterface->isReady(); }, timeout));
+    SECTION("Test setting propBool")
+    {
+        std::atomic<bool> ispropBoolChanged = false;
+        clientNoSignalsInterface->connect(clientNoSignalsInterface.get(), &tb_simple::AbstractNoSignalsInterface::propBoolChanged, [&ispropBoolChanged ](auto value){ispropBoolChanged  = true;});
+        auto test_value = true;
+        clientNoSignalsInterface->setPropBool(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropBoolChanged]() {return ispropBoolChanged  == true; }, timeout));
+        REQUIRE(implNoSignalsInterface->propBool() == test_value);
+        REQUIRE(clientNoSignalsInterface->propBool() == test_value);
+    }
+    SECTION("Test setting propInt")
+    {
+        std::atomic<bool> ispropIntChanged = false;
+        clientNoSignalsInterface->connect(clientNoSignalsInterface.get(), &tb_simple::AbstractNoSignalsInterface::propIntChanged, [&ispropIntChanged ](auto value){ispropIntChanged  = true;});
+        auto test_value = 1;
+        clientNoSignalsInterface->setPropInt(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropIntChanged]() {return ispropIntChanged  == true; }, timeout));
+        REQUIRE(implNoSignalsInterface->propInt() == test_value);
+        REQUIRE(clientNoSignalsInterface->propInt() == test_value);
+    }
+    SECTION("Test method funcVoid")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientNoSignalsInterface, &finished](){
+            clientNoSignalsInterface->funcVoid();
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcVoid async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNoSignalsInterface->funcVoidAsync();
+        resultFuture.then([&finished](){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcBool")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientNoSignalsInterface, &finished](){
+            [[maybe_unused]] auto result = clientNoSignalsInterface->funcBool(false);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcBool async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNoSignalsInterface->funcBoolAsync(false);
+        resultFuture.then([&finished](bool /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == false);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientNoSignalsInterface.reset();
+    serviceNoSignalsInterface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_simple/mqtt/tests/test_mqttsimplearrayinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/tests/test_mqttsimplearrayinterface.cpp
@@ -1,0 +1,477 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/simplearrayinterface.h"
+#include "mqtt/mqttsimplearrayinterface.h"
+#include "mqtt/mqttsimplearrayinterfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.simple SimpleArrayInterface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientSimpleArrayInterface = std::make_shared<tb_simple::MqttSimpleArrayInterface >(client);
+    auto implSimpleArrayInterface = std::make_shared<tb_simple::SimpleArrayInterface>();
+    auto serviceSimpleArrayInterface = std::make_shared<tb_simple::MqttSimpleArrayInterfaceAdapter>(service, implSimpleArrayInterface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientSimpleArrayInterface, &serviceSimpleArrayInterface]() {return clientSimpleArrayInterface->isReady() && serviceSimpleArrayInterface->isReady(); }, timeout));
+    SECTION("Test setting propBool")
+    {
+        std::atomic<bool> ispropBoolChanged = false;
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::propBoolChanged, [&ispropBoolChanged ](auto value){ispropBoolChanged  = true;});
+        auto test_value = QList<bool>();  
+        test_value.append(true);
+        clientSimpleArrayInterface->setPropBool(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropBoolChanged]() {return ispropBoolChanged  == true; }, timeout));
+        REQUIRE(implSimpleArrayInterface->propBool() == test_value);
+        REQUIRE(clientSimpleArrayInterface->propBool() == test_value);
+    }
+    SECTION("Test setting propInt")
+    {
+        std::atomic<bool> ispropIntChanged = false;
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::propIntChanged, [&ispropIntChanged ](auto value){ispropIntChanged  = true;});
+        auto test_value = QList<int>();  
+        test_value.append(1);
+        clientSimpleArrayInterface->setPropInt(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropIntChanged]() {return ispropIntChanged  == true; }, timeout));
+        REQUIRE(implSimpleArrayInterface->propInt() == test_value);
+        REQUIRE(clientSimpleArrayInterface->propInt() == test_value);
+    }
+    SECTION("Test setting propInt32")
+    {
+        std::atomic<bool> ispropInt32Changed = false;
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::propInt32Changed, [&ispropInt32Changed ](auto value){ispropInt32Changed  = true;});
+        auto test_value = QList<qint32>();  
+        test_value.append(1);
+        clientSimpleArrayInterface->setPropInt32(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropInt32Changed]() {return ispropInt32Changed  == true; }, timeout));
+        REQUIRE(implSimpleArrayInterface->propInt32() == test_value);
+        REQUIRE(clientSimpleArrayInterface->propInt32() == test_value);
+    }
+    SECTION("Test setting propInt64")
+    {
+        std::atomic<bool> ispropInt64Changed = false;
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::propInt64Changed, [&ispropInt64Changed ](auto value){ispropInt64Changed  = true;});
+        auto test_value = QList<qint64>();  
+        test_value.append(1LL);
+        clientSimpleArrayInterface->setPropInt64(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropInt64Changed]() {return ispropInt64Changed  == true; }, timeout));
+        REQUIRE(implSimpleArrayInterface->propInt64() == test_value);
+        REQUIRE(clientSimpleArrayInterface->propInt64() == test_value);
+    }
+    SECTION("Test setting propFloat")
+    {
+        std::atomic<bool> ispropFloatChanged = false;
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::propFloatChanged, [&ispropFloatChanged ](auto value){ispropFloatChanged  = true;});
+        auto test_value = QList<qreal>();  
+        test_value.append(1.1f);
+        clientSimpleArrayInterface->setPropFloat(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropFloatChanged]() {return ispropFloatChanged  == true; }, timeout));
+        REQUIRE(implSimpleArrayInterface->propFloat() == test_value);
+        REQUIRE(clientSimpleArrayInterface->propFloat() == test_value);
+    }
+    SECTION("Test setting propFloat32")
+    {
+        std::atomic<bool> ispropFloat32Changed = false;
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::propFloat32Changed, [&ispropFloat32Changed ](auto value){ispropFloat32Changed  = true;});
+        auto test_value = QList<float>();  
+        test_value.append(1.1f);
+        clientSimpleArrayInterface->setPropFloat32(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropFloat32Changed]() {return ispropFloat32Changed  == true; }, timeout));
+        REQUIRE(implSimpleArrayInterface->propFloat32() == test_value);
+        REQUIRE(clientSimpleArrayInterface->propFloat32() == test_value);
+    }
+    SECTION("Test setting propFloat64")
+    {
+        std::atomic<bool> ispropFloat64Changed = false;
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::propFloat64Changed, [&ispropFloat64Changed ](auto value){ispropFloat64Changed  = true;});
+        auto test_value = QList<double>();  
+        test_value.append(1.1);
+        clientSimpleArrayInterface->setPropFloat64(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropFloat64Changed]() {return ispropFloat64Changed  == true; }, timeout));
+        REQUIRE(implSimpleArrayInterface->propFloat64() == test_value);
+        REQUIRE(clientSimpleArrayInterface->propFloat64() == test_value);
+    }
+    SECTION("Test setting propString")
+    {
+        std::atomic<bool> ispropStringChanged = false;
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::propStringChanged, [&ispropStringChanged ](auto value){ispropStringChanged  = true;});
+        auto test_value = QList<QString>();  
+        test_value.append(QString("xyz"));
+        clientSimpleArrayInterface->setPropString(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropStringChanged]() {return ispropStringChanged  == true; }, timeout));
+        REQUIRE(implSimpleArrayInterface->propString() == test_value);
+        REQUIRE(clientSimpleArrayInterface->propString() == test_value);
+    }
+    SECTION("Test emit sigBool")
+    {
+        std::atomic<bool> issigBoolEmitted = false;
+        auto local_param_bool_array = QList<bool>();
+        local_param_bool_array.append(true);
+
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::sigBool,
+        [&issigBoolEmitted, &local_param_bool_array](const QList<bool>& paramBool)
+        {
+            REQUIRE(paramBool == local_param_bool_array);
+            issigBoolEmitted  = true;
+        });
+
+        emit implSimpleArrayInterface->sigBool(local_param_bool_array);
+        REQUIRE(QTest::qWaitFor([&issigBoolEmitted ]() {return issigBoolEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigInt")
+    {
+        std::atomic<bool> issigIntEmitted = false;
+        auto local_param_int_array = QList<int>();
+        local_param_int_array.append(1);
+
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::sigInt,
+        [&issigIntEmitted, &local_param_int_array](const QList<int>& paramInt)
+        {
+            REQUIRE(paramInt == local_param_int_array);
+            issigIntEmitted  = true;
+        });
+
+        emit implSimpleArrayInterface->sigInt(local_param_int_array);
+        REQUIRE(QTest::qWaitFor([&issigIntEmitted ]() {return issigIntEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigInt32")
+    {
+        std::atomic<bool> issigInt32Emitted = false;
+        auto local_param_int32_array = QList<qint32>();
+        local_param_int32_array.append(1);
+
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::sigInt32,
+        [&issigInt32Emitted, &local_param_int32_array](const QList<qint32>& paramInt32)
+        {
+            REQUIRE(paramInt32 == local_param_int32_array);
+            issigInt32Emitted  = true;
+        });
+
+        emit implSimpleArrayInterface->sigInt32(local_param_int32_array);
+        REQUIRE(QTest::qWaitFor([&issigInt32Emitted ]() {return issigInt32Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigInt64")
+    {
+        std::atomic<bool> issigInt64Emitted = false;
+        auto local_param_int64_array = QList<qint64>();
+        local_param_int64_array.append(1LL);
+
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::sigInt64,
+        [&issigInt64Emitted, &local_param_int64_array](const QList<qint64>& paramInt64)
+        {
+            REQUIRE(paramInt64 == local_param_int64_array);
+            issigInt64Emitted  = true;
+        });
+
+        emit implSimpleArrayInterface->sigInt64(local_param_int64_array);
+        REQUIRE(QTest::qWaitFor([&issigInt64Emitted ]() {return issigInt64Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigFloat")
+    {
+        std::atomic<bool> issigFloatEmitted = false;
+        auto local_param_float_array = QList<qreal>();
+        local_param_float_array.append(1.1f);
+
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::sigFloat,
+        [&issigFloatEmitted, &local_param_float_array](const QList<qreal>& paramFloat)
+        {
+            REQUIRE(paramFloat == local_param_float_array);
+            issigFloatEmitted  = true;
+        });
+
+        emit implSimpleArrayInterface->sigFloat(local_param_float_array);
+        REQUIRE(QTest::qWaitFor([&issigFloatEmitted ]() {return issigFloatEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigFloat32")
+    {
+        std::atomic<bool> issigFloat32Emitted = false;
+        auto local_param_floa32_array = QList<float>();
+        local_param_floa32_array.append(1.1f);
+
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::sigFloat32,
+        [&issigFloat32Emitted, &local_param_floa32_array](const QList<float>& paramFloa32)
+        {
+            REQUIRE(paramFloa32 == local_param_floa32_array);
+            issigFloat32Emitted  = true;
+        });
+
+        emit implSimpleArrayInterface->sigFloat32(local_param_floa32_array);
+        REQUIRE(QTest::qWaitFor([&issigFloat32Emitted ]() {return issigFloat32Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigFloat64")
+    {
+        std::atomic<bool> issigFloat64Emitted = false;
+        auto local_param_float64_array = QList<double>();
+        local_param_float64_array.append(1.1);
+
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::sigFloat64,
+        [&issigFloat64Emitted, &local_param_float64_array](const QList<double>& paramFloat64)
+        {
+            REQUIRE(paramFloat64 == local_param_float64_array);
+            issigFloat64Emitted  = true;
+        });
+
+        emit implSimpleArrayInterface->sigFloat64(local_param_float64_array);
+        REQUIRE(QTest::qWaitFor([&issigFloat64Emitted ]() {return issigFloat64Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigString")
+    {
+        std::atomic<bool> issigStringEmitted = false;
+        auto local_param_string_array = QList<QString>();
+        local_param_string_array.append(QString("xyz"));
+
+        clientSimpleArrayInterface->connect(clientSimpleArrayInterface.get(), &tb_simple::AbstractSimpleArrayInterface::sigString,
+        [&issigStringEmitted, &local_param_string_array](const QList<QString>& paramString)
+        {
+            REQUIRE(paramString == local_param_string_array);
+            issigStringEmitted  = true;
+        });
+
+        emit implSimpleArrayInterface->sigString(local_param_string_array);
+        REQUIRE(QTest::qWaitFor([&issigStringEmitted ]() {return issigStringEmitted   == true; }, timeout));
+    }
+    SECTION("Test method funcBool")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleArrayInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleArrayInterface->funcBool(QList<bool>());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcBool async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleArrayInterface->funcBoolAsync(QList<bool>());
+        resultFuture.then([&finished](QList<bool> /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == QList<bool>());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcInt")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleArrayInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleArrayInterface->funcInt(QList<int>());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcInt async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleArrayInterface->funcIntAsync(QList<int>());
+        resultFuture.then([&finished](QList<int> /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == QList<int>());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcInt32")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleArrayInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleArrayInterface->funcInt32(QList<qint32>());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcInt32 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleArrayInterface->funcInt32Async(QList<qint32>());
+        resultFuture.then([&finished](QList<qint32> /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == QList<qint32>());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcInt64")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleArrayInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleArrayInterface->funcInt64(QList<qint64>());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcInt64 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleArrayInterface->funcInt64Async(QList<qint64>());
+        resultFuture.then([&finished](QList<qint64> /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == QList<qint64>());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcFloat")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleArrayInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleArrayInterface->funcFloat(QList<qreal>());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcFloat async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleArrayInterface->funcFloatAsync(QList<qreal>());
+        resultFuture.then([&finished](QList<qreal> /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == QList<qreal>());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcFloat32")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleArrayInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleArrayInterface->funcFloat32(QList<float>());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcFloat32 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleArrayInterface->funcFloat32Async(QList<float>());
+        resultFuture.then([&finished](QList<float> /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == QList<float>());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcFloat64")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleArrayInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleArrayInterface->funcFloat64(QList<double>());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcFloat64 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleArrayInterface->funcFloat64Async(QList<double>());
+        resultFuture.then([&finished](QList<double> /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == QList<double>());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcString")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleArrayInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleArrayInterface->funcString(QList<QString>());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcString async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleArrayInterface->funcStringAsync(QList<QString>());
+        resultFuture.then([&finished](QList<QString> /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == QList<QString>());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientSimpleArrayInterface.reset();
+    serviceSimpleArrayInterface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_simple/mqtt/tests/test_mqttsimpleinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/tests/test_mqttsimpleinterface.cpp
@@ -1,0 +1,475 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/simpleinterface.h"
+#include "mqtt/mqttsimpleinterface.h"
+#include "mqtt/mqttsimpleinterfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.simple SimpleInterface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientSimpleInterface = std::make_shared<tb_simple::MqttSimpleInterface >(client);
+    auto implSimpleInterface = std::make_shared<tb_simple::SimpleInterface>();
+    auto serviceSimpleInterface = std::make_shared<tb_simple::MqttSimpleInterfaceAdapter>(service, implSimpleInterface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientSimpleInterface, &serviceSimpleInterface]() {return clientSimpleInterface->isReady() && serviceSimpleInterface->isReady(); }, timeout));
+    SECTION("Test setting propBool")
+    {
+        std::atomic<bool> ispropBoolChanged = false;
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::propBoolChanged, [&ispropBoolChanged ](auto value){ispropBoolChanged  = true;});
+        auto test_value = true;
+        clientSimpleInterface->setPropBool(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropBoolChanged]() {return ispropBoolChanged  == true; }, timeout));
+        REQUIRE(implSimpleInterface->propBool() == test_value);
+        REQUIRE(clientSimpleInterface->propBool() == test_value);
+    }
+    SECTION("Test setting propInt")
+    {
+        std::atomic<bool> ispropIntChanged = false;
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::propIntChanged, [&ispropIntChanged ](auto value){ispropIntChanged  = true;});
+        auto test_value = 1;
+        clientSimpleInterface->setPropInt(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropIntChanged]() {return ispropIntChanged  == true; }, timeout));
+        REQUIRE(implSimpleInterface->propInt() == test_value);
+        REQUIRE(clientSimpleInterface->propInt() == test_value);
+    }
+    SECTION("Test setting propInt32")
+    {
+        std::atomic<bool> ispropInt32Changed = false;
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::propInt32Changed, [&ispropInt32Changed ](auto value){ispropInt32Changed  = true;});
+        auto test_value = 1;
+        clientSimpleInterface->setPropInt32(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropInt32Changed]() {return ispropInt32Changed  == true; }, timeout));
+        REQUIRE(implSimpleInterface->propInt32() == test_value);
+        REQUIRE(clientSimpleInterface->propInt32() == test_value);
+    }
+    SECTION("Test setting propInt64")
+    {
+        std::atomic<bool> ispropInt64Changed = false;
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::propInt64Changed, [&ispropInt64Changed ](auto value){ispropInt64Changed  = true;});
+        auto test_value = 1LL;
+        clientSimpleInterface->setPropInt64(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropInt64Changed]() {return ispropInt64Changed  == true; }, timeout));
+        REQUIRE(implSimpleInterface->propInt64() == test_value);
+        REQUIRE(clientSimpleInterface->propInt64() == test_value);
+    }
+    SECTION("Test setting propFloat")
+    {
+        std::atomic<bool> ispropFloatChanged = false;
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::propFloatChanged, [&ispropFloatChanged ](auto value){ispropFloatChanged  = true;});
+        auto test_value = 1.1f;
+        clientSimpleInterface->setPropFloat(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropFloatChanged]() {return ispropFloatChanged  == true; }, timeout));
+        REQUIRE(implSimpleInterface->propFloat() == test_value);
+        REQUIRE(clientSimpleInterface->propFloat() == test_value);
+    }
+    SECTION("Test setting propFloat32")
+    {
+        std::atomic<bool> ispropFloat32Changed = false;
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::propFloat32Changed, [&ispropFloat32Changed ](auto value){ispropFloat32Changed  = true;});
+        auto test_value = 1.1f;
+        clientSimpleInterface->setPropFloat32(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropFloat32Changed]() {return ispropFloat32Changed  == true; }, timeout));
+        REQUIRE(implSimpleInterface->propFloat32() == test_value);
+        REQUIRE(clientSimpleInterface->propFloat32() == test_value);
+    }
+    SECTION("Test setting propFloat64")
+    {
+        std::atomic<bool> ispropFloat64Changed = false;
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::propFloat64Changed, [&ispropFloat64Changed ](auto value){ispropFloat64Changed  = true;});
+        auto test_value = 1.1;
+        clientSimpleInterface->setPropFloat64(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropFloat64Changed]() {return ispropFloat64Changed  == true; }, timeout));
+        REQUIRE(implSimpleInterface->propFloat64() == test_value);
+        REQUIRE(clientSimpleInterface->propFloat64() == test_value);
+    }
+    SECTION("Test setting propString")
+    {
+        std::atomic<bool> ispropStringChanged = false;
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::propStringChanged, [&ispropStringChanged ](auto value){ispropStringChanged  = true;});
+        auto test_value = QString("xyz");
+        clientSimpleInterface->setPropString(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropStringChanged]() {return ispropStringChanged  == true; }, timeout));
+        REQUIRE(implSimpleInterface->propString() == test_value);
+        REQUIRE(clientSimpleInterface->propString() == test_value);
+    }
+    SECTION("Test emit sigBool")
+    {
+        std::atomic<bool> issigBoolEmitted = false;
+
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::sigBool,
+        [&issigBoolEmitted](bool paramBool)
+        {
+            REQUIRE(paramBool == true);
+            issigBoolEmitted  = true;
+        });
+
+        emit implSimpleInterface->sigBool(true);
+        REQUIRE(QTest::qWaitFor([&issigBoolEmitted ]() {return issigBoolEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigInt")
+    {
+        std::atomic<bool> issigIntEmitted = false;
+
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::sigInt,
+        [&issigIntEmitted](int paramInt)
+        {
+            REQUIRE(paramInt == 1);
+            issigIntEmitted  = true;
+        });
+
+        emit implSimpleInterface->sigInt(1);
+        REQUIRE(QTest::qWaitFor([&issigIntEmitted ]() {return issigIntEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigInt32")
+    {
+        std::atomic<bool> issigInt32Emitted = false;
+
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::sigInt32,
+        [&issigInt32Emitted](qint32 paramInt32)
+        {
+            REQUIRE(paramInt32 == 1);
+            issigInt32Emitted  = true;
+        });
+
+        emit implSimpleInterface->sigInt32(1);
+        REQUIRE(QTest::qWaitFor([&issigInt32Emitted ]() {return issigInt32Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigInt64")
+    {
+        std::atomic<bool> issigInt64Emitted = false;
+
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::sigInt64,
+        [&issigInt64Emitted](qint64 paramInt64)
+        {
+            REQUIRE(paramInt64 == 1LL);
+            issigInt64Emitted  = true;
+        });
+
+        emit implSimpleInterface->sigInt64(1LL);
+        REQUIRE(QTest::qWaitFor([&issigInt64Emitted ]() {return issigInt64Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigFloat")
+    {
+        std::atomic<bool> issigFloatEmitted = false;
+
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::sigFloat,
+        [&issigFloatEmitted](qreal paramFloat)
+        {
+            REQUIRE(paramFloat == 1.1f);
+            issigFloatEmitted  = true;
+        });
+
+        emit implSimpleInterface->sigFloat(1.1f);
+        REQUIRE(QTest::qWaitFor([&issigFloatEmitted ]() {return issigFloatEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigFloat32")
+    {
+        std::atomic<bool> issigFloat32Emitted = false;
+
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::sigFloat32,
+        [&issigFloat32Emitted](float paramFloat32)
+        {
+            REQUIRE(paramFloat32 == 1.1f);
+            issigFloat32Emitted  = true;
+        });
+
+        emit implSimpleInterface->sigFloat32(1.1f);
+        REQUIRE(QTest::qWaitFor([&issigFloat32Emitted ]() {return issigFloat32Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigFloat64")
+    {
+        std::atomic<bool> issigFloat64Emitted = false;
+
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::sigFloat64,
+        [&issigFloat64Emitted](double paramFloat64)
+        {
+            REQUIRE(paramFloat64 == 1.1);
+            issigFloat64Emitted  = true;
+        });
+
+        emit implSimpleInterface->sigFloat64(1.1);
+        REQUIRE(QTest::qWaitFor([&issigFloat64Emitted ]() {return issigFloat64Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigString")
+    {
+        std::atomic<bool> issigStringEmitted = false;
+
+        clientSimpleInterface->connect(clientSimpleInterface.get(), &tb_simple::AbstractSimpleInterface::sigString,
+        [&issigStringEmitted](const QString& paramString)
+        {
+            REQUIRE(paramString == QString("xyz"));
+            issigStringEmitted  = true;
+        });
+
+        emit implSimpleInterface->sigString(QString("xyz"));
+        REQUIRE(QTest::qWaitFor([&issigStringEmitted ]() {return issigStringEmitted   == true; }, timeout));
+    }
+    SECTION("Test method funcNoReturnValue")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleInterface, &finished](){
+            clientSimpleInterface->funcNoReturnValue(false);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcNoReturnValue async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcNoReturnValueAsync(false);
+        resultFuture.then([&finished](){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcBool")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleInterface->funcBool(false);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcBool async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcBoolAsync(false);
+        resultFuture.then([&finished](bool /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == false);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcInt")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleInterface->funcInt(0);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcInt async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcIntAsync(0);
+        resultFuture.then([&finished](int /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == 0);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcInt32")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleInterface->funcInt32(0);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcInt32 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcInt32Async(0);
+        resultFuture.then([&finished](qint32 /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == 0);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcInt64")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleInterface->funcInt64(0LL);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcInt64 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcInt64Async(0LL);
+        resultFuture.then([&finished](qint64 /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == 0LL);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcFloat")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleInterface->funcFloat(0.0f);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcFloat async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcFloatAsync(0.0f);
+        resultFuture.then([&finished](qreal /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == 0.0f);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcFloat32")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleInterface->funcFloat32(0.0f);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcFloat32 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcFloat32Async(0.0f);
+        resultFuture.then([&finished](float /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == 0.0f);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcFloat64")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleInterface->funcFloat64(0.0);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcFloat64 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcFloat64Async(0.0);
+        resultFuture.then([&finished](double /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == 0.0);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcString")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientSimpleInterface, &finished](){
+            [[maybe_unused]] auto result = clientSimpleInterface->funcString(QString());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcString async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcStringAsync(QString());
+        resultFuture.then([&finished](QString /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == QString());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientSimpleInterface.reset();
+    serviceSimpleInterface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/tb_simple/mqtt/tests/test_mqttvoidinterface.cpp
+++ b/goldenmaster/tb_simple/mqtt/tests/test_mqttvoidinterface.cpp
@@ -1,0 +1,104 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/voidinterface.h"
+#include "mqtt/mqttvoidinterface.h"
+#include "mqtt/mqttvoidinterfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  tb.simple VoidInterface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientVoidInterface = std::make_shared<tb_simple::MqttVoidInterface >(client);
+    auto implVoidInterface = std::make_shared<tb_simple::VoidInterface>();
+    auto serviceVoidInterface = std::make_shared<tb_simple::MqttVoidInterfaceAdapter>(service, implVoidInterface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientVoidInterface, &serviceVoidInterface]() {return clientVoidInterface->isReady() && serviceVoidInterface->isReady(); }, timeout));
+    SECTION("Test emit sigVoid")
+    {
+        std::atomic<bool> issigVoidEmitted = false;
+
+        clientVoidInterface->connect(clientVoidInterface.get(), &tb_simple::AbstractVoidInterface::sigVoid,
+        [&issigVoidEmitted]()
+        {
+            issigVoidEmitted  = true;
+        });
+
+        emit implVoidInterface->sigVoid();
+        REQUIRE(QTest::qWaitFor([&issigVoidEmitted ]() {return issigVoidEmitted   == true; }, timeout));
+    }
+    SECTION("Test method funcVoid")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientVoidInterface, &finished](){
+            clientVoidInterface->funcVoid();
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcVoid async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientVoidInterface->funcVoidAsync();
+        resultFuture.then([&finished](){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientVoidInterface.reset();
+    serviceVoidInterface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/testbed1/mqtt/CMakeLists.txt
+++ b/goldenmaster/testbed1/mqtt/CMakeLists.txt
@@ -33,6 +33,10 @@ target_include_directories(testbed1_mqtt
     $<INSTALL_INTERFACE:include/testbed1>
 )
 
+if (ENABLE_MQTT_TEST_FOR_NON_LINUX_OS OR ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")))
+add_subdirectory(tests)
+endif()
+
 target_link_libraries(testbed1_mqtt PUBLIC testbed1::testbed1_api apigear::apigear_mqtt Qt6::Concurrent)
 target_compile_definitions(testbed1_mqtt PRIVATE TESTBED1_MQTT_LIBRARY)
 

--- a/goldenmaster/testbed1/mqtt/mqttstructarrayinterface.cpp
+++ b/goldenmaster/testbed1/mqtt/mqttstructarrayinterface.cpp
@@ -193,11 +193,14 @@ QFuture<QList<StructBool>> MqttStructArrayInterface::funcBoolAsync(const QList<S
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcBool");
     auto promise = std::make_shared<QPromise<QList<StructBool>>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(QList<StructBool>());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -205,7 +208,9 @@ QFuture<QList<StructBool>> MqttStructArrayInterface::funcBoolAsync(const QList<S
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(QList<StructBool>());
+        promise->addResult(QList<StructBool>());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramBool });       
@@ -214,6 +219,7 @@ QFuture<QList<StructBool>> MqttStructArrayInterface::funcBoolAsync(const QList<S
         {
             QList<StructBool> value = arg.get<QList<StructBool>>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -236,11 +242,14 @@ QFuture<QList<StructInt>> MqttStructArrayInterface::funcIntAsync(const QList<Str
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcInt");
     auto promise = std::make_shared<QPromise<QList<StructInt>>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(QList<StructInt>());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -248,7 +257,9 @@ QFuture<QList<StructInt>> MqttStructArrayInterface::funcIntAsync(const QList<Str
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(QList<StructInt>());
+        promise->addResult(QList<StructInt>());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramInt });       
@@ -257,6 +268,7 @@ QFuture<QList<StructInt>> MqttStructArrayInterface::funcIntAsync(const QList<Str
         {
             QList<StructInt> value = arg.get<QList<StructInt>>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -279,11 +291,14 @@ QFuture<QList<StructFloat>> MqttStructArrayInterface::funcFloatAsync(const QList
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcFloat");
     auto promise = std::make_shared<QPromise<QList<StructFloat>>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(QList<StructFloat>());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -291,7 +306,9 @@ QFuture<QList<StructFloat>> MqttStructArrayInterface::funcFloatAsync(const QList
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(QList<StructFloat>());
+        promise->addResult(QList<StructFloat>());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramFloat });       
@@ -300,6 +317,7 @@ QFuture<QList<StructFloat>> MqttStructArrayInterface::funcFloatAsync(const QList
         {
             QList<StructFloat> value = arg.get<QList<StructFloat>>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -322,11 +340,14 @@ QFuture<QList<StructString>> MqttStructArrayInterface::funcStringAsync(const QLi
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcString");
     auto promise = std::make_shared<QPromise<QList<StructString>>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(QList<StructString>());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -334,7 +355,9 @@ QFuture<QList<StructString>> MqttStructArrayInterface::funcStringAsync(const QLi
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(QList<StructString>());
+        promise->addResult(QList<StructString>());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramString });       
@@ -343,6 +366,7 @@ QFuture<QList<StructString>> MqttStructArrayInterface::funcStringAsync(const QLi
         {
             QList<StructString> value = arg.get<QList<StructString>>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/testbed1/mqtt/mqttstructarrayinterface.cpp
+++ b/goldenmaster/testbed1/mqtt/mqttstructarrayinterface.cpp
@@ -351,27 +351,27 @@ const QString& MqttStructArrayInterface::interfaceName()
 }
 void MqttStructArrayInterface::subscribeForPropertiesChanges()
 {
-        static const QString topicpropBool = interfaceName() + "/prop/propBool";
+        const QString topicpropBool = interfaceName() + "/prop/propBool";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropBool, [this](auto& value) { setPropBoolLocal(value);}));
-        static const QString topicpropInt = interfaceName() + "/prop/propInt";
+        const QString topicpropInt = interfaceName() + "/prop/propInt";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt, [this](auto& value) { setPropIntLocal(value);}));
-        static const QString topicpropFloat = interfaceName() + "/prop/propFloat";
+        const QString topicpropFloat = interfaceName() + "/prop/propFloat";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat, [this](auto& value) { setPropFloatLocal(value);}));
-        static const QString topicpropString = interfaceName() + "/prop/propString";
+        const QString topicpropString = interfaceName() + "/prop/propString";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropString, [this](auto& value) { setPropStringLocal(value);}));
 }
 void MqttStructArrayInterface::subscribeForSignals()
 {
-        static const QString topicsigBool = interfaceName() + "/sig/sigBool";
+        const QString topicsigBool = interfaceName() + "/sig/sigBool";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigBool, [this](const nlohmann::json& argumentsArray){
             emit sigBool(argumentsArray[0].get<QList<StructBool>>());}));
-        static const QString topicsigInt = interfaceName() + "/sig/sigInt";
+        const QString topicsigInt = interfaceName() + "/sig/sigInt";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt, [this](const nlohmann::json& argumentsArray){
             emit sigInt(argumentsArray[0].get<QList<StructInt>>());}));
-        static const QString topicsigFloat = interfaceName() + "/sig/sigFloat";
+        const QString topicsigFloat = interfaceName() + "/sig/sigFloat";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat, [this](const nlohmann::json& argumentsArray){
             emit sigFloat(argumentsArray[0].get<QList<StructFloat>>());}));
-        static const QString topicsigString = interfaceName() + "/sig/sigString";
+        const QString topicsigString = interfaceName() + "/sig/sigString";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigString, [this](const nlohmann::json& argumentsArray){
             emit sigString(argumentsArray[0].get<QList<StructString>>());}));
 }

--- a/goldenmaster/testbed1/mqtt/mqttstructarrayinterface.h
+++ b/goldenmaster/testbed1/mqtt/mqttstructarrayinterface.h
@@ -125,12 +125,16 @@ public:
     * Remote call of IStructArrayInterface::funcString on the StructArrayInterface service.
     */
     QFuture<QList<StructString>> funcStringAsync(const QList<StructString>& paramString);
+    /**
+    * Use to check if the MqttStructArrayInterface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttStructArrayInterface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -168,9 +172,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttStructArrayInterface.
     * Handles incoming and outgoing messages.
@@ -198,6 +204,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace testbed1

--- a/goldenmaster/testbed1/mqtt/mqttstructarrayinterfaceadapter.h
+++ b/goldenmaster/testbed1/mqtt/mqttstructarrayinterfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttStructArrayInterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttStructArrayInterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a StructArrayInterface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace testbed1

--- a/goldenmaster/testbed1/mqtt/mqttstructinterface.cpp
+++ b/goldenmaster/testbed1/mqtt/mqttstructinterface.cpp
@@ -36,7 +36,7 @@ MqttStructInterface::MqttStructInterface(ApiGear::Mqtt::Client& client, QObject 
     , m_propInt(StructInt())
     , m_propFloat(StructFloat())
     , m_propString(StructString())
-    , m_isReady(false)
+    , m_finishedInitialization(false)
     , m_client(client)
 {
     if (m_client.isReady())
@@ -50,11 +50,13 @@ MqttStructInterface::MqttStructInterface(ApiGear::Mqtt::Client& client, QObject 
             subscribeForPropertiesChanges();
             subscribeForSignals();
             subscribeForInvokeResponses();
+            m_finishedInitialization = true;
     });
     connect(&m_client, &ApiGear::Mqtt::Client::disconnected, [this](){
         m_subscribedIds.clear();
         m_InvokeCallsInfo.clear();
     });
+    m_finishedInitialization = m_client.isReady();
 }
 
 MqttStructInterface::~MqttStructInterface()
@@ -62,6 +64,11 @@ MqttStructInterface::~MqttStructInterface()
     disconnect(&m_client, &ApiGear::Mqtt::Client::disconnected, 0, 0);
     disconnect(&m_client, &ApiGear::Mqtt::Client::ready, 0, 0);
     unsubscribeAll();
+}
+
+bool MqttStructInterface::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
 }
 
 void MqttStructInterface::setPropBool(const StructBool& propBool)
@@ -349,37 +356,80 @@ const QString& MqttStructInterface::interfaceName()
 {
     return InterfaceName;
 }
+
+void MqttStructInterface::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
+    }
+}
 void MqttStructInterface::subscribeForPropertiesChanges()
 {
+        // Subscription may succeed, before finising the function that subscribes it and assigns an id for if it was already added (and succeeded) for same topic,
+        // hence, for pending subscriptions a topic is used, and added before the subscribe function.
         const QString topicpropBool = interfaceName() + "/prop/propBool";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropBool, [this](auto& value) { setPropBoolLocal(value);}));
+        m_pendingSubscriptions.push_back(topicpropBool);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropBool,
+            [this, topicpropBool](auto id, bool hasSucceed){handleOnSubscribed(topicpropBool, id, hasSucceed);},
+            [this](auto& value) { setPropBoolLocal(value);}));
         const QString topicpropInt = interfaceName() + "/prop/propInt";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt, [this](auto& value) { setPropIntLocal(value);}));
+        m_pendingSubscriptions.push_back(topicpropInt);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt,
+            [this, topicpropInt](auto id, bool hasSucceed){handleOnSubscribed(topicpropInt, id, hasSucceed);},
+            [this](auto& value) { setPropIntLocal(value);}));
         const QString topicpropFloat = interfaceName() + "/prop/propFloat";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat, [this](auto& value) { setPropFloatLocal(value);}));
+        m_pendingSubscriptions.push_back(topicpropFloat);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat,
+            [this, topicpropFloat](auto id, bool hasSucceed){handleOnSubscribed(topicpropFloat, id, hasSucceed);},
+            [this](auto& value) { setPropFloatLocal(value);}));
         const QString topicpropString = interfaceName() + "/prop/propString";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropString, [this](auto& value) { setPropStringLocal(value);}));
+        m_pendingSubscriptions.push_back(topicpropString);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicpropString,
+            [this, topicpropString](auto id, bool hasSucceed){handleOnSubscribed(topicpropString, id, hasSucceed);},
+            [this](auto& value) { setPropStringLocal(value);}));
 }
 void MqttStructInterface::subscribeForSignals()
 {
         const QString topicsigBool = interfaceName() + "/sig/sigBool";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigBool, [this](const nlohmann::json& argumentsArray){
-            emit sigBool(argumentsArray[0].get<StructBool>());}));
+        m_pendingSubscriptions.push_back(topicsigBool);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigBool,
+            [this, topicsigBool](auto id, bool hasSucceed){handleOnSubscribed(topicsigBool, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigBool(argumentsArray[0].get<StructBool>());}));
         const QString topicsigInt = interfaceName() + "/sig/sigInt";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt, [this](const nlohmann::json& argumentsArray){
-            emit sigInt(argumentsArray[0].get<StructInt>());}));
+        m_pendingSubscriptions.push_back(topicsigInt);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt,
+            [this, topicsigInt](auto id, bool hasSucceed){handleOnSubscribed(topicsigInt, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigInt(argumentsArray[0].get<StructInt>());}));
         const QString topicsigFloat = interfaceName() + "/sig/sigFloat";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat, [this](const nlohmann::json& argumentsArray){
-            emit sigFloat(argumentsArray[0].get<StructFloat>());}));
+        m_pendingSubscriptions.push_back(topicsigFloat);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat,
+            [this, topicsigFloat](auto id, bool hasSucceed){handleOnSubscribed(topicsigFloat, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigFloat(argumentsArray[0].get<StructFloat>());}));
         const QString topicsigString = interfaceName() + "/sig/sigString";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigString, [this](const nlohmann::json& argumentsArray){
-            emit sigString(argumentsArray[0].get<StructString>());}));
+        m_pendingSubscriptions.push_back(topicsigString);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsigString,
+            [this, topicsigString](auto id, bool hasSucceed){handleOnSubscribed(topicsigString, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sigString(argumentsArray[0].get<StructString>());}));
 }
 void MqttStructInterface::subscribeForInvokeResponses()
 {
     const QString topicfuncBool = interfaceName() + "/rpc/funcBool";
     const QString topicfuncBoolInvokeResp = interfaceName() + "/rpc/funcBool"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncBoolInvokeResp);
     auto id_funcBool = m_client.subscribeForInvokeResponse(topicfuncBoolInvokeResp, 
+                        [this, topicfuncBoolInvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncBoolInvokeResp, id, hasSucceed);},
                         [this, topicfuncBoolInvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncBoolInvokeResp);
@@ -387,7 +437,9 @@ void MqttStructInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncBool] = std::make_pair(topicfuncBoolInvokeResp, id_funcBool);
     const QString topicfuncInt = interfaceName() + "/rpc/funcInt";
     const QString topicfuncIntInvokeResp = interfaceName() + "/rpc/funcInt"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncIntInvokeResp);
     auto id_funcInt = m_client.subscribeForInvokeResponse(topicfuncIntInvokeResp, 
+                        [this, topicfuncIntInvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncIntInvokeResp, id, hasSucceed);},
                         [this, topicfuncIntInvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncIntInvokeResp);
@@ -395,7 +447,9 @@ void MqttStructInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncInt] = std::make_pair(topicfuncIntInvokeResp, id_funcInt);
     const QString topicfuncFloat = interfaceName() + "/rpc/funcFloat";
     const QString topicfuncFloatInvokeResp = interfaceName() + "/rpc/funcFloat"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncFloatInvokeResp);
     auto id_funcFloat = m_client.subscribeForInvokeResponse(topicfuncFloatInvokeResp, 
+                        [this, topicfuncFloatInvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncFloatInvokeResp, id, hasSucceed);},
                         [this, topicfuncFloatInvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncFloatInvokeResp);
@@ -403,7 +457,9 @@ void MqttStructInterface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfuncFloat] = std::make_pair(topicfuncFloatInvokeResp, id_funcFloat);
     const QString topicfuncString = interfaceName() + "/rpc/funcString";
     const QString topicfuncStringInvokeResp = interfaceName() + "/rpc/funcString"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfuncStringInvokeResp);
     auto id_funcString = m_client.subscribeForInvokeResponse(topicfuncStringInvokeResp, 
+                        [this, topicfuncStringInvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfuncStringInvokeResp, id, hasSucceed);},
                         [this, topicfuncStringInvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfuncStringInvokeResp);

--- a/goldenmaster/testbed1/mqtt/mqttstructinterface.cpp
+++ b/goldenmaster/testbed1/mqtt/mqttstructinterface.cpp
@@ -193,11 +193,14 @@ QFuture<StructBool> MqttStructInterface::funcBoolAsync(const StructBool& paramBo
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcBool");
     auto promise = std::make_shared<QPromise<StructBool>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(StructBool());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -205,7 +208,9 @@ QFuture<StructBool> MqttStructInterface::funcBoolAsync(const StructBool& paramBo
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(StructBool());
+        promise->addResult(StructBool());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramBool });       
@@ -214,6 +219,7 @@ QFuture<StructBool> MqttStructInterface::funcBoolAsync(const StructBool& paramBo
         {
             StructBool value = arg.get<StructBool>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -236,11 +242,14 @@ QFuture<StructInt> MqttStructInterface::funcIntAsync(const StructInt& paramInt)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcInt");
     auto promise = std::make_shared<QPromise<StructInt>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(StructInt());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -248,7 +257,9 @@ QFuture<StructInt> MqttStructInterface::funcIntAsync(const StructInt& paramInt)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(StructInt());
+        promise->addResult(StructInt());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramInt });       
@@ -257,6 +268,7 @@ QFuture<StructInt> MqttStructInterface::funcIntAsync(const StructInt& paramInt)
         {
             StructInt value = arg.get<StructInt>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -279,11 +291,14 @@ QFuture<StructFloat> MqttStructInterface::funcFloatAsync(const StructFloat& para
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcFloat");
     auto promise = std::make_shared<QPromise<StructFloat>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(StructFloat());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -291,7 +306,9 @@ QFuture<StructFloat> MqttStructInterface::funcFloatAsync(const StructFloat& para
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(StructFloat());
+        promise->addResult(StructFloat());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramFloat });       
@@ -300,6 +317,7 @@ QFuture<StructFloat> MqttStructInterface::funcFloatAsync(const StructFloat& para
         {
             StructFloat value = arg.get<StructFloat>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -322,11 +340,14 @@ QFuture<StructString> MqttStructInterface::funcStringAsync(const StructString& p
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/funcString");
     auto promise = std::make_shared<QPromise<StructString>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(StructString());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -334,7 +355,9 @@ QFuture<StructString> MqttStructInterface::funcStringAsync(const StructString& p
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(StructString());
+        promise->addResult(StructString());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({paramString });       
@@ -343,6 +366,7 @@ QFuture<StructString> MqttStructInterface::funcStringAsync(const StructString& p
         {
             StructString value = arg.get<StructString>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/testbed1/mqtt/mqttstructinterface.cpp
+++ b/goldenmaster/testbed1/mqtt/mqttstructinterface.cpp
@@ -351,27 +351,27 @@ const QString& MqttStructInterface::interfaceName()
 }
 void MqttStructInterface::subscribeForPropertiesChanges()
 {
-        static const QString topicpropBool = interfaceName() + "/prop/propBool";
+        const QString topicpropBool = interfaceName() + "/prop/propBool";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropBool, [this](auto& value) { setPropBoolLocal(value);}));
-        static const QString topicpropInt = interfaceName() + "/prop/propInt";
+        const QString topicpropInt = interfaceName() + "/prop/propInt";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropInt, [this](auto& value) { setPropIntLocal(value);}));
-        static const QString topicpropFloat = interfaceName() + "/prop/propFloat";
+        const QString topicpropFloat = interfaceName() + "/prop/propFloat";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropFloat, [this](auto& value) { setPropFloatLocal(value);}));
-        static const QString topicpropString = interfaceName() + "/prop/propString";
+        const QString topicpropString = interfaceName() + "/prop/propString";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicpropString, [this](auto& value) { setPropStringLocal(value);}));
 }
 void MqttStructInterface::subscribeForSignals()
 {
-        static const QString topicsigBool = interfaceName() + "/sig/sigBool";
+        const QString topicsigBool = interfaceName() + "/sig/sigBool";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigBool, [this](const nlohmann::json& argumentsArray){
             emit sigBool(argumentsArray[0].get<StructBool>());}));
-        static const QString topicsigInt = interfaceName() + "/sig/sigInt";
+        const QString topicsigInt = interfaceName() + "/sig/sigInt";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigInt, [this](const nlohmann::json& argumentsArray){
             emit sigInt(argumentsArray[0].get<StructInt>());}));
-        static const QString topicsigFloat = interfaceName() + "/sig/sigFloat";
+        const QString topicsigFloat = interfaceName() + "/sig/sigFloat";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigFloat, [this](const nlohmann::json& argumentsArray){
             emit sigFloat(argumentsArray[0].get<StructFloat>());}));
-        static const QString topicsigString = interfaceName() + "/sig/sigString";
+        const QString topicsigString = interfaceName() + "/sig/sigString";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsigString, [this](const nlohmann::json& argumentsArray){
             emit sigString(argumentsArray[0].get<StructString>());}));
 }

--- a/goldenmaster/testbed1/mqtt/mqttstructinterface.h
+++ b/goldenmaster/testbed1/mqtt/mqttstructinterface.h
@@ -125,12 +125,16 @@ public:
     * Remote call of IStructInterface::funcString on the StructInterface service.
     */
     QFuture<StructString> funcStringAsync(const StructString& paramString);
+    /**
+    * Use to check if the MqttStructInterface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttStructInterface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -168,9 +172,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttStructInterface.
     * Handles incoming and outgoing messages.
@@ -198,6 +204,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace testbed1

--- a/goldenmaster/testbed1/mqtt/mqttstructinterfaceadapter.h
+++ b/goldenmaster/testbed1/mqtt/mqttstructinterfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttStructInterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttStructInterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a StructInterface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace testbed1

--- a/goldenmaster/testbed1/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/testbed1/mqtt/tests/CMakeLists.txt
@@ -29,6 +29,8 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 endif()
 
 set(TEST_TESTBED1_GENERATED_MQTT_SOURCES
+    test_mqttstructinterface.cpp
+    test_mqttstructarrayinterface.cpp
     test_main.cpp
     )
 

--- a/goldenmaster/testbed1/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/testbed1/mqtt/tests/CMakeLists.txt
@@ -1,0 +1,60 @@
+
+cmake_minimum_required(VERSION 3.20)
+project(test_testbed1_generated_mqtt)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(BUILD_TESTING)
+include(CTest)
+enable_testing()
+
+find_package(Qt6 REQUIRED COMPONENTS Test Core)
+find_package(apigear QUIET COMPONENTS apigear_mqtt)
+find_package(testbed1 QUIET COMPONENTS testbed1_impl testbed1_mqtt)
+
+find_package(Catch2 REQUIRED)
+
+set(CMAKE_CTEST_COMMAND ctest -V)
+if(NOT TARGET check)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+set(TEST_TESTBED1_GENERATED_MQTT_SOURCES
+    test_main.cpp
+    )
+
+include_directories(test_testbed1_generated_mqtt
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+add_executable(test_testbed1_generated_mqtt ${TEST_TESTBED1_GENERATED_MQTT_SOURCES})
+add_test(NAME test_testbed1_generated_mqtt COMMAND $<TARGET_FILE:test_testbed1_generated_mqtt>)
+add_dependencies(check test_testbed1_generated_mqtt)
+
+target_link_libraries(test_testbed1_generated_mqtt PRIVATE
+    apigear_mqtt
+    testbed1_impl
+    testbed1_mqtt
+    Catch2::Catch2
+    Qt::Test)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_testbed1_generated_mqtt
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+
+endif() # BUILD_TESTING

--- a/goldenmaster/testbed1/mqtt/tests/test_main.cpp
+++ b/goldenmaster/testbed1/mqtt/tests/test_main.cpp
@@ -1,0 +1,12 @@
+#define CATCH_CONFIG_RUNNER
+
+#include <QCoreApplication>
+#include <catch2/catch.hpp>
+
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv); // -platform offscreen
+    int result = Catch::Session().run(argc, argv); // --break
+    return result;
+}

--- a/goldenmaster/testbed1/mqtt/tests/test_mqttstructarrayinterface.cpp
+++ b/goldenmaster/testbed1/mqtt/tests/test_mqttstructarrayinterface.cpp
@@ -1,0 +1,289 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/structarrayinterface.h"
+#include "mqtt/mqttstructarrayinterface.h"
+#include "mqtt/mqttstructarrayinterfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  testbed1 StructArrayInterface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientStructArrayInterface = std::make_shared<testbed1::MqttStructArrayInterface >(client);
+    auto implStructArrayInterface = std::make_shared<testbed1::StructArrayInterface>();
+    auto serviceStructArrayInterface = std::make_shared<testbed1::MqttStructArrayInterfaceAdapter>(service, implStructArrayInterface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientStructArrayInterface, &serviceStructArrayInterface]() {return clientStructArrayInterface->isReady() && serviceStructArrayInterface->isReady(); }, timeout));
+    SECTION("Test setting propBool")
+    {
+        std::atomic<bool> ispropBoolChanged = false;
+        clientStructArrayInterface->connect(clientStructArrayInterface.get(), &testbed1::AbstractStructArrayInterface::propBoolChanged, [&ispropBoolChanged ](auto value){ispropBoolChanged  = true;});
+        auto test_value = QList<testbed1::StructBool>();
+        auto element = testbed1::StructBool();
+        testbed1::fillTestStructBool(element);
+        test_value.append(element);
+        clientStructArrayInterface->setPropBool(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropBoolChanged]() {return ispropBoolChanged  == true; }, timeout));
+        REQUIRE(implStructArrayInterface->propBool() == test_value);
+        REQUIRE(clientStructArrayInterface->propBool() == test_value);
+    }
+    SECTION("Test setting propInt")
+    {
+        std::atomic<bool> ispropIntChanged = false;
+        clientStructArrayInterface->connect(clientStructArrayInterface.get(), &testbed1::AbstractStructArrayInterface::propIntChanged, [&ispropIntChanged ](auto value){ispropIntChanged  = true;});
+        auto test_value = QList<testbed1::StructInt>();
+        auto element = testbed1::StructInt();
+        testbed1::fillTestStructInt(element);
+        test_value.append(element);
+        clientStructArrayInterface->setPropInt(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropIntChanged]() {return ispropIntChanged  == true; }, timeout));
+        REQUIRE(implStructArrayInterface->propInt() == test_value);
+        REQUIRE(clientStructArrayInterface->propInt() == test_value);
+    }
+    SECTION("Test setting propFloat")
+    {
+        std::atomic<bool> ispropFloatChanged = false;
+        clientStructArrayInterface->connect(clientStructArrayInterface.get(), &testbed1::AbstractStructArrayInterface::propFloatChanged, [&ispropFloatChanged ](auto value){ispropFloatChanged  = true;});
+        auto test_value = QList<testbed1::StructFloat>();
+        auto element = testbed1::StructFloat();
+        testbed1::fillTestStructFloat(element);
+        test_value.append(element);
+        clientStructArrayInterface->setPropFloat(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropFloatChanged]() {return ispropFloatChanged  == true; }, timeout));
+        REQUIRE(implStructArrayInterface->propFloat() == test_value);
+        REQUIRE(clientStructArrayInterface->propFloat() == test_value);
+    }
+    SECTION("Test setting propString")
+    {
+        std::atomic<bool> ispropStringChanged = false;
+        clientStructArrayInterface->connect(clientStructArrayInterface.get(), &testbed1::AbstractStructArrayInterface::propStringChanged, [&ispropStringChanged ](auto value){ispropStringChanged  = true;});
+        auto test_value = QList<testbed1::StructString>();
+        auto element = testbed1::StructString();
+        testbed1::fillTestStructString(element);
+        test_value.append(element);
+        clientStructArrayInterface->setPropString(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropStringChanged]() {return ispropStringChanged  == true; }, timeout));
+        REQUIRE(implStructArrayInterface->propString() == test_value);
+        REQUIRE(clientStructArrayInterface->propString() == test_value);
+    }
+    SECTION("Test emit sigBool")
+    {
+        std::atomic<bool> issigBoolEmitted = false;
+        auto local_param_bool_array = QList<testbed1::StructBool>();
+        auto element_paramBool = testbed1::StructBool();
+        testbed1::fillTestStructBool(element_paramBool);
+        local_param_bool_array .append(element_paramBool);
+
+        clientStructArrayInterface->connect(clientStructArrayInterface.get(), &testbed1::AbstractStructArrayInterface::sigBool,
+        [&issigBoolEmitted, &local_param_bool_array](const QList<testbed1::StructBool>& paramBool)
+        {
+            REQUIRE(paramBool == local_param_bool_array);
+            issigBoolEmitted  = true;
+        });
+
+        emit implStructArrayInterface->sigBool(local_param_bool_array);
+        REQUIRE(QTest::qWaitFor([&issigBoolEmitted ]() {return issigBoolEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigInt")
+    {
+        std::atomic<bool> issigIntEmitted = false;
+        auto local_param_int_array = QList<testbed1::StructInt>();
+        auto element_paramInt = testbed1::StructInt();
+        testbed1::fillTestStructInt(element_paramInt);
+        local_param_int_array .append(element_paramInt);
+
+        clientStructArrayInterface->connect(clientStructArrayInterface.get(), &testbed1::AbstractStructArrayInterface::sigInt,
+        [&issigIntEmitted, &local_param_int_array](const QList<testbed1::StructInt>& paramInt)
+        {
+            REQUIRE(paramInt == local_param_int_array);
+            issigIntEmitted  = true;
+        });
+
+        emit implStructArrayInterface->sigInt(local_param_int_array);
+        REQUIRE(QTest::qWaitFor([&issigIntEmitted ]() {return issigIntEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigFloat")
+    {
+        std::atomic<bool> issigFloatEmitted = false;
+        auto local_param_float_array = QList<testbed1::StructFloat>();
+        auto element_paramFloat = testbed1::StructFloat();
+        testbed1::fillTestStructFloat(element_paramFloat);
+        local_param_float_array .append(element_paramFloat);
+
+        clientStructArrayInterface->connect(clientStructArrayInterface.get(), &testbed1::AbstractStructArrayInterface::sigFloat,
+        [&issigFloatEmitted, &local_param_float_array](const QList<testbed1::StructFloat>& paramFloat)
+        {
+            REQUIRE(paramFloat == local_param_float_array);
+            issigFloatEmitted  = true;
+        });
+
+        emit implStructArrayInterface->sigFloat(local_param_float_array);
+        REQUIRE(QTest::qWaitFor([&issigFloatEmitted ]() {return issigFloatEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigString")
+    {
+        std::atomic<bool> issigStringEmitted = false;
+        auto local_param_string_array = QList<testbed1::StructString>();
+        auto element_paramString = testbed1::StructString();
+        testbed1::fillTestStructString(element_paramString);
+        local_param_string_array .append(element_paramString);
+
+        clientStructArrayInterface->connect(clientStructArrayInterface.get(), &testbed1::AbstractStructArrayInterface::sigString,
+        [&issigStringEmitted, &local_param_string_array](const QList<testbed1::StructString>& paramString)
+        {
+            REQUIRE(paramString == local_param_string_array);
+            issigStringEmitted  = true;
+        });
+
+        emit implStructArrayInterface->sigString(local_param_string_array);
+        REQUIRE(QTest::qWaitFor([&issigStringEmitted ]() {return issigStringEmitted   == true; }, timeout));
+    }
+    SECTION("Test method funcBool")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientStructArrayInterface, &finished](){
+            [[maybe_unused]] auto result = clientStructArrayInterface->funcBool(QList<testbed1::StructBool>());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcBool async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayInterface->funcBoolAsync(QList<testbed1::StructBool>());
+        resultFuture.then([&finished](QList<testbed1::StructBool> /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == QList<testbed1::StructBool>());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcInt")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientStructArrayInterface, &finished](){
+            [[maybe_unused]] auto result = clientStructArrayInterface->funcInt(QList<testbed1::StructInt>());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcInt async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayInterface->funcIntAsync(QList<testbed1::StructInt>());
+        resultFuture.then([&finished](QList<testbed1::StructInt> /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == QList<testbed1::StructInt>());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcFloat")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientStructArrayInterface, &finished](){
+            [[maybe_unused]] auto result = clientStructArrayInterface->funcFloat(QList<testbed1::StructFloat>());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcFloat async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayInterface->funcFloatAsync(QList<testbed1::StructFloat>());
+        resultFuture.then([&finished](QList<testbed1::StructFloat> /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == QList<testbed1::StructFloat>());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcString")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientStructArrayInterface, &finished](){
+            [[maybe_unused]] auto result = clientStructArrayInterface->funcString(QList<testbed1::StructString>());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcString async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayInterface->funcStringAsync(QList<testbed1::StructString>());
+        resultFuture.then([&finished](QList<testbed1::StructString> /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == QList<testbed1::StructString>());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientStructArrayInterface.reset();
+    serviceStructArrayInterface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/testbed1/mqtt/tests/test_mqttstructinterface.cpp
+++ b/goldenmaster/testbed1/mqtt/tests/test_mqttstructinterface.cpp
@@ -1,0 +1,273 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/structinterface.h"
+#include "mqtt/mqttstructinterface.h"
+#include "mqtt/mqttstructinterfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  testbed1 StructInterface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientStructInterface = std::make_shared<testbed1::MqttStructInterface >(client);
+    auto implStructInterface = std::make_shared<testbed1::StructInterface>();
+    auto serviceStructInterface = std::make_shared<testbed1::MqttStructInterfaceAdapter>(service, implStructInterface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientStructInterface, &serviceStructInterface]() {return clientStructInterface->isReady() && serviceStructInterface->isReady(); }, timeout));
+    SECTION("Test setting propBool")
+    {
+        std::atomic<bool> ispropBoolChanged = false;
+        clientStructInterface->connect(clientStructInterface.get(), &testbed1::AbstractStructInterface::propBoolChanged, [&ispropBoolChanged ](auto value){ispropBoolChanged  = true;});
+        auto test_value = testbed1::StructBool();
+        testbed1::fillTestStructBool(test_value);
+        clientStructInterface->setPropBool(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropBoolChanged]() {return ispropBoolChanged  == true; }, timeout));
+        REQUIRE(implStructInterface->propBool() == test_value);
+        REQUIRE(clientStructInterface->propBool() == test_value);
+    }
+    SECTION("Test setting propInt")
+    {
+        std::atomic<bool> ispropIntChanged = false;
+        clientStructInterface->connect(clientStructInterface.get(), &testbed1::AbstractStructInterface::propIntChanged, [&ispropIntChanged ](auto value){ispropIntChanged  = true;});
+        auto test_value = testbed1::StructInt();
+        testbed1::fillTestStructInt(test_value);
+        clientStructInterface->setPropInt(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropIntChanged]() {return ispropIntChanged  == true; }, timeout));
+        REQUIRE(implStructInterface->propInt() == test_value);
+        REQUIRE(clientStructInterface->propInt() == test_value);
+    }
+    SECTION("Test setting propFloat")
+    {
+        std::atomic<bool> ispropFloatChanged = false;
+        clientStructInterface->connect(clientStructInterface.get(), &testbed1::AbstractStructInterface::propFloatChanged, [&ispropFloatChanged ](auto value){ispropFloatChanged  = true;});
+        auto test_value = testbed1::StructFloat();
+        testbed1::fillTestStructFloat(test_value);
+        clientStructInterface->setPropFloat(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropFloatChanged]() {return ispropFloatChanged  == true; }, timeout));
+        REQUIRE(implStructInterface->propFloat() == test_value);
+        REQUIRE(clientStructInterface->propFloat() == test_value);
+    }
+    SECTION("Test setting propString")
+    {
+        std::atomic<bool> ispropStringChanged = false;
+        clientStructInterface->connect(clientStructInterface.get(), &testbed1::AbstractStructInterface::propStringChanged, [&ispropStringChanged ](auto value){ispropStringChanged  = true;});
+        auto test_value = testbed1::StructString();
+        testbed1::fillTestStructString(test_value);
+        clientStructInterface->setPropString(test_value);
+        REQUIRE(QTest::qWaitFor([&ispropStringChanged]() {return ispropStringChanged  == true; }, timeout));
+        REQUIRE(implStructInterface->propString() == test_value);
+        REQUIRE(clientStructInterface->propString() == test_value);
+    }
+    SECTION("Test emit sigBool")
+    {
+        std::atomic<bool> issigBoolEmitted = false;
+        auto local_param_bool_struct = testbed1::StructBool();
+        testbed1::fillTestStructBool(local_param_bool_struct);
+
+        clientStructInterface->connect(clientStructInterface.get(), &testbed1::AbstractStructInterface::sigBool,
+        [&issigBoolEmitted, &local_param_bool_struct](const testbed1::StructBool& paramBool)
+        {
+            REQUIRE(paramBool ==local_param_bool_struct);
+            issigBoolEmitted  = true;
+        });
+
+        emit implStructInterface->sigBool(local_param_bool_struct);
+        REQUIRE(QTest::qWaitFor([&issigBoolEmitted ]() {return issigBoolEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigInt")
+    {
+        std::atomic<bool> issigIntEmitted = false;
+        auto local_param_int_struct = testbed1::StructInt();
+        testbed1::fillTestStructInt(local_param_int_struct);
+
+        clientStructInterface->connect(clientStructInterface.get(), &testbed1::AbstractStructInterface::sigInt,
+        [&issigIntEmitted, &local_param_int_struct](const testbed1::StructInt& paramInt)
+        {
+            REQUIRE(paramInt ==local_param_int_struct);
+            issigIntEmitted  = true;
+        });
+
+        emit implStructInterface->sigInt(local_param_int_struct);
+        REQUIRE(QTest::qWaitFor([&issigIntEmitted ]() {return issigIntEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigFloat")
+    {
+        std::atomic<bool> issigFloatEmitted = false;
+        auto local_param_float_struct = testbed1::StructFloat();
+        testbed1::fillTestStructFloat(local_param_float_struct);
+
+        clientStructInterface->connect(clientStructInterface.get(), &testbed1::AbstractStructInterface::sigFloat,
+        [&issigFloatEmitted, &local_param_float_struct](const testbed1::StructFloat& paramFloat)
+        {
+            REQUIRE(paramFloat ==local_param_float_struct);
+            issigFloatEmitted  = true;
+        });
+
+        emit implStructInterface->sigFloat(local_param_float_struct);
+        REQUIRE(QTest::qWaitFor([&issigFloatEmitted ]() {return issigFloatEmitted   == true; }, timeout));
+    }
+    SECTION("Test emit sigString")
+    {
+        std::atomic<bool> issigStringEmitted = false;
+        auto local_param_string_struct = testbed1::StructString();
+        testbed1::fillTestStructString(local_param_string_struct);
+
+        clientStructInterface->connect(clientStructInterface.get(), &testbed1::AbstractStructInterface::sigString,
+        [&issigStringEmitted, &local_param_string_struct](const testbed1::StructString& paramString)
+        {
+            REQUIRE(paramString ==local_param_string_struct);
+            issigStringEmitted  = true;
+        });
+
+        emit implStructInterface->sigString(local_param_string_struct);
+        REQUIRE(QTest::qWaitFor([&issigStringEmitted ]() {return issigStringEmitted   == true; }, timeout));
+    }
+    SECTION("Test method funcBool")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientStructInterface, &finished](){
+            [[maybe_unused]] auto result = clientStructInterface->funcBool(testbed1::StructBool());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcBool async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructInterface->funcBoolAsync(testbed1::StructBool());
+        resultFuture.then([&finished](testbed1::StructBool /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == testbed1::StructBool());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcInt")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientStructInterface, &finished](){
+            [[maybe_unused]] auto result = clientStructInterface->funcInt(testbed1::StructInt());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcInt async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructInterface->funcIntAsync(testbed1::StructInt());
+        resultFuture.then([&finished](testbed1::StructInt /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == testbed1::StructInt());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcFloat")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientStructInterface, &finished](){
+            [[maybe_unused]] auto result = clientStructInterface->funcFloat(testbed1::StructFloat());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcFloat async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructInterface->funcFloatAsync(testbed1::StructFloat());
+        resultFuture.then([&finished](testbed1::StructFloat /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == testbed1::StructFloat());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcString")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientStructInterface, &finished](){
+            [[maybe_unused]] auto result = clientStructInterface->funcString(testbed1::StructString());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method funcString async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructInterface->funcStringAsync(testbed1::StructString());
+        resultFuture.then([&finished](testbed1::StructString /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == testbed1::StructString());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientStructInterface.reset();
+    serviceStructInterface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/testbed2/mqtt/CMakeLists.txt
+++ b/goldenmaster/testbed2/mqtt/CMakeLists.txt
@@ -37,6 +37,10 @@ target_include_directories(testbed2_mqtt
     $<INSTALL_INTERFACE:include/testbed2>
 )
 
+if (ENABLE_MQTT_TEST_FOR_NON_LINUX_OS OR ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")))
+add_subdirectory(tests)
+endif()
+
 target_link_libraries(testbed2_mqtt PUBLIC testbed2::testbed2_api apigear::apigear_mqtt Qt6::Concurrent)
 target_compile_definitions(testbed2_mqtt PRIVATE TESTBED2_MQTT_LIBRARY)
 

--- a/goldenmaster/testbed2/mqtt/mqttmanyparaminterface.cpp
+++ b/goldenmaster/testbed2/mqtt/mqttmanyparaminterface.cpp
@@ -193,11 +193,14 @@ QFuture<int> MqttManyParamInterface::func1Async(int param1)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func1");
     auto promise = std::make_shared<QPromise<int>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(0);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -205,7 +208,9 @@ QFuture<int> MqttManyParamInterface::func1Async(int param1)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(0);
+        promise->addResult(0);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1 });       
@@ -214,6 +219,7 @@ QFuture<int> MqttManyParamInterface::func1Async(int param1)
         {
             int value = arg.get<int>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -236,11 +242,14 @@ QFuture<int> MqttManyParamInterface::func2Async(int param1, int param2)
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func2");
     auto promise = std::make_shared<QPromise<int>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(0);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -248,7 +257,9 @@ QFuture<int> MqttManyParamInterface::func2Async(int param1, int param2)
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(0);
+        promise->addResult(0);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1, param2 });       
@@ -257,6 +268,7 @@ QFuture<int> MqttManyParamInterface::func2Async(int param1, int param2)
         {
             int value = arg.get<int>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -279,11 +291,14 @@ QFuture<int> MqttManyParamInterface::func3Async(int param1, int param2, int para
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func3");
     auto promise = std::make_shared<QPromise<int>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(0);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -291,7 +306,9 @@ QFuture<int> MqttManyParamInterface::func3Async(int param1, int param2, int para
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(0);
+        promise->addResult(0);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1, param2, param3 });       
@@ -300,6 +317,7 @@ QFuture<int> MqttManyParamInterface::func3Async(int param1, int param2, int para
         {
             int value = arg.get<int>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -322,11 +340,14 @@ QFuture<int> MqttManyParamInterface::func4Async(int param1, int param2, int para
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func4");
     auto promise = std::make_shared<QPromise<int>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(0);
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -334,7 +355,9 @@ QFuture<int> MqttManyParamInterface::func4Async(int param1, int param2, int para
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(0);
+        promise->addResult(0);
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1, param2, param3, param4 });       
@@ -343,6 +366,7 @@ QFuture<int> MqttManyParamInterface::func4Async(int param1, int param2, int para
         {
             int value = arg.get<int>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/testbed2/mqtt/mqttmanyparaminterface.cpp
+++ b/goldenmaster/testbed2/mqtt/mqttmanyparaminterface.cpp
@@ -351,27 +351,27 @@ const QString& MqttManyParamInterface::interfaceName()
 }
 void MqttManyParamInterface::subscribeForPropertiesChanges()
 {
-        static const QString topicprop1 = interfaceName() + "/prop/prop1";
+        const QString topicprop1 = interfaceName() + "/prop/prop1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
-        static const QString topicprop2 = interfaceName() + "/prop/prop2";
+        const QString topicprop2 = interfaceName() + "/prop/prop2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2, [this](auto& value) { setProp2Local(value);}));
-        static const QString topicprop3 = interfaceName() + "/prop/prop3";
+        const QString topicprop3 = interfaceName() + "/prop/prop3";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop3, [this](auto& value) { setProp3Local(value);}));
-        static const QString topicprop4 = interfaceName() + "/prop/prop4";
+        const QString topicprop4 = interfaceName() + "/prop/prop4";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop4, [this](auto& value) { setProp4Local(value);}));
 }
 void MqttManyParamInterface::subscribeForSignals()
 {
-        static const QString topicsig1 = interfaceName() + "/sig/sig1";
+        const QString topicsig1 = interfaceName() + "/sig/sig1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
             emit sig1(argumentsArray[0].get<int>());}));
-        static const QString topicsig2 = interfaceName() + "/sig/sig2";
+        const QString topicsig2 = interfaceName() + "/sig/sig2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2, [this](const nlohmann::json& argumentsArray){
             emit sig2(argumentsArray[0].get<int>(),argumentsArray[1].get<int>());}));
-        static const QString topicsig3 = interfaceName() + "/sig/sig3";
+        const QString topicsig3 = interfaceName() + "/sig/sig3";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig3, [this](const nlohmann::json& argumentsArray){
             emit sig3(argumentsArray[0].get<int>(),argumentsArray[1].get<int>(),argumentsArray[2].get<int>());}));
-        static const QString topicsig4 = interfaceName() + "/sig/sig4";
+        const QString topicsig4 = interfaceName() + "/sig/sig4";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig4, [this](const nlohmann::json& argumentsArray){
             emit sig4(argumentsArray[0].get<int>(),argumentsArray[1].get<int>(),argumentsArray[2].get<int>(),argumentsArray[3].get<int>());}));
 }

--- a/goldenmaster/testbed2/mqtt/mqttmanyparaminterface.h
+++ b/goldenmaster/testbed2/mqtt/mqttmanyparaminterface.h
@@ -125,12 +125,16 @@ public:
     * Remote call of IManyParamInterface::func4 on the ManyParamInterface service.
     */
     QFuture<int> func4Async(int param1, int param2, int param3, int param4);
+    /**
+    * Use to check if the MqttManyParamInterface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttManyParamInterface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -168,9 +172,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttManyParamInterface.
     * Handles incoming and outgoing messages.
@@ -198,6 +204,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace testbed2

--- a/goldenmaster/testbed2/mqtt/mqttmanyparaminterfaceadapter.h
+++ b/goldenmaster/testbed2/mqtt/mqttmanyparaminterfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttManyParamInterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttManyParamInterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a ManyParamInterface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace testbed2

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct1interface.cpp
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct1interface.cpp
@@ -138,12 +138,12 @@ const QString& MqttNestedStruct1Interface::interfaceName()
 }
 void MqttNestedStruct1Interface::subscribeForPropertiesChanges()
 {
-        static const QString topicprop1 = interfaceName() + "/prop/prop1";
+        const QString topicprop1 = interfaceName() + "/prop/prop1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
 }
 void MqttNestedStruct1Interface::subscribeForSignals()
 {
-        static const QString topicsig1 = interfaceName() + "/sig/sig1";
+        const QString topicsig1 = interfaceName() + "/sig/sig1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
             emit sig1(argumentsArray[0].get<NestedStruct1>());}));
 }

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct1interface.cpp
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct1interface.cpp
@@ -33,7 +33,7 @@ const QString InterfaceName = "testbed2/NestedStruct1Interface";
 MqttNestedStruct1Interface::MqttNestedStruct1Interface(ApiGear::Mqtt::Client& client, QObject *parent)
     : AbstractNestedStruct1Interface(parent)
     , m_prop1(NestedStruct1())
-    , m_isReady(false)
+    , m_finishedInitialization(false)
     , m_client(client)
 {
     if (m_client.isReady())
@@ -47,11 +47,13 @@ MqttNestedStruct1Interface::MqttNestedStruct1Interface(ApiGear::Mqtt::Client& cl
             subscribeForPropertiesChanges();
             subscribeForSignals();
             subscribeForInvokeResponses();
+            m_finishedInitialization = true;
     });
     connect(&m_client, &ApiGear::Mqtt::Client::disconnected, [this](){
         m_subscribedIds.clear();
         m_InvokeCallsInfo.clear();
     });
+    m_finishedInitialization = m_client.isReady();
 }
 
 MqttNestedStruct1Interface::~MqttNestedStruct1Interface()
@@ -59,6 +61,11 @@ MqttNestedStruct1Interface::~MqttNestedStruct1Interface()
     disconnect(&m_client, &ApiGear::Mqtt::Client::disconnected, 0, 0);
     disconnect(&m_client, &ApiGear::Mqtt::Client::ready, 0, 0);
     unsubscribeAll();
+}
+
+bool MqttNestedStruct1Interface::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
 }
 
 void MqttNestedStruct1Interface::setProp1(const NestedStruct1& prop1)
@@ -136,22 +143,50 @@ const QString& MqttNestedStruct1Interface::interfaceName()
 {
     return InterfaceName;
 }
+
+void MqttNestedStruct1Interface::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
+    }
+}
 void MqttNestedStruct1Interface::subscribeForPropertiesChanges()
 {
+        // Subscription may succeed, before finising the function that subscribes it and assigns an id for if it was already added (and succeeded) for same topic,
+        // hence, for pending subscriptions a topic is used, and added before the subscribe function.
         const QString topicprop1 = interfaceName() + "/prop/prop1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
+        m_pendingSubscriptions.push_back(topicprop1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1,
+            [this, topicprop1](auto id, bool hasSucceed){handleOnSubscribed(topicprop1, id, hasSucceed);},
+            [this](auto& value) { setProp1Local(value);}));
 }
 void MqttNestedStruct1Interface::subscribeForSignals()
 {
         const QString topicsig1 = interfaceName() + "/sig/sig1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
-            emit sig1(argumentsArray[0].get<NestedStruct1>());}));
+        m_pendingSubscriptions.push_back(topicsig1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1,
+            [this, topicsig1](auto id, bool hasSucceed){handleOnSubscribed(topicsig1, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sig1(argumentsArray[0].get<NestedStruct1>());}));
 }
 void MqttNestedStruct1Interface::subscribeForInvokeResponses()
 {
     const QString topicfunc1 = interfaceName() + "/rpc/func1";
     const QString topicfunc1InvokeResp = interfaceName() + "/rpc/func1"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfunc1InvokeResp);
     auto id_func1 = m_client.subscribeForInvokeResponse(topicfunc1InvokeResp, 
+                        [this, topicfunc1InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfunc1InvokeResp, id, hasSucceed);},
                         [this, topicfunc1InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfunc1InvokeResp);

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct1interface.cpp
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct1interface.cpp
@@ -109,11 +109,14 @@ QFuture<NestedStruct1> MqttNestedStruct1Interface::func1Async(const NestedStruct
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func1");
     auto promise = std::make_shared<QPromise<NestedStruct1>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(NestedStruct1());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -121,7 +124,9 @@ QFuture<NestedStruct1> MqttNestedStruct1Interface::func1Async(const NestedStruct
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(NestedStruct1());
+        promise->addResult(NestedStruct1());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1 });       
@@ -130,6 +135,7 @@ QFuture<NestedStruct1> MqttNestedStruct1Interface::func1Async(const NestedStruct
         {
             NestedStruct1 value = arg.get<NestedStruct1>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct1interface.h
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct1interface.h
@@ -68,12 +68,16 @@ public:
     * Remote call of INestedStruct1Interface::func1 on the NestedStruct1Interface service.
     */
     QFuture<NestedStruct1> func1Async(const NestedStruct1& param1);
+    /**
+    * Use to check if the MqttNestedStruct1Interface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttNestedStruct1Interface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -99,9 +103,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttNestedStruct1Interface.
     * Handles incoming and outgoing messages.
@@ -129,6 +135,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace testbed2

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct1interfaceadapter.cpp
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct1interfaceadapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "testbed2/NestedStruct1Interface";
 MqttNestedStruct1InterfaceAdapter::MqttNestedStruct1InterfaceAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractNestedStruct1Interface> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -53,12 +54,14 @@ MqttNestedStruct1InterfaceAdapter::MqttNestedStruct1InterfaceAdapter(ApiGear::Mq
         subscribeForInvokeRequests();
         connectServicePropertiesChanges();
         connectServiceSignals();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttNestedStruct1InterfaceAdapter::~MqttNestedStruct1InterfaceAdapter()
@@ -68,6 +71,12 @@ MqttNestedStruct1InterfaceAdapter::~MqttNestedStruct1InterfaceAdapter()
     unsubscribeAll();
 }
 
+bool MqttNestedStruct1InterfaceAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
+
 const QString& MqttNestedStruct1InterfaceAdapter::interfaceName()
 {
     return InterfaceName;
@@ -76,7 +85,9 @@ const QString& MqttNestedStruct1InterfaceAdapter::interfaceName()
 void MqttNestedStruct1InterfaceAdapter::subscribeForPropertiesChanges()
 {
     const auto setTopic_prop1 = interfaceName() + "/set/prop1";
+    m_pendingSubscriptions.push_back(setTopic_prop1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop1,
+        [this, setTopic_prop1](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop1, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             NestedStruct1 prop1 = value.get<NestedStruct1>();
@@ -87,7 +98,9 @@ void MqttNestedStruct1InterfaceAdapter::subscribeForPropertiesChanges()
 void MqttNestedStruct1InterfaceAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_func1 = interfaceName() + "/rpc/func1";
+    m_pendingSubscriptions.push_back(invokeTopic_func1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func1,
+        [this, invokeTopic_func1](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func1, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             NestedStruct1 param1 = arguments.at(0).get<NestedStruct1>();
@@ -122,6 +135,25 @@ void MqttNestedStruct1InterfaceAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttNestedStruct1InterfaceAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct1interfaceadapter.h
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct1interfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttNestedStruct1InterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttNestedStruct1InterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a NestedStruct1Interface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace testbed2

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct2interface.cpp
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct2interface.cpp
@@ -137,11 +137,14 @@ QFuture<NestedStruct1> MqttNestedStruct2Interface::func1Async(const NestedStruct
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func1");
     auto promise = std::make_shared<QPromise<NestedStruct1>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(NestedStruct1());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -149,7 +152,9 @@ QFuture<NestedStruct1> MqttNestedStruct2Interface::func1Async(const NestedStruct
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(NestedStruct1());
+        promise->addResult(NestedStruct1());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1 });       
@@ -158,6 +163,7 @@ QFuture<NestedStruct1> MqttNestedStruct2Interface::func1Async(const NestedStruct
         {
             NestedStruct1 value = arg.get<NestedStruct1>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -180,11 +186,14 @@ QFuture<NestedStruct1> MqttNestedStruct2Interface::func2Async(const NestedStruct
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func2");
     auto promise = std::make_shared<QPromise<NestedStruct1>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(NestedStruct1());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -192,7 +201,9 @@ QFuture<NestedStruct1> MqttNestedStruct2Interface::func2Async(const NestedStruct
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(NestedStruct1());
+        promise->addResult(NestedStruct1());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1, param2 });       
@@ -201,6 +212,7 @@ QFuture<NestedStruct1> MqttNestedStruct2Interface::func2Async(const NestedStruct
         {
             NestedStruct1 value = arg.get<NestedStruct1>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct2interface.cpp
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct2interface.cpp
@@ -34,7 +34,7 @@ MqttNestedStruct2Interface::MqttNestedStruct2Interface(ApiGear::Mqtt::Client& cl
     : AbstractNestedStruct2Interface(parent)
     , m_prop1(NestedStruct1())
     , m_prop2(NestedStruct2())
-    , m_isReady(false)
+    , m_finishedInitialization(false)
     , m_client(client)
 {
     if (m_client.isReady())
@@ -48,11 +48,13 @@ MqttNestedStruct2Interface::MqttNestedStruct2Interface(ApiGear::Mqtt::Client& cl
             subscribeForPropertiesChanges();
             subscribeForSignals();
             subscribeForInvokeResponses();
+            m_finishedInitialization = true;
     });
     connect(&m_client, &ApiGear::Mqtt::Client::disconnected, [this](){
         m_subscribedIds.clear();
         m_InvokeCallsInfo.clear();
     });
+    m_finishedInitialization = m_client.isReady();
 }
 
 MqttNestedStruct2Interface::~MqttNestedStruct2Interface()
@@ -60,6 +62,11 @@ MqttNestedStruct2Interface::~MqttNestedStruct2Interface()
     disconnect(&m_client, &ApiGear::Mqtt::Client::disconnected, 0, 0);
     disconnect(&m_client, &ApiGear::Mqtt::Client::ready, 0, 0);
     unsubscribeAll();
+}
+
+bool MqttNestedStruct2Interface::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
 }
 
 void MqttNestedStruct2Interface::setProp1(const NestedStruct1& prop1)
@@ -207,27 +214,60 @@ const QString& MqttNestedStruct2Interface::interfaceName()
 {
     return InterfaceName;
 }
+
+void MqttNestedStruct2Interface::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
+    }
+}
 void MqttNestedStruct2Interface::subscribeForPropertiesChanges()
 {
+        // Subscription may succeed, before finising the function that subscribes it and assigns an id for if it was already added (and succeeded) for same topic,
+        // hence, for pending subscriptions a topic is used, and added before the subscribe function.
         const QString topicprop1 = interfaceName() + "/prop/prop1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
+        m_pendingSubscriptions.push_back(topicprop1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1,
+            [this, topicprop1](auto id, bool hasSucceed){handleOnSubscribed(topicprop1, id, hasSucceed);},
+            [this](auto& value) { setProp1Local(value);}));
         const QString topicprop2 = interfaceName() + "/prop/prop2";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2, [this](auto& value) { setProp2Local(value);}));
+        m_pendingSubscriptions.push_back(topicprop2);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2,
+            [this, topicprop2](auto id, bool hasSucceed){handleOnSubscribed(topicprop2, id, hasSucceed);},
+            [this](auto& value) { setProp2Local(value);}));
 }
 void MqttNestedStruct2Interface::subscribeForSignals()
 {
         const QString topicsig1 = interfaceName() + "/sig/sig1";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
-            emit sig1(argumentsArray[0].get<NestedStruct1>());}));
+        m_pendingSubscriptions.push_back(topicsig1);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1,
+            [this, topicsig1](auto id, bool hasSucceed){handleOnSubscribed(topicsig1, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sig1(argumentsArray[0].get<NestedStruct1>());}));
         const QString topicsig2 = interfaceName() + "/sig/sig2";
-        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2, [this](const nlohmann::json& argumentsArray){
-            emit sig2(argumentsArray[0].get<NestedStruct1>(),argumentsArray[1].get<NestedStruct2>());}));
+        m_pendingSubscriptions.push_back(topicsig2);
+        m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2,
+            [this, topicsig2](auto id, bool hasSucceed){handleOnSubscribed(topicsig2, id, hasSucceed);},
+            [this](const nlohmann::json& argumentsArray){ emit sig2(argumentsArray[0].get<NestedStruct1>(), argumentsArray[1].get<NestedStruct2>());}));
 }
 void MqttNestedStruct2Interface::subscribeForInvokeResponses()
 {
     const QString topicfunc1 = interfaceName() + "/rpc/func1";
     const QString topicfunc1InvokeResp = interfaceName() + "/rpc/func1"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfunc1InvokeResp);
     auto id_func1 = m_client.subscribeForInvokeResponse(topicfunc1InvokeResp, 
+                        [this, topicfunc1InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfunc1InvokeResp, id, hasSucceed);},
                         [this, topicfunc1InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfunc1InvokeResp);
@@ -235,7 +275,9 @@ void MqttNestedStruct2Interface::subscribeForInvokeResponses()
     m_InvokeCallsInfo[topicfunc1] = std::make_pair(topicfunc1InvokeResp, id_func1);
     const QString topicfunc2 = interfaceName() + "/rpc/func2";
     const QString topicfunc2InvokeResp = interfaceName() + "/rpc/func2"+ m_client.clientId() + "/result";
+    m_pendingSubscriptions.push_back(topicfunc2InvokeResp);
     auto id_func2 = m_client.subscribeForInvokeResponse(topicfunc2InvokeResp, 
+                        [this, topicfunc2InvokeResp](auto id, bool hasSucceed){handleOnSubscribed(topicfunc2InvokeResp, id, hasSucceed);},
                         [this, topicfunc2InvokeResp](const nlohmann::json& value, quint64 callId)
                         {
                             findAndExecuteCall(value, callId, topicfunc2InvokeResp);

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct2interface.cpp
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct2interface.cpp
@@ -209,17 +209,17 @@ const QString& MqttNestedStruct2Interface::interfaceName()
 }
 void MqttNestedStruct2Interface::subscribeForPropertiesChanges()
 {
-        static const QString topicprop1 = interfaceName() + "/prop/prop1";
+        const QString topicprop1 = interfaceName() + "/prop/prop1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
-        static const QString topicprop2 = interfaceName() + "/prop/prop2";
+        const QString topicprop2 = interfaceName() + "/prop/prop2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2, [this](auto& value) { setProp2Local(value);}));
 }
 void MqttNestedStruct2Interface::subscribeForSignals()
 {
-        static const QString topicsig1 = interfaceName() + "/sig/sig1";
+        const QString topicsig1 = interfaceName() + "/sig/sig1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
             emit sig1(argumentsArray[0].get<NestedStruct1>());}));
-        static const QString topicsig2 = interfaceName() + "/sig/sig2";
+        const QString topicsig2 = interfaceName() + "/sig/sig2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2, [this](const nlohmann::json& argumentsArray){
             emit sig2(argumentsArray[0].get<NestedStruct1>(),argumentsArray[1].get<NestedStruct2>());}));
 }

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct2interface.h
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct2interface.h
@@ -87,12 +87,16 @@ public:
     * Remote call of INestedStruct2Interface::func2 on the NestedStruct2Interface service.
     */
     QFuture<NestedStruct1> func2Async(const NestedStruct1& param1, const NestedStruct2& param2);
+    /**
+    * Use to check if the MqttNestedStruct2Interface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttNestedStruct2Interface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -122,9 +126,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttNestedStruct2Interface.
     * Handles incoming and outgoing messages.
@@ -152,6 +158,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace testbed2

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct2interfaceadapter.cpp
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct2interfaceadapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "testbed2/NestedStruct2Interface";
 MqttNestedStruct2InterfaceAdapter::MqttNestedStruct2InterfaceAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractNestedStruct2Interface> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -53,12 +54,14 @@ MqttNestedStruct2InterfaceAdapter::MqttNestedStruct2InterfaceAdapter(ApiGear::Mq
         subscribeForInvokeRequests();
         connectServicePropertiesChanges();
         connectServiceSignals();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttNestedStruct2InterfaceAdapter::~MqttNestedStruct2InterfaceAdapter()
@@ -68,6 +71,12 @@ MqttNestedStruct2InterfaceAdapter::~MqttNestedStruct2InterfaceAdapter()
     unsubscribeAll();
 }
 
+bool MqttNestedStruct2InterfaceAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
+
 const QString& MqttNestedStruct2InterfaceAdapter::interfaceName()
 {
     return InterfaceName;
@@ -76,14 +85,18 @@ const QString& MqttNestedStruct2InterfaceAdapter::interfaceName()
 void MqttNestedStruct2InterfaceAdapter::subscribeForPropertiesChanges()
 {
     const auto setTopic_prop1 = interfaceName() + "/set/prop1";
+    m_pendingSubscriptions.push_back(setTopic_prop1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop1,
+        [this, setTopic_prop1](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop1, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             NestedStruct1 prop1 = value.get<NestedStruct1>();
             m_impl->setProp1(prop1);
         }));
     const auto setTopic_prop2 = interfaceName() + "/set/prop2";
+    m_pendingSubscriptions.push_back(setTopic_prop2);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop2,
+        [this, setTopic_prop2](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop2, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             NestedStruct2 prop2 = value.get<NestedStruct2>();
@@ -94,7 +107,9 @@ void MqttNestedStruct2InterfaceAdapter::subscribeForPropertiesChanges()
 void MqttNestedStruct2InterfaceAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_func1 = interfaceName() + "/rpc/func1";
+    m_pendingSubscriptions.push_back(invokeTopic_func1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func1,
+        [this, invokeTopic_func1](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func1, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             NestedStruct1 param1 = arguments.at(0).get<NestedStruct1>();
@@ -102,7 +117,9 @@ void MqttNestedStruct2InterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_func2 = interfaceName() + "/rpc/func2";
+    m_pendingSubscriptions.push_back(invokeTopic_func2);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func2,
+        [this, invokeTopic_func2](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func2, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             NestedStruct1 param1 = arguments.at(0).get<NestedStruct1>();
@@ -151,6 +168,25 @@ void MqttNestedStruct2InterfaceAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttNestedStruct2InterfaceAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct2interfaceadapter.h
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct2interfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttNestedStruct2InterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttNestedStruct2InterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a NestedStruct2Interface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace testbed2

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct3interface.cpp
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct3interface.cpp
@@ -280,22 +280,22 @@ const QString& MqttNestedStruct3Interface::interfaceName()
 }
 void MqttNestedStruct3Interface::subscribeForPropertiesChanges()
 {
-        static const QString topicprop1 = interfaceName() + "/prop/prop1";
+        const QString topicprop1 = interfaceName() + "/prop/prop1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop1, [this](auto& value) { setProp1Local(value);}));
-        static const QString topicprop2 = interfaceName() + "/prop/prop2";
+        const QString topicprop2 = interfaceName() + "/prop/prop2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop2, [this](auto& value) { setProp2Local(value);}));
-        static const QString topicprop3 = interfaceName() + "/prop/prop3";
+        const QString topicprop3 = interfaceName() + "/prop/prop3";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicprop3, [this](auto& value) { setProp3Local(value);}));
 }
 void MqttNestedStruct3Interface::subscribeForSignals()
 {
-        static const QString topicsig1 = interfaceName() + "/sig/sig1";
+        const QString topicsig1 = interfaceName() + "/sig/sig1";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig1, [this](const nlohmann::json& argumentsArray){
             emit sig1(argumentsArray[0].get<NestedStruct1>());}));
-        static const QString topicsig2 = interfaceName() + "/sig/sig2";
+        const QString topicsig2 = interfaceName() + "/sig/sig2";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig2, [this](const nlohmann::json& argumentsArray){
             emit sig2(argumentsArray[0].get<NestedStruct1>(),argumentsArray[1].get<NestedStruct2>());}));
-        static const QString topicsig3 = interfaceName() + "/sig/sig3";
+        const QString topicsig3 = interfaceName() + "/sig/sig3";
         m_subscribedIds.push_back(m_client.subscribeTopic(topicsig3, [this](const nlohmann::json& argumentsArray){
             emit sig3(argumentsArray[0].get<NestedStruct1>(),argumentsArray[1].get<NestedStruct2>(),argumentsArray[2].get<NestedStruct3>());}));
 }

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct3interface.cpp
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct3interface.cpp
@@ -165,11 +165,14 @@ QFuture<NestedStruct1> MqttNestedStruct3Interface::func1Async(const NestedStruct
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func1");
     auto promise = std::make_shared<QPromise<NestedStruct1>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(NestedStruct1());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -177,7 +180,9 @@ QFuture<NestedStruct1> MqttNestedStruct3Interface::func1Async(const NestedStruct
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(NestedStruct1());
+        promise->addResult(NestedStruct1());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1 });       
@@ -186,6 +191,7 @@ QFuture<NestedStruct1> MqttNestedStruct3Interface::func1Async(const NestedStruct
         {
             NestedStruct1 value = arg.get<NestedStruct1>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -208,11 +214,14 @@ QFuture<NestedStruct1> MqttNestedStruct3Interface::func2Async(const NestedStruct
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func2");
     auto promise = std::make_shared<QPromise<NestedStruct1>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(NestedStruct1());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -220,7 +229,9 @@ QFuture<NestedStruct1> MqttNestedStruct3Interface::func2Async(const NestedStruct
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(NestedStruct1());
+        promise->addResult(NestedStruct1());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1, param2 });       
@@ -229,6 +240,7 @@ QFuture<NestedStruct1> MqttNestedStruct3Interface::func2Async(const NestedStruct
         {
             NestedStruct1 value = arg.get<NestedStruct1>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);
@@ -251,11 +263,14 @@ QFuture<NestedStruct1> MqttNestedStruct3Interface::func3Async(const NestedStruct
     AG_LOG_DEBUG(Q_FUNC_INFO);
     static const QString topic = interfaceName() + QString("/rpc/func3");
     auto promise = std::make_shared<QPromise<NestedStruct1>>();
+    promise->start();
     if(!m_client.isReady())
     {
         static auto subscriptionIssues = "Trying to send a message for "+ topic+", but client is not connected. Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
             promise->addResult(NestedStruct1());
+        promise->finish();
+        return promise->future();
     }
 
     auto callInfo = m_InvokeCallsInfo.find(topic);
@@ -263,7 +278,9 @@ QFuture<NestedStruct1> MqttNestedStruct3Interface::func3Async(const NestedStruct
     {
         static auto subscriptionIssues = "Could not perform operation "+ topic+". Try reconnecting the client.";
         AG_LOG_WARNING(subscriptionIssues);
-            promise->addResult(NestedStruct1());
+        promise->addResult(NestedStruct1());
+        promise->finish();
+        return promise->future();
     }
     auto respTopic = callInfo->second.first;
     auto arguments = nlohmann::json::array({param1, param2, param3 });       
@@ -272,6 +289,7 @@ QFuture<NestedStruct1> MqttNestedStruct3Interface::func3Async(const NestedStruct
         {
             NestedStruct1 value = arg.get<NestedStruct1>();
             promise->addResult(value);
+            promise->finish();
         };
     auto callId = m_client.invokeRemote(topic, arguments, respTopic);
     auto lock = std::unique_lock<std::mutex>(m_pendingCallMutex);

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct3interface.h
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct3interface.h
@@ -106,12 +106,16 @@ public:
     * Remote call of INestedStruct3Interface::func3 on the NestedStruct3Interface service.
     */
     QFuture<NestedStruct1> func3Async(const NestedStruct1& param1, const NestedStruct2& param2, const NestedStruct3& param3);
+    /**
+    * Use to check if the MqttNestedStruct3Interface is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the MqttNestedStruct3Interface is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -145,9 +149,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the MqttNestedStruct3Interface.
     * Handles incoming and outgoing messages.
@@ -175,6 +181,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace testbed2

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct3interfaceadapter.cpp
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct3interfaceadapter.cpp
@@ -38,6 +38,7 @@ const QString InterfaceName = "testbed2/NestedStruct3Interface";
 MqttNestedStruct3InterfaceAdapter::MqttNestedStruct3InterfaceAdapter(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<AbstractNestedStruct3Interface> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -53,12 +54,14 @@ MqttNestedStruct3InterfaceAdapter::MqttNestedStruct3InterfaceAdapter(ApiGear::Mq
         subscribeForInvokeRequests();
         connectServicePropertiesChanges();
         connectServiceSignals();
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 MqttNestedStruct3InterfaceAdapter::~MqttNestedStruct3InterfaceAdapter()
@@ -68,6 +71,12 @@ MqttNestedStruct3InterfaceAdapter::~MqttNestedStruct3InterfaceAdapter()
     unsubscribeAll();
 }
 
+bool MqttNestedStruct3InterfaceAdapter::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
+
 const QString& MqttNestedStruct3InterfaceAdapter::interfaceName()
 {
     return InterfaceName;
@@ -76,21 +85,27 @@ const QString& MqttNestedStruct3InterfaceAdapter::interfaceName()
 void MqttNestedStruct3InterfaceAdapter::subscribeForPropertiesChanges()
 {
     const auto setTopic_prop1 = interfaceName() + "/set/prop1";
+    m_pendingSubscriptions.push_back(setTopic_prop1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop1,
+        [this, setTopic_prop1](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop1, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             NestedStruct1 prop1 = value.get<NestedStruct1>();
             m_impl->setProp1(prop1);
         }));
     const auto setTopic_prop2 = interfaceName() + "/set/prop2";
+    m_pendingSubscriptions.push_back(setTopic_prop2);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop2,
+        [this, setTopic_prop2](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop2, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             NestedStruct2 prop2 = value.get<NestedStruct2>();
             m_impl->setProp2(prop2);
         }));
     const auto setTopic_prop3 = interfaceName() + "/set/prop3";
+    m_pendingSubscriptions.push_back(setTopic_prop3);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_prop3,
+        [this, setTopic_prop3](auto id, bool hasSucceed){handleOnSubscribed(setTopic_prop3, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             NestedStruct3 prop3 = value.get<NestedStruct3>();
@@ -101,7 +116,9 @@ void MqttNestedStruct3InterfaceAdapter::subscribeForPropertiesChanges()
 void MqttNestedStruct3InterfaceAdapter::subscribeForInvokeRequests()
 {
     const auto invokeTopic_func1 = interfaceName() + "/rpc/func1";
+    m_pendingSubscriptions.push_back(invokeTopic_func1);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func1,
+        [this, invokeTopic_func1](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func1, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             NestedStruct1 param1 = arguments.at(0).get<NestedStruct1>();
@@ -109,7 +126,9 @@ void MqttNestedStruct3InterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_func2 = interfaceName() + "/rpc/func2";
+    m_pendingSubscriptions.push_back(invokeTopic_func2);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func2,
+        [this, invokeTopic_func2](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func2, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             NestedStruct1 param1 = arguments.at(0).get<NestedStruct1>();
@@ -118,7 +137,9 @@ void MqttNestedStruct3InterfaceAdapter::subscribeForInvokeRequests()
             return result;
         }));
     const auto invokeTopic_func3 = interfaceName() + "/rpc/func3";
+    m_pendingSubscriptions.push_back(invokeTopic_func3);
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_func3,
+        [this, invokeTopic_func3](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_func3, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             NestedStruct1 param1 = arguments.at(0).get<NestedStruct1>();
@@ -181,6 +202,25 @@ void MqttNestedStruct3InterfaceAdapter::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void MqttNestedStruct3InterfaceAdapter::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/goldenmaster/testbed2/mqtt/mqttnestedstruct3interfaceadapter.h
+++ b/goldenmaster/testbed2/mqtt/mqttnestedstruct3interfaceadapter.h
@@ -55,7 +55,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the MqttNestedStruct3InterfaceAdapter is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the MqttNestedStruct3InterfaceAdapter is ready to send and receive messages.
+    */
+    void ready();
 private:
     // Helper function, subscribes this adpater for property change requests from remote clients.
     void subscribeForPropertiesChanges();
@@ -68,6 +77,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a NestedStruct3Interface that gets adapted to be a service in mqtt network.
@@ -78,8 +89,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace testbed2

--- a/goldenmaster/testbed2/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/testbed2/mqtt/tests/CMakeLists.txt
@@ -1,0 +1,60 @@
+
+cmake_minimum_required(VERSION 3.20)
+project(test_testbed2_generated_mqtt)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(BUILD_TESTING)
+include(CTest)
+enable_testing()
+
+find_package(Qt6 REQUIRED COMPONENTS Test Core)
+find_package(apigear QUIET COMPONENTS apigear_mqtt)
+find_package(testbed2 QUIET COMPONENTS testbed2_impl testbed2_mqtt)
+
+find_package(Catch2 REQUIRED)
+
+set(CMAKE_CTEST_COMMAND ctest -V)
+if(NOT TARGET check)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+set(TEST_TESTBED2_GENERATED_MQTT_SOURCES
+    test_main.cpp
+    )
+
+include_directories(test_testbed2_generated_mqtt
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+add_executable(test_testbed2_generated_mqtt ${TEST_TESTBED2_GENERATED_MQTT_SOURCES})
+add_test(NAME test_testbed2_generated_mqtt COMMAND $<TARGET_FILE:test_testbed2_generated_mqtt>)
+add_dependencies(check test_testbed2_generated_mqtt)
+
+target_link_libraries(test_testbed2_generated_mqtt PRIVATE
+    apigear_mqtt
+    testbed2_impl
+    testbed2_mqtt
+    Catch2::Catch2
+    Qt::Test)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_testbed2_generated_mqtt
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+
+endif() # BUILD_TESTING

--- a/goldenmaster/testbed2/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/testbed2/mqtt/tests/CMakeLists.txt
@@ -29,6 +29,10 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 endif()
 
 set(TEST_TESTBED2_GENERATED_MQTT_SOURCES
+    test_mqttmanyparaminterface.cpp
+    test_mqttnestedstruct1interface.cpp
+    test_mqttnestedstruct2interface.cpp
+    test_mqttnestedstruct3interface.cpp
     test_main.cpp
     )
 

--- a/goldenmaster/testbed2/mqtt/tests/test_main.cpp
+++ b/goldenmaster/testbed2/mqtt/tests/test_main.cpp
@@ -1,0 +1,12 @@
+#define CATCH_CONFIG_RUNNER
+
+#include <QCoreApplication>
+#include <catch2/catch.hpp>
+
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv); // -platform offscreen
+    int result = Catch::Session().run(argc, argv); // --break
+    return result;
+}

--- a/goldenmaster/testbed2/mqtt/tests/test_mqttmanyparaminterface.cpp
+++ b/goldenmaster/testbed2/mqtt/tests/test_mqttmanyparaminterface.cpp
@@ -1,0 +1,267 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/manyparaminterface.h"
+#include "mqtt/mqttmanyparaminterface.h"
+#include "mqtt/mqttmanyparaminterfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  testbed2 ManyParamInterface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientManyParamInterface = std::make_shared<testbed2::MqttManyParamInterface >(client);
+    auto implManyParamInterface = std::make_shared<testbed2::ManyParamInterface>();
+    auto serviceManyParamInterface = std::make_shared<testbed2::MqttManyParamInterfaceAdapter>(service, implManyParamInterface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientManyParamInterface, &serviceManyParamInterface]() {return clientManyParamInterface->isReady() && serviceManyParamInterface->isReady(); }, timeout));
+    SECTION("Test setting prop1")
+    {
+        std::atomic<bool> isprop1Changed = false;
+        clientManyParamInterface->connect(clientManyParamInterface.get(), &testbed2::AbstractManyParamInterface::prop1Changed, [&isprop1Changed ](auto value){isprop1Changed  = true;});
+        auto test_value = 1;
+        clientManyParamInterface->setProp1(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop1Changed]() {return isprop1Changed  == true; }, timeout));
+        REQUIRE(implManyParamInterface->prop1() == test_value);
+        REQUIRE(clientManyParamInterface->prop1() == test_value);
+    }
+    SECTION("Test setting prop2")
+    {
+        std::atomic<bool> isprop2Changed = false;
+        clientManyParamInterface->connect(clientManyParamInterface.get(), &testbed2::AbstractManyParamInterface::prop2Changed, [&isprop2Changed ](auto value){isprop2Changed  = true;});
+        auto test_value = 1;
+        clientManyParamInterface->setProp2(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop2Changed]() {return isprop2Changed  == true; }, timeout));
+        REQUIRE(implManyParamInterface->prop2() == test_value);
+        REQUIRE(clientManyParamInterface->prop2() == test_value);
+    }
+    SECTION("Test setting prop3")
+    {
+        std::atomic<bool> isprop3Changed = false;
+        clientManyParamInterface->connect(clientManyParamInterface.get(), &testbed2::AbstractManyParamInterface::prop3Changed, [&isprop3Changed ](auto value){isprop3Changed  = true;});
+        auto test_value = 1;
+        clientManyParamInterface->setProp3(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop3Changed]() {return isprop3Changed  == true; }, timeout));
+        REQUIRE(implManyParamInterface->prop3() == test_value);
+        REQUIRE(clientManyParamInterface->prop3() == test_value);
+    }
+    SECTION("Test setting prop4")
+    {
+        std::atomic<bool> isprop4Changed = false;
+        clientManyParamInterface->connect(clientManyParamInterface.get(), &testbed2::AbstractManyParamInterface::prop4Changed, [&isprop4Changed ](auto value){isprop4Changed  = true;});
+        auto test_value = 1;
+        clientManyParamInterface->setProp4(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop4Changed]() {return isprop4Changed  == true; }, timeout));
+        REQUIRE(implManyParamInterface->prop4() == test_value);
+        REQUIRE(clientManyParamInterface->prop4() == test_value);
+    }
+    SECTION("Test emit sig1")
+    {
+        std::atomic<bool> issig1Emitted = false;
+
+        clientManyParamInterface->connect(clientManyParamInterface.get(), &testbed2::AbstractManyParamInterface::sig1,
+        [&issig1Emitted](int param1)
+        {
+            REQUIRE(param1 == 1);
+            issig1Emitted  = true;
+        });
+
+        emit implManyParamInterface->sig1(1);
+        REQUIRE(QTest::qWaitFor([&issig1Emitted ]() {return issig1Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sig2")
+    {
+        std::atomic<bool> issig2Emitted = false;
+
+        clientManyParamInterface->connect(clientManyParamInterface.get(), &testbed2::AbstractManyParamInterface::sig2,
+        [&issig2Emitted](int param1, int param2)
+        {
+            REQUIRE(param1 == 1);
+            REQUIRE(param2 == 1);
+            issig2Emitted  = true;
+        });
+
+        emit implManyParamInterface->sig2(1, 1);
+        REQUIRE(QTest::qWaitFor([&issig2Emitted ]() {return issig2Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sig3")
+    {
+        std::atomic<bool> issig3Emitted = false;
+
+        clientManyParamInterface->connect(clientManyParamInterface.get(), &testbed2::AbstractManyParamInterface::sig3,
+        [&issig3Emitted](int param1, int param2, int param3)
+        {
+            REQUIRE(param1 == 1);
+            REQUIRE(param2 == 1);
+            REQUIRE(param3 == 1);
+            issig3Emitted  = true;
+        });
+
+        emit implManyParamInterface->sig3(1, 1, 1);
+        REQUIRE(QTest::qWaitFor([&issig3Emitted ]() {return issig3Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sig4")
+    {
+        std::atomic<bool> issig4Emitted = false;
+
+        clientManyParamInterface->connect(clientManyParamInterface.get(), &testbed2::AbstractManyParamInterface::sig4,
+        [&issig4Emitted](int param1, int param2, int param3, int param4)
+        {
+            REQUIRE(param1 == 1);
+            REQUIRE(param2 == 1);
+            REQUIRE(param3 == 1);
+            REQUIRE(param4 == 1);
+            issig4Emitted  = true;
+        });
+
+        emit implManyParamInterface->sig4(1, 1, 1, 1);
+        REQUIRE(QTest::qWaitFor([&issig4Emitted ]() {return issig4Emitted   == true; }, timeout));
+    }
+    SECTION("Test method func1")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientManyParamInterface, &finished](){
+            [[maybe_unused]] auto result = clientManyParamInterface->func1(0);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func1 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientManyParamInterface->func1Async(0);
+        resultFuture.then([&finished](int /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == 0);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method func2")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientManyParamInterface, &finished](){
+            [[maybe_unused]] auto result = clientManyParamInterface->func2(0, 0);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func2 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientManyParamInterface->func2Async(0, 0);
+        resultFuture.then([&finished](int /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == 0);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method func3")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientManyParamInterface, &finished](){
+            [[maybe_unused]] auto result = clientManyParamInterface->func3(0, 0, 0);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func3 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientManyParamInterface->func3Async(0, 0, 0);
+        resultFuture.then([&finished](int /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == 0);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method func4")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientManyParamInterface, &finished](){
+            [[maybe_unused]] auto result = clientManyParamInterface->func4(0, 0, 0, 0);
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func4 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientManyParamInterface->func4Async(0, 0, 0, 0);
+        resultFuture.then([&finished](int /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == 0);
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientManyParamInterface.reset();
+    serviceManyParamInterface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/testbed2/mqtt/tests/test_mqttnestedstruct1interface.cpp
+++ b/goldenmaster/testbed2/mqtt/tests/test_mqttnestedstruct1interface.cpp
@@ -1,0 +1,120 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/nestedstruct1interface.h"
+#include "mqtt/mqttnestedstruct1interface.h"
+#include "mqtt/mqttnestedstruct1interfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  testbed2 NestedStruct1Interface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientNestedStruct1Interface = std::make_shared<testbed2::MqttNestedStruct1Interface >(client);
+    auto implNestedStruct1Interface = std::make_shared<testbed2::NestedStruct1Interface>();
+    auto serviceNestedStruct1Interface = std::make_shared<testbed2::MqttNestedStruct1InterfaceAdapter>(service, implNestedStruct1Interface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientNestedStruct1Interface, &serviceNestedStruct1Interface]() {return clientNestedStruct1Interface->isReady() && serviceNestedStruct1Interface->isReady(); }, timeout));
+    SECTION("Test setting prop1")
+    {
+        std::atomic<bool> isprop1Changed = false;
+        clientNestedStruct1Interface->connect(clientNestedStruct1Interface.get(), &testbed2::AbstractNestedStruct1Interface::prop1Changed, [&isprop1Changed ](auto value){isprop1Changed  = true;});
+        auto test_value = testbed2::NestedStruct1();
+        testbed2::fillTestNestedStruct1(test_value);
+        clientNestedStruct1Interface->setProp1(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop1Changed]() {return isprop1Changed  == true; }, timeout));
+        REQUIRE(implNestedStruct1Interface->prop1() == test_value);
+        REQUIRE(clientNestedStruct1Interface->prop1() == test_value);
+    }
+    SECTION("Test emit sig1")
+    {
+        std::atomic<bool> issig1Emitted = false;
+        auto local_param1_struct = testbed2::NestedStruct1();
+        testbed2::fillTestNestedStruct1(local_param1_struct);
+
+        clientNestedStruct1Interface->connect(clientNestedStruct1Interface.get(), &testbed2::AbstractNestedStruct1Interface::sig1,
+        [&issig1Emitted, &local_param1_struct](const testbed2::NestedStruct1& param1)
+        {
+            REQUIRE(param1 ==local_param1_struct);
+            issig1Emitted  = true;
+        });
+
+        emit implNestedStruct1Interface->sig1(local_param1_struct);
+        REQUIRE(QTest::qWaitFor([&issig1Emitted ]() {return issig1Emitted   == true; }, timeout));
+    }
+    SECTION("Test method func1")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientNestedStruct1Interface, &finished](){
+            [[maybe_unused]] auto result = clientNestedStruct1Interface->func1(testbed2::NestedStruct1());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func1 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct1Interface->func1Async(testbed2::NestedStruct1());
+        resultFuture.then([&finished](testbed2::NestedStruct1 /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == testbed2::NestedStruct1());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientNestedStruct1Interface.reset();
+    serviceNestedStruct1Interface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/testbed2/mqtt/tests/test_mqttnestedstruct2interface.cpp
+++ b/goldenmaster/testbed2/mqtt/tests/test_mqttnestedstruct2interface.cpp
@@ -1,0 +1,174 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/nestedstruct2interface.h"
+#include "mqtt/mqttnestedstruct2interface.h"
+#include "mqtt/mqttnestedstruct2interfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  testbed2 NestedStruct2Interface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientNestedStruct2Interface = std::make_shared<testbed2::MqttNestedStruct2Interface >(client);
+    auto implNestedStruct2Interface = std::make_shared<testbed2::NestedStruct2Interface>();
+    auto serviceNestedStruct2Interface = std::make_shared<testbed2::MqttNestedStruct2InterfaceAdapter>(service, implNestedStruct2Interface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientNestedStruct2Interface, &serviceNestedStruct2Interface]() {return clientNestedStruct2Interface->isReady() && serviceNestedStruct2Interface->isReady(); }, timeout));
+    SECTION("Test setting prop1")
+    {
+        std::atomic<bool> isprop1Changed = false;
+        clientNestedStruct2Interface->connect(clientNestedStruct2Interface.get(), &testbed2::AbstractNestedStruct2Interface::prop1Changed, [&isprop1Changed ](auto value){isprop1Changed  = true;});
+        auto test_value = testbed2::NestedStruct1();
+        testbed2::fillTestNestedStruct1(test_value);
+        clientNestedStruct2Interface->setProp1(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop1Changed]() {return isprop1Changed  == true; }, timeout));
+        REQUIRE(implNestedStruct2Interface->prop1() == test_value);
+        REQUIRE(clientNestedStruct2Interface->prop1() == test_value);
+    }
+    SECTION("Test setting prop2")
+    {
+        std::atomic<bool> isprop2Changed = false;
+        clientNestedStruct2Interface->connect(clientNestedStruct2Interface.get(), &testbed2::AbstractNestedStruct2Interface::prop2Changed, [&isprop2Changed ](auto value){isprop2Changed  = true;});
+        auto test_value = testbed2::NestedStruct2();
+        testbed2::fillTestNestedStruct2(test_value);
+        clientNestedStruct2Interface->setProp2(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop2Changed]() {return isprop2Changed  == true; }, timeout));
+        REQUIRE(implNestedStruct2Interface->prop2() == test_value);
+        REQUIRE(clientNestedStruct2Interface->prop2() == test_value);
+    }
+    SECTION("Test emit sig1")
+    {
+        std::atomic<bool> issig1Emitted = false;
+        auto local_param1_struct = testbed2::NestedStruct1();
+        testbed2::fillTestNestedStruct1(local_param1_struct);
+
+        clientNestedStruct2Interface->connect(clientNestedStruct2Interface.get(), &testbed2::AbstractNestedStruct2Interface::sig1,
+        [&issig1Emitted, &local_param1_struct](const testbed2::NestedStruct1& param1)
+        {
+            REQUIRE(param1 ==local_param1_struct);
+            issig1Emitted  = true;
+        });
+
+        emit implNestedStruct2Interface->sig1(local_param1_struct);
+        REQUIRE(QTest::qWaitFor([&issig1Emitted ]() {return issig1Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sig2")
+    {
+        std::atomic<bool> issig2Emitted = false;
+        auto local_param1_struct = testbed2::NestedStruct1();
+        testbed2::fillTestNestedStruct1(local_param1_struct);
+        auto local_param2_struct = testbed2::NestedStruct2();
+        testbed2::fillTestNestedStruct2(local_param2_struct);
+
+        clientNestedStruct2Interface->connect(clientNestedStruct2Interface.get(), &testbed2::AbstractNestedStruct2Interface::sig2,
+        [&issig2Emitted, &local_param1_struct, &local_param2_struct](const testbed2::NestedStruct1& param1, const testbed2::NestedStruct2& param2)
+        {
+            REQUIRE(param1 ==local_param1_struct);
+            REQUIRE(param2 ==local_param2_struct);
+            issig2Emitted  = true;
+        });
+
+        emit implNestedStruct2Interface->sig2(local_param1_struct, local_param2_struct);
+        REQUIRE(QTest::qWaitFor([&issig2Emitted ]() {return issig2Emitted   == true; }, timeout));
+    }
+    SECTION("Test method func1")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientNestedStruct2Interface, &finished](){
+            [[maybe_unused]] auto result = clientNestedStruct2Interface->func1(testbed2::NestedStruct1());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func1 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct2Interface->func1Async(testbed2::NestedStruct1());
+        resultFuture.then([&finished](testbed2::NestedStruct1 /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == testbed2::NestedStruct1());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method func2")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientNestedStruct2Interface, &finished](){
+            [[maybe_unused]] auto result = clientNestedStruct2Interface->func2(testbed2::NestedStruct1(), testbed2::NestedStruct2());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func2 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct2Interface->func2Async(testbed2::NestedStruct1(), testbed2::NestedStruct2());
+        resultFuture.then([&finished](testbed2::NestedStruct1 /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == testbed2::NestedStruct1());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientNestedStruct2Interface.reset();
+    serviceNestedStruct2Interface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/goldenmaster/testbed2/mqtt/tests/test_mqttnestedstruct3interface.cpp
+++ b/goldenmaster/testbed2/mqtt/tests/test_mqttnestedstruct3interface.cpp
@@ -1,0 +1,231 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/nestedstruct3interface.h"
+#include "mqtt/mqttnestedstruct3interface.h"
+#include "mqtt/mqttnestedstruct3interfaceadapter.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  testbed2 NestedStruct3Interface tests")
+{
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto clientNestedStruct3Interface = std::make_shared<testbed2::MqttNestedStruct3Interface >(client);
+    auto implNestedStruct3Interface = std::make_shared<testbed2::NestedStruct3Interface>();
+    auto serviceNestedStruct3Interface = std::make_shared<testbed2::MqttNestedStruct3InterfaceAdapter>(service, implNestedStruct3Interface);
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&clientNestedStruct3Interface, &serviceNestedStruct3Interface]() {return clientNestedStruct3Interface->isReady() && serviceNestedStruct3Interface->isReady(); }, timeout));
+    SECTION("Test setting prop1")
+    {
+        std::atomic<bool> isprop1Changed = false;
+        clientNestedStruct3Interface->connect(clientNestedStruct3Interface.get(), &testbed2::AbstractNestedStruct3Interface::prop1Changed, [&isprop1Changed ](auto value){isprop1Changed  = true;});
+        auto test_value = testbed2::NestedStruct1();
+        testbed2::fillTestNestedStruct1(test_value);
+        clientNestedStruct3Interface->setProp1(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop1Changed]() {return isprop1Changed  == true; }, timeout));
+        REQUIRE(implNestedStruct3Interface->prop1() == test_value);
+        REQUIRE(clientNestedStruct3Interface->prop1() == test_value);
+    }
+    SECTION("Test setting prop2")
+    {
+        std::atomic<bool> isprop2Changed = false;
+        clientNestedStruct3Interface->connect(clientNestedStruct3Interface.get(), &testbed2::AbstractNestedStruct3Interface::prop2Changed, [&isprop2Changed ](auto value){isprop2Changed  = true;});
+        auto test_value = testbed2::NestedStruct2();
+        testbed2::fillTestNestedStruct2(test_value);
+        clientNestedStruct3Interface->setProp2(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop2Changed]() {return isprop2Changed  == true; }, timeout));
+        REQUIRE(implNestedStruct3Interface->prop2() == test_value);
+        REQUIRE(clientNestedStruct3Interface->prop2() == test_value);
+    }
+    SECTION("Test setting prop3")
+    {
+        std::atomic<bool> isprop3Changed = false;
+        clientNestedStruct3Interface->connect(clientNestedStruct3Interface.get(), &testbed2::AbstractNestedStruct3Interface::prop3Changed, [&isprop3Changed ](auto value){isprop3Changed  = true;});
+        auto test_value = testbed2::NestedStruct3();
+        testbed2::fillTestNestedStruct3(test_value);
+        clientNestedStruct3Interface->setProp3(test_value);
+        REQUIRE(QTest::qWaitFor([&isprop3Changed]() {return isprop3Changed  == true; }, timeout));
+        REQUIRE(implNestedStruct3Interface->prop3() == test_value);
+        REQUIRE(clientNestedStruct3Interface->prop3() == test_value);
+    }
+    SECTION("Test emit sig1")
+    {
+        std::atomic<bool> issig1Emitted = false;
+        auto local_param1_struct = testbed2::NestedStruct1();
+        testbed2::fillTestNestedStruct1(local_param1_struct);
+
+        clientNestedStruct3Interface->connect(clientNestedStruct3Interface.get(), &testbed2::AbstractNestedStruct3Interface::sig1,
+        [&issig1Emitted, &local_param1_struct](const testbed2::NestedStruct1& param1)
+        {
+            REQUIRE(param1 ==local_param1_struct);
+            issig1Emitted  = true;
+        });
+
+        emit implNestedStruct3Interface->sig1(local_param1_struct);
+        REQUIRE(QTest::qWaitFor([&issig1Emitted ]() {return issig1Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sig2")
+    {
+        std::atomic<bool> issig2Emitted = false;
+        auto local_param1_struct = testbed2::NestedStruct1();
+        testbed2::fillTestNestedStruct1(local_param1_struct);
+        auto local_param2_struct = testbed2::NestedStruct2();
+        testbed2::fillTestNestedStruct2(local_param2_struct);
+
+        clientNestedStruct3Interface->connect(clientNestedStruct3Interface.get(), &testbed2::AbstractNestedStruct3Interface::sig2,
+        [&issig2Emitted, &local_param1_struct, &local_param2_struct](const testbed2::NestedStruct1& param1, const testbed2::NestedStruct2& param2)
+        {
+            REQUIRE(param1 ==local_param1_struct);
+            REQUIRE(param2 ==local_param2_struct);
+            issig2Emitted  = true;
+        });
+
+        emit implNestedStruct3Interface->sig2(local_param1_struct, local_param2_struct);
+        REQUIRE(QTest::qWaitFor([&issig2Emitted ]() {return issig2Emitted   == true; }, timeout));
+    }
+    SECTION("Test emit sig3")
+    {
+        std::atomic<bool> issig3Emitted = false;
+        auto local_param1_struct = testbed2::NestedStruct1();
+        testbed2::fillTestNestedStruct1(local_param1_struct);
+        auto local_param2_struct = testbed2::NestedStruct2();
+        testbed2::fillTestNestedStruct2(local_param2_struct);
+        auto local_param3_struct = testbed2::NestedStruct3();
+        testbed2::fillTestNestedStruct3(local_param3_struct);
+
+        clientNestedStruct3Interface->connect(clientNestedStruct3Interface.get(), &testbed2::AbstractNestedStruct3Interface::sig3,
+        [&issig3Emitted, &local_param1_struct, &local_param2_struct, &local_param3_struct](const testbed2::NestedStruct1& param1, const testbed2::NestedStruct2& param2, const testbed2::NestedStruct3& param3)
+        {
+            REQUIRE(param1 ==local_param1_struct);
+            REQUIRE(param2 ==local_param2_struct);
+            REQUIRE(param3 ==local_param3_struct);
+            issig3Emitted  = true;
+        });
+
+        emit implNestedStruct3Interface->sig3(local_param1_struct, local_param2_struct, local_param3_struct);
+        REQUIRE(QTest::qWaitFor([&issig3Emitted ]() {return issig3Emitted   == true; }, timeout));
+    }
+    SECTION("Test method func1")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientNestedStruct3Interface, &finished](){
+            [[maybe_unused]] auto result = clientNestedStruct3Interface->func1(testbed2::NestedStruct1());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func1 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct3Interface->func1Async(testbed2::NestedStruct1());
+        resultFuture.then([&finished](testbed2::NestedStruct1 /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == testbed2::NestedStruct1());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method func2")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientNestedStruct3Interface, &finished](){
+            [[maybe_unused]] auto result = clientNestedStruct3Interface->func2(testbed2::NestedStruct1(), testbed2::NestedStruct2());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func2 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct3Interface->func2Async(testbed2::NestedStruct1(), testbed2::NestedStruct2());
+        resultFuture.then([&finished](testbed2::NestedStruct1 /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == testbed2::NestedStruct1());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method func3")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([clientNestedStruct3Interface, &finished](){
+            [[maybe_unused]] auto result = clientNestedStruct3Interface->func3(testbed2::NestedStruct1(), testbed2::NestedStruct2(), testbed2::NestedStruct3());
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method func3 async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct3Interface->func3Async(testbed2::NestedStruct1(), testbed2::NestedStruct2(), testbed2::NestedStruct3());
+        resultFuture.then([&finished](testbed2::NestedStruct1 /*res*/){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == testbed2::NestedStruct1());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    clientNestedStruct3Interface.reset();
+    serviceNestedStruct3Interface.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/rules.yaml
+++ b/rules.yaml
@@ -213,6 +213,7 @@ features:
       - api
       - apigear
       - stubs
+      - test_helpers
     scopes:
       - match: system
         documents:
@@ -260,7 +261,9 @@ features:
           - source: "mqtt/mqttadapter.h.tpl"
             target: "mqtt{{lower .Interface.Name}}adapter.h"
           - source: "mqtt/mqttadapter.cpp.tpl"
-            target: "mqtt{{lower .Interface.Name}}adapter.cpp"     
+            target: "mqtt{{lower .Interface.Name}}adapter.cpp"
+          - source: "mqtt/tests/interface_test.cpp.tpl"
+            target: "tests/test_mqtt{{lower .Interface.Name}}.cpp"
   - name: qmlplugin
     scopes:
       - match: module

--- a/rules.yaml
+++ b/rules.yaml
@@ -212,6 +212,7 @@ features:
     requires:
       - api
       - apigear
+      - stubs
     scopes:
       - match: system
         documents:
@@ -244,6 +245,11 @@ features:
             target: "mqttfactory.cpp"
           - source: "mqtt/mqtt_common.h.tpl"
             target: "mqtt_common.h"
+          - source: "mqtt/tests/CMakeLists.txt.tpl"
+            target: "tests/CMakeLists.txt"
+          - source: "mqtt/tests/test_main.cpp"
+            target: "tests/test_main.cpp"
+            raw: true
       - match: interface
         prefix: "{{snake .Module.Name}}/mqtt/"
         documents:

--- a/templates/CMakeLists.txt.tpl
+++ b/templates/CMakeLists.txt.tpl
@@ -27,6 +27,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 option(BUILD_TESTING "Enable this option to build the test targets" OFF)
 
 if(BUILD_TESTING)
+
+option(ENABLE_MQTT_TEST_FOR_NON_LINUX_OS "By default enable only for linux, due to easy broker setup on CI" OFF)
+
 find_package(Qt6 COMPONENTS Test REQUIRED)
 enable_testing()
 

--- a/templates/apigear/mqtt/mqttclient.cpp
+++ b/templates/apigear/mqtt/mqttclient.cpp
@@ -44,7 +44,7 @@ void Client::writeMessage(const QMqttTopicName& topic, const QByteArray& message
     m_client.publish(topic, message, QoS, noRetain);
 }
 
-void Client::onSubscribeTopic(quint64 id, const QString &topic, SimpleSubscribeCallback callback)
+void Client::onSubscribeTopic(quint64 id, const QString &topic, OnSubscribedCallback onSubscribed, SimpleSubscribeCallback callback)
 {
     auto subscription = m_client.subscribe(topic, QoS);
     auto subscribedTopic = subscription->topic();
@@ -69,7 +69,7 @@ void Client::onSubscribeTopic(quint64 id, const QString &topic, SimpleSubscribeC
     m_subscriptions.insert(subscription->topic(), std::make_pair(id, callback));
 }
 
-void Client::onSubscribeForInvokeResponse(quint64 id, const QString &topic, InvokeReplyCallback callback)
+void Client::onSubscribeForInvokeResponse(quint64 id, const QString &topic, OnSubscribedCallback onSubscribed, InvokeReplyCallback callback)
 {
     auto subscription = m_client.subscribe(topic, QoS);
     auto topicFilter = subscription->topic();
@@ -136,17 +136,17 @@ void Client::connectToHost(QString hostAddress,int port)
 
 }
 
-quint64 Client::subscribeTopic(const QString &topic, SimpleSubscribeCallback callback)
+quint64 Client::subscribeTopic(const QString &topic, OnSubscribedCallback onSubscribed, SimpleSubscribeCallback callback)
 {
     auto id = subscriptionIdGenerator.getId();
-    subscribeTopicSignal(id, topic, callback);
+    emit subscribeTopicSignal(id, topic, onSubscribed, callback);
     return id;
 }
 
-quint64 Client::subscribeForInvokeResponse(const QString &topic, InvokeReplyCallback callback)
+quint64 Client::subscribeForInvokeResponse(const QString &topic, OnSubscribedCallback onSubscribed, InvokeReplyCallback callback)
 {
     auto id = subscriptionIdGenerator.getId();
-    subscribeForInvokeResponseSignal(id, topic, callback);
+    emit subscribeForInvokeResponseSignal(id, topic, onSubscribed, callback);
     return id;
 }
 

--- a/templates/apigear/mqtt/mqttclient.cpp
+++ b/templates/apigear/mqtt/mqttclient.cpp
@@ -44,7 +44,7 @@ void Client::writeMessage(const QMqttTopicName& topic, const QByteArray& message
     m_client.publish(topic, message, QoS, noRetain);
 }
 
-void Client::onSubscribeTopic(quint64 id, const QString &topic, subscribeCallback callback)
+void Client::onSubscribeTopic(quint64 id, const QString &topic, SimpleSubscribeCallback callback)
 {
     auto subscription = m_client.subscribe(topic, QoS);
     auto subscribedTopic = subscription->topic();
@@ -69,7 +69,7 @@ void Client::onSubscribeTopic(quint64 id, const QString &topic, subscribeCallbac
     m_subscriptions.insert(subscription->topic(), std::make_pair(id, callback));
 }
 
-void Client::onSubscribeForInvokeResponse(quint64 id, const QString &topic, invokeReplyCallback callback)
+void Client::onSubscribeForInvokeResponse(quint64 id, const QString &topic, InvokeReplyCallback callback)
 {
     auto subscription = m_client.subscribe(topic, QoS);
     auto topicFilter = subscription->topic();
@@ -136,14 +136,14 @@ void Client::connectToHost(QString hostAddress,int port)
 
 }
 
-quint64 Client::subscribeTopic(const QString &topic, subscribeCallback callback)
+quint64 Client::subscribeTopic(const QString &topic, SimpleSubscribeCallback callback)
 {
     auto id = subscriptionIdGenerator.getId();
     subscribeTopicSignal(id, topic, callback);
     return id;
 }
 
-quint64 Client::subscribeForInvokeResponse(const QString &topic, invokeReplyCallback callback)
+quint64 Client::subscribeForInvokeResponse(const QString &topic, InvokeReplyCallback callback)
 {
     auto id = subscriptionIdGenerator.getId();
     subscribeForInvokeResponseSignal(id, topic, callback);

--- a/templates/apigear/mqtt/mqttclient.h
+++ b/templates/apigear/mqtt/mqttclient.h
@@ -32,18 +32,18 @@ public:
     /** dtor */
     virtual ~Client() override = default;
     // An alias for callback, necessary for signals/slots, which don't handle well function parameters with "const". 
-    using subscribeCallback = std::function<void(const nlohmann::json&)>;
+    using SimpleSubscribeCallback = std::function<void(const nlohmann::json&)>;
     // An alias for callback, necessary for signals/slots, which don't handle well function parameters with "const".
-    using invokeReplyCallback = std::function<void(const nlohmann::json&, quint64)>;
+    using InvokeReplyCallback = std::function<void(const nlohmann::json&, quint64)>;
 public slots:
     // Internal handler for internal messageToWriteWithProperties signal emitted during invoke requests.
     void writeMessageWithProperties(const QMqttTopicName& topic, const QByteArray& message, const QMqttPublishProperties &properties);
     // Internal handler for internal messageToWrite signal emitted by setRemoteProperty.
     void writeMessage(const QMqttTopicName& topic, const QByteArray& message);
     // Internal handler for internal subscribeTopicSignal signal, emitted by  subscribeTopic method.
-    void onSubscribeTopic(quint64 id, const QString &topic, subscribeCallback callback);
+    void onSubscribeTopic(quint64 id, const QString &topic, SimpleSubscribeCallback callback);
     // Internal handler of subscribeForInvokeResponseSignal signal, emitted by subscribeForInvokeResponse method.
-    void onSubscribeForInvokeResponse(quint64 id, const QString &topic, invokeReplyCallback callback);
+    void onSubscribeForInvokeResponse(quint64 id, const QString &topic, InvokeReplyCallback callback);
     // Internal handler for an unsubscribeTopic signal.
     void onUnsubscribedTopic(quint64 subscriptionId);
 
@@ -61,9 +61,9 @@ signals:
     // Internal signal for publishing messages. Used to allow multi thread safe use.
     void messageToWrite(const QMqttTopicName& topic, const QByteArray& message);
     // Internal signal emitted by subscribeTopic. Used to allow multi thread safe use.
-    void subscribeTopicSignal(quint64 id, const QString &topic, subscribeCallback callback);
+    void subscribeTopicSignal(quint64 id, const QString &topic, SimpleSubscribeCallback callback);
     // Internal signal emitted by subscribeForInvokeTopic. Used to allow multi thread safe use.
-    void subscribeForInvokeResponseSignal(quint64 id, const QString &topic, invokeReplyCallback callback);
+    void subscribeForInvokeResponseSignal(quint64 id, const QString &topic, InvokeReplyCallback callback);
     /**
     * Unsubscribes the callback from a topic, and the topic if there is no more callbacks subscribed to it.
     * @param id. A subscription id of a subscribed callback for a topic.
@@ -95,7 +95,7 @@ public:
     * NOTE Remember to unsubscribe the callback with an id given here as a parameter.
     * WARNING make sure that client is already connected.
     */
-    quint64 subscribeTopic(const QString &topic, subscribeCallback callback);
+    quint64 subscribeTopic(const QString &topic, SimpleSubscribeCallback callback);
     /**
     * Subscribes for receiving topic and provides a callback to be executed on receiving topic.
     * May subscribe many callbacks for same topic, all of subscribed callbacks will be executed on receiving the message.
@@ -104,7 +104,7 @@ public:
     * @return an Id for this subscription. Remember to unsubscribe the callback with this id.
     * WARNING make sure that client is already connected.
     */
-    quint64 subscribeForInvokeResponse(const QString &topic, invokeReplyCallback callback);
+    quint64 subscribeForInvokeResponse(const QString &topic, InvokeReplyCallback callback);
 
     /**
     * Publishes message, use requesting for a property of your interface to change.
@@ -139,9 +139,9 @@ private:
     /**The basic implementation of a Mqtt client, which gets adapted to expose interface as a service.*/
     QMqttClient m_client;
     /** Storage for subscribed topics for signals and property changes with their callbacks and subscription identifiers.*/
-    QMultiMap<QMqttTopicFilter, std::pair<quint64, subscribeCallback>> m_subscriptions;
+    QMultiMap<QMqttTopicFilter, std::pair<quint64, SimpleSubscribeCallback>> m_subscriptions;
     /** All invoke responses topic subscriptions and ids for them, stored by the topic*/
-    QMultiMap<QMqttTopicFilter, std::pair<quint64, invokeReplyCallback>> m_invokeReplySubscriptions;
+    QMultiMap<QMqttTopicFilter, std::pair<quint64, InvokeReplyCallback>> m_invokeReplySubscriptions;
     /** Object used to generate ids subscriptions.*/
     UniqueIdGenerator subscriptionIdGenerator;
     /** Object used to generate ids for awaited method invocation responses callbacks.*/

--- a/templates/apigear/mqtt/mqttservice.cpp
+++ b/templates/apigear/mqtt/mqttservice.cpp
@@ -74,7 +74,7 @@ void ServiceAdapter::writeMessage(const QMqttTopicName& topic, const QByteArray&
     m_client.publish(topic, message, QoS, retain);
 }
 
-void ServiceAdapter::onSubscribeTopic(quint64 id, const QString &topic, SimpleSubscribeCallback callback)
+void ServiceAdapter::onSubscribeTopic(quint64 id, const QString &topic, OnSubscribedCallback onSubscribed, SimpleSubscribeCallback callback)
 {
     auto subscription = m_client.subscribe(topic, QoS);
     auto subscribedTopic = subscription->topic();
@@ -98,7 +98,7 @@ void ServiceAdapter::onSubscribeTopic(quint64 id, const QString &topic, SimpleSu
     m_subscriptions.insert(subscription->topic(), std::make_pair(id, callback));
 }
 
-void ServiceAdapter::onSubscribeForInvokeTopic(quint64 id, const QString &topic, InvokeSubscribeCallback callback)
+void ServiceAdapter::onSubscribeForInvokeTopic(quint64 id, const QString &topic, OnSubscribedCallback onSubscribed, InvokeSubscribeCallback callback)
 {
     auto subscription = m_client.subscribe(topic, QoS);
     auto topicFilter = subscription->topic();
@@ -127,17 +127,17 @@ void ServiceAdapter::connectToHost(QString hostAddress,int port)
 
 }
 
-quint64 ServiceAdapter::subscribeTopic(const QString &topic, SimpleSubscribeCallback callback)
+quint64 ServiceAdapter::subscribeTopic(const QString &topic, OnSubscribedCallback onSubscribed, SimpleSubscribeCallback callback)
 {
     auto id = subscriptionIdGenerator.getId();
-    subscribeTopicSignal(id, topic, callback);
+    emit subscribeTopicSignal(id, topic, onSubscribed, callback);
     return id;
 }
 
-quint64 ServiceAdapter::subscribeForInvokeTopic(const QString &topic, InvokeSubscribeCallback callback){
+quint64 ServiceAdapter::subscribeForInvokeTopic(const QString &topic, OnSubscribedCallback onSubscribed, InvokeSubscribeCallback callback){
 
     auto id = subscriptionIdGenerator.getId();
-    subscribeForInvokeTopicSignal(id,topic, callback);
+    emit subscribeForInvokeTopicSignal(id, topic, onSubscribed, callback);
     return id;
 }
 

--- a/templates/apigear/mqtt/mqttservice.cpp
+++ b/templates/apigear/mqtt/mqttservice.cpp
@@ -127,14 +127,14 @@ void ServiceAdapter::connectToHost(QString hostAddress,int port)
 
 }
 
-quint64 ServiceAdapter::subscribeTopic(const QString &topic, std::function<void(const nlohmann::json&)> callback)
+quint64 ServiceAdapter::subscribeTopic(const QString &topic, SimpleSubscribeCallback callback)
 {
     auto id = subscriptionIdGenerator.getId();
     subscribeTopicSignal(id, topic, callback);
     return id;
 }
 
-quint64 ServiceAdapter::subscribeForInvokeTopic(const QString &topic, std::function<nlohmann::json(const nlohmann::json&)> callback){
+quint64 ServiceAdapter::subscribeForInvokeTopic(const QString &topic, InvokeSubscribeCallback callback){
 
     auto id = subscriptionIdGenerator.getId();
     subscribeForInvokeTopicSignal(id,topic, callback);

--- a/templates/mqtt/CMakeLists.txt.tpl
+++ b/templates/mqtt/CMakeLists.txt.tpl
@@ -39,6 +39,10 @@ target_include_directories({{$lib_id}}
     $<INSTALL_INTERFACE:include/{{$module_id}}>
 )
 
+if (ENABLE_MQTT_TEST_FOR_NON_LINUX_OS OR ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")))
+add_subdirectory(tests)
+endif()
+
 target_link_libraries({{$lib_id}} PUBLIC {{$module_id}}::{{$module_id}}_api apigear::apigear_mqtt Qt6::Concurrent)
 target_compile_definitions({{$lib_id}} PRIVATE {{$MODULE_ID}}_LIBRARY)
 

--- a/templates/mqtt/mqttadapter.cpp.tpl
+++ b/templates/mqtt/mqttadapter.cpp.tpl
@@ -26,6 +26,7 @@ const QString InterfaceName = "{{$module}}/{{$iface}}";
 {{$class}}::{{$class}}(ApiGear::Mqtt::ServiceAdapter& mqttServiceAdapter, std::shared_ptr<Abstract{{$iface}}> impl, QObject *parent)
     : QObject(parent)
     , m_impl(impl)
+    , m_finishedInitialization(false)
     , m_mqttServiceAdapter(mqttServiceAdapter)
 {
     if (m_mqttServiceAdapter.isReady())
@@ -57,12 +58,14 @@ const QString InterfaceName = "{{$module}}/{{$iface}}";
         {{- if (len .Interface.Signals) }}
         connectServiceSignals();
         {{- end }}
+        m_finishedInitialization = true;
     });
     
     connect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::disconnected, [this](){
     AG_LOG_DEBUG(Q_FUNC_INFO);
         m_subscribedIds.clear();
     });
+    m_finishedInitialization = m_mqttServiceAdapter.isReady();
 }
 
 {{$class}}::~{{$class}}()
@@ -71,6 +74,12 @@ const QString InterfaceName = "{{$module}}/{{$iface}}";
     disconnect(&m_mqttServiceAdapter, &ApiGear::Mqtt::ServiceAdapter::ready, 0, 0);
     unsubscribeAll();
 }
+
+bool {{$class}}::isReady() const
+{
+    return m_finishedInitialization && m_pendingSubscriptions.empty();
+}
+
 
 const QString& {{$class}}::interfaceName()
 {
@@ -81,7 +90,9 @@ void {{$class}}::subscribeForPropertiesChanges()
 {
     {{- range .Interface.Properties }}
     const auto setTopic_{{.Name}} = interfaceName() + "/set/{{.Name}}";
+    m_pendingSubscriptions.push_back(setTopic_{{.Name}});
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeTopic(setTopic_{{.Name}},
+        [this, setTopic_{{.Name}}](auto id, bool hasSucceed){handleOnSubscribed(setTopic_{{.Name}}, id, hasSucceed);},
         [this](const nlohmann::json& value)
         {
             {{qtReturn "" .}} {{.Name}} = value.get<{{qtReturn "" .}}>();
@@ -96,7 +107,9 @@ void {{$class}}::subscribeForInvokeRequests()
 {
     {{- range .Interface.Operations }}
     const auto invokeTopic_{{.Name}} = interfaceName() + "/rpc/{{.Name}}";
+    m_pendingSubscriptions.push_back(invokeTopic_{{.Name}});
     m_subscribedIds.push_back(m_mqttServiceAdapter.subscribeForInvokeTopic(invokeTopic_{{.Name}},
+        [this, invokeTopic_{{.Name}}](auto id, bool hasSucceed){handleOnSubscribed(invokeTopic_{{.Name}}, id, hasSucceed);},
         [this](const nlohmann::json& arguments)
         {
             {{- range  $i, $e := .Params }}
@@ -149,6 +162,25 @@ void {{$class}}::unsubscribeAll()
     for(auto id :m_subscribedIds)
     {
         m_mqttServiceAdapter.unsubscribeTopic(id);
+    }
+}
+
+void {{$class}}::handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed)
+{
+    if (!hasSucceed)
+    {
+        AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    auto iter = std::find_if(m_pendingSubscriptions.begin(), m_pendingSubscriptions.end(), [topic](auto element){return topic == element;});
+    if (iter == m_pendingSubscriptions.end()){
+         AG_LOG_WARNING("Subscription failed for  "+ topic+". Try reconnecting the client.");
+        return;
+    }
+    m_pendingSubscriptions.erase(iter);
+    if (m_finishedInitialization && m_pendingSubscriptions.empty())
+    {
+        emit ready();
     }
 }
 

--- a/templates/mqtt/mqttadapter.cpp.tpl
+++ b/templates/mqtt/mqttadapter.cpp.tpl
@@ -19,7 +19,7 @@ namespace {{qtNamespace .Module.Name }} {
 
 namespace
 {
-const QString InterfaceName = "{{$module}}/{{$iface}}";
+const QString InterfaceName = "{{$module}}/{{ .Interface.Name}}";
 }
 
 
@@ -146,7 +146,7 @@ void {{$class}}::connectServiceSignals()
 {
 {{- range .Interface.Signals }}
 {{- $signalName := camel .Name }}
-    const auto topic_{{$signalName}} = interfaceName() + "/sig/{{$signalName}}";
+    const auto topic_{{$signalName}} = interfaceName() + "/sig/{{.Name}}";
     connect(m_impl.get(), &Abstract{{$iface}}::{{$signalName}}, this,
         [this, topic_{{$signalName}}]({{qtParams "" .Params}})
         {

--- a/templates/mqtt/mqttadapter.h.tpl
+++ b/templates/mqtt/mqttadapter.h.tpl
@@ -43,7 +43,16 @@ public:
     * so adapter for an interface on client side has to have the same name.
     */
     const QString& interfaceName();
+    /**
+    * Use to check if the {{$class}} is ready to send and receive messages.
+    */
+    bool isReady() const;
 
+signals:
+    /**
+    * Informs if the {{$class}} is ready to send and receive messages.
+    */
+    void ready();
 private:
     {{- if (len .Interface.Properties) }}
     // Helper function, subscribes this adpater for property change requests from remote clients.
@@ -64,6 +73,8 @@ private:
 
     // Helper function for removing all subscriptions. 
     void unsubscribeAll();
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
     /**
     * The actual implementation of a {{$interface}} that gets adapted to be a service in mqtt network.
@@ -74,8 +85,13 @@ private:
     */
     ApiGear::Mqtt::ServiceAdapter& m_mqttServiceAdapter;
 
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
+
     /** Ids of subscribed topics */
     std::vector<quint64> m_subscribedIds;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } // namespace {{qtNamespace .Module.Name }}

--- a/templates/mqtt/mqttinterface.cpp.tpl
+++ b/templates/mqtt/mqttinterface.cpp.tpl
@@ -172,7 +172,7 @@ const QString& {{$class}}::interfaceName()
 void {{$class}}::subscribeForPropertiesChanges()
 {
     {{- range .Interface.Properties }}
-        static const QString topic{{.Name}} = interfaceName() + "/prop/{{.Name}}";
+        const QString topic{{.Name}} = interfaceName() + "/prop/{{.Name}}";
         m_subscribedIds.push_back(m_client.subscribeTopic(topic{{.Name}}, [this](auto& value) { set{{Camel .Name}}Local(value);}));
 
     {{- end }}
@@ -183,7 +183,7 @@ void {{$class}}::subscribeForPropertiesChanges()
 void {{$class}}::subscribeForSignals()
 {
     {{- range .Interface.Signals }}
-        static const QString topic{{.Name}} = interfaceName() + "/sig/{{.Name}}";
+        const QString topic{{.Name}} = interfaceName() + "/sig/{{.Name}}";
         m_subscribedIds.push_back(m_client.subscribeTopic(topic{{.Name}}, [this](const nlohmann::json& argumentsArray){
             emit {{camel .Name}}( {{- range $i, $e := .Params }}{{if $i}},{{end -}}
             argumentsArray[{{$i}}].get<{{qtReturn "" .}}>(){{- end -}});}));

--- a/templates/mqtt/mqttinterface.h.tpl
+++ b/templates/mqtt/mqttinterface.h.tpl
@@ -68,12 +68,16 @@ public:
     */
     QFuture<{{qtReturn "" .Return}}> {{camel .Name}}Async({{qtParams "" .Params}});
 {{- end }}
+    /**
+    * Use to check if the {{$class}} is ready to send and receive messages.
+    */
+    bool isReady() const;
 
 signals:
     /**
     * Informs if the {{$class}} is ready to send and receive messages.
     */
-    void isReady();
+    void ready();
 
 public:
     /**
@@ -109,9 +113,11 @@ private:
     void unsubscribeAll();
     //Helper function for handling invoke responses.
     void findAndExecuteCall(const nlohmann::json& value, quint64 callId, QString topic);
+    // Helper function for handling subsbscriptions
+    void handleOnSubscribed(QString topic, quint64 id,  bool hasSucceed);
 
-    /** An indicator if the object is linked with the service. */
-    bool m_isReady;
+    /** An indicator if the object has fisnished initialization. */
+    bool m_finishedInitialization;
     /** 
     * An abstraction layer over the connection with service for the {{$class}}.
     * Handles incoming and outgoing messages.
@@ -139,6 +145,8 @@ private:
     std::map<quint64, std::pair<QString, std::function<void(const nlohmann::json&)>>> m_pendingCallsInfo;
     /* Pending calls mutex */
     std::mutex m_pendingCallMutex;
+    /* Storage for tracking pending subscriptions */
+    std::vector<QString> m_pendingSubscriptions;
 };
 
 } //namespace {{qtNamespace .Module.Name }}

--- a/templates/mqtt/tests/CMakeLists.txt.tpl
+++ b/templates/mqtt/tests/CMakeLists.txt.tpl
@@ -1,0 +1,61 @@
+{{- $module_id := printf "%s" (snake .Module.Name) }}
+{{- $MODULE_ID := printf "%s" (SNAKE .Module.Name) }}
+cmake_minimum_required(VERSION 3.20)
+project(test_{{$module_id}}_generated_mqtt)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(BUILD_TESTING)
+include(CTest)
+enable_testing()
+
+find_package(Qt6 REQUIRED COMPONENTS Test Core)
+find_package(apigear QUIET COMPONENTS apigear_mqtt)
+find_package({{$module_id}} QUIET COMPONENTS {{$module_id}}_impl {{$module_id}}_mqtt)
+
+find_package(Catch2 REQUIRED)
+
+set(CMAKE_CTEST_COMMAND ctest -V)
+if(NOT TARGET check)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+set(TEST_{{$MODULE_ID}}_GENERATED_MQTT_SOURCES
+    test_main.cpp
+    )
+
+include_directories(test_{{$module_id}}_generated_mqtt
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+add_executable(test_{{$module_id}}_generated_mqtt ${TEST_{{$MODULE_ID}}_GENERATED_MQTT_SOURCES})
+add_test(NAME test_{{$module_id}}_generated_mqtt COMMAND $<TARGET_FILE:test_{{$module_id}}_generated_mqtt>)
+add_dependencies(check test_{{$module_id}}_generated_mqtt)
+
+target_link_libraries(test_{{$module_id}}_generated_mqtt PRIVATE
+    apigear_mqtt
+    {{$module_id}}_impl
+    {{$module_id}}_mqtt
+    Catch2::Catch2
+    Qt::Test)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_{{$module_id}}_generated_mqtt
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+
+endif() # BUILD_TESTING

--- a/templates/mqtt/tests/CMakeLists.txt.tpl
+++ b/templates/mqtt/tests/CMakeLists.txt.tpl
@@ -30,6 +30,9 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 endif()
 
 set(TEST_{{$MODULE_ID}}_GENERATED_MQTT_SOURCES
+{{- range .Module.Interfaces }}
+    test_mqtt{{lower .Name}}.cpp
+{{- end }}
     test_main.cpp
     )
 

--- a/templates/mqtt/tests/interface_test.cpp.tpl
+++ b/templates/mqtt/tests/interface_test.cpp.tpl
@@ -1,0 +1,218 @@
+{{- $class := Camel .Interface.Name  }}
+{{- $namespace := qtNamespace .Module.Name   }}
+{{- $mqttclient := printf "Mqtt%s" .Interface.Name }}
+{{- $mqttservice := printf "Mqtt%sAdapter" .Interface.Name }}
+{{- $namespacePrefix := printf "%s::" (qtNamespace .Module.Name) -}}
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include <QtCore>
+#include <QTest>
+#include <QThreadPool>
+#include "api/api.h"
+#include "api/test_struct_helper.h"
+#include "implementation/{{lower .Interface.Name}}.h"
+#include "mqtt/mqtt{{lower .Interface.Name}}.h"
+#include "mqtt/mqtt{{lower .Interface.Name}}adapter.h"
+
+{{- $listqtExterns := qtExterns .Module.Externs}}
+{{- $includes := (collectFields $listqtExterns  "Include")}}
+{{- range .Module.Imports }}
+{{- $includeName :=  printf "\"%s/api/api.h\"" (snake .Name) }}
+{{- $includeName :=  printf "\"%s/api/test_struct_helper.h\"" (snake .Name) }}
+{{- $includes = (appendList $includes  $includeName) }}
+{{- end }}
+{{- $includes = unique $includes }}
+{{ range $includes }}
+#include {{ .}}
+{{- end }}
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+{{- define "get_namespace"}}
+        {{- $module_prefix:= printf "%s" (qtNamespace .Module.Name) }}
+        {{- if (ne .Import "") }}
+        {{- $module_prefix = (qtNamespace .Import ) }}
+        {{- end}}
+        {{- $module_prefix -}}
+{{- end}}
+
+// Those tests require an external mqtt broker, which is not provided here with  the mqtt feature.
+// Before running tests make sure that the broker of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+    
+    class HandleCallTask : public QRunnable
+    {
+    public:
+        HandleCallTask(std::function<void()> func)
+            :execute(func)
+        {
+        }
+
+        void run() override
+        {
+            execute();
+        }
+
+    private:
+        std::function<void()> execute;
+    };
+
+}
+
+TEST_CASE("MQTT  {{.Module.Name}} {{$class}} tests")
+{
+    {{- if .Interface.Operations }}
+    /** A ThreadPool to handle blocking functions in separate thread. By default the thread pool size is set to one to keep order of messages guaranteed */
+    QThreadPool m_handleCallsThreads;
+    m_handleCallsThreads.setMaxThreadCount(1);
+    {{- end }}
+    ApiGear::Mqtt::ServiceAdapter service("ServiceUniqueNameInMqtt");
+    service.connectToHost("localhost", 1883);
+
+    ApiGear::Mqtt::Client client("UniqueClientName");
+    client.connectToHost("localhost", 1883);
+
+    auto client{{$class}} = std::make_shared< {{- $namespacePrefix }}{{$mqttclient}} >(client);
+    auto impl{{$class}} = std::make_shared<{{ $namespacePrefix }}{{$class}}>();
+    auto service{{$class}} = std::make_shared<{{$namespacePrefix}}{{$mqttservice}}>(service, impl{{$class}});
+
+    REQUIRE(QTest::qWaitFor([&client, &service]() {return client.isReady() && service.isReady(); }, timeout));
+    REQUIRE(QTest::qWaitFor([&client{{$class}}, &service{{$class}}]() {return client{{$class}}->isReady() && service{{$class}}->isReady(); }, timeout));
+    {{- range .Interface.Properties }}
+    {{- if and (not .IsReadOnly) (not (eq .KindType "extern")) }}
+    SECTION("Test setting {{.Name}}")
+    {
+        std::atomic<bool> is{{.Name}}Changed = false;
+        client{{$class}}->connect(client{{$class}}.get(), &{{$namespace}}::Abstract{{$class}}::{{.Name}}Changed, [&is{{.Name}}Changed ](auto value){is{{.Name}}Changed  = true;});
+        {{- if .IsArray }}
+        auto test_value = {{ qtDefault $namespacePrefix . }};
+	    {{- if not ( or ( .IsPrimitive)  (eq .KindType "enum")) }}
+        auto element = {{ qtTestValue $namespacePrefix . }};
+        {{template "get_namespace" .}}::fillTest{{.Type }}(element);
+        test_value.append(element);
+        {{- else }}  
+        test_value.append({{ qtTestValue $namespacePrefix .}});
+        {{- end }}
+	{{- else }}
+        {{- if and (not .IsPrimitive) (not (eq .KindType "enum"))}}
+        auto test_value = {{ qtDefault $namespacePrefix . }};
+        {{template "get_namespace" .}}::fillTest{{.Type}}(test_value);
+        {{- else}}
+        auto test_value = {{ qtTestValue $namespacePrefix . }};
+        {{- end }}
+	{{- end }}
+        client{{$class}}->set{{Camel .Name}}(test_value);
+        REQUIRE(QTest::qWaitFor([&is{{.Name}}Changed]() {return is{{.Name}}Changed  == true; }, timeout));
+        REQUIRE(impl{{$class}}->{{.Name}}() == test_value);
+        REQUIRE(client{{$class}}->{{.Name}}() == test_value);
+    }
+    {{- end }}
+    {{- end }}
+
+    {{- range .Interface.Signals }}
+    SECTION("Test emit {{.Name}}")
+    {
+        std::atomic<bool> is{{.Name}}Emitted = false;
+
+        {{- range $idx, $p := .Params -}}
+        {{- if .IsArray }}
+        auto local_{{snake .Name}}_array = {{ qtDefault $namespacePrefix . }};
+        {{- if not ( or (eq .KindType "extern") ( or .IsPrimitive  (eq .KindType "enum") ) )}}
+        auto element_{{$p.Name}} = {{ qtTestValue $namespacePrefix . }};
+        {{template "get_namespace" .}}::fillTest{{.Type }}(element_{{$p.Name}});
+        local_{{snake .Name}}_array .append(element_{{$p.Name}});
+        {{- else }}
+        local_{{snake .Name}}_array.append({{ qtTestValue $namespacePrefix . }});
+        {{- end }}
+        {{- else if not ( or (eq .KindType "extern") ( or .IsPrimitive  (eq .KindType "enum") ) )}}
+        auto local_{{snake .Name}}_struct = {{ qtDefault $namespacePrefix . }};
+        {{template "get_namespace" .}}::fillTest{{.Type }}(local_{{snake .Name}}_struct);
+        {{- end -}}
+        {{- end }}
+
+        client{{$class}}->connect(client{{$class}}.get(), &{{$namespace}}::Abstract{{$class}}::{{camel .Name}},
+        [&is{{.Name}}Emitted 
+        {{- range $idx, $p := .Params -}}
+        {{- if .IsArray }}, &local_{{snake .Name}}_array
+        {{- else if not ( or (eq .KindType "extern") ( or .IsPrimitive  (eq .KindType "enum") ) ) }}, &local_{{snake .Name}}_struct{{- end -}}
+        {{- end }}]({{qtParams $namespacePrefix .Params}})
+        {
+        {{- range $idx, $p := .Params }}
+            REQUIRE({{ .Name}} == 
+            {{- if .IsArray }} local_{{snake .Name}}_array
+            {{- else if (eq .KindType "extern") }} {{ qtDefault $namespacePrefix .}}
+            {{- else if  ( or .IsPrimitive  (eq .KindType "enum") ) }} {{ qtTestValue $namespacePrefix . }}
+            {{- else -}} local_{{snake .Name}}_struct
+            {{- end }});
+        {{- end }}
+            is{{.Name}}Emitted  = true;
+        });
+
+        emit impl{{$class}}->{{camel .Name}}(
+    {{- range $idx, $p := .Params -}}
+            {{- if $idx }}, {{end -}}
+            {{- if .IsArray }}local_{{snake .Name}}_array
+            {{- else if (eq .KindType "extern") }}{{ qtDefault $namespacePrefix .}}
+            {{- else if  ( or .IsPrimitive  (eq .KindType "enum") ) }}{{ qtTestValue $namespacePrefix . }}
+            {{- else -}}
+            local_{{snake .Name}}_struct
+            {{- end -}}
+    {{- end -}}
+        );
+        REQUIRE(QTest::qWaitFor([&is{{.Name}}Emitted ]() {return is{{.Name}}Emitted   == true; }, timeout));
+    }
+    {{- end }}
+
+    {{- range .Interface.Operations }}
+    SECTION("Test method {{.Name}}")
+    {
+        std::atomic<bool> finished = false;
+        auto* task = new HandleCallTask([client{{$class}}, &finished](){
+            {{ if (not .Return.IsVoid) }}[[maybe_unused]] auto result = {{ end }}client{{$class}}->{{camel .Name}}(
+    {{- range $idx, $p := .Params -}}
+            {{- if $idx }}, {{end -}}
+            {{ qtDefault $namespacePrefix .}}
+    {{- end -}}
+        );
+            finished = true;
+        });
+        task->setAutoDelete(true);
+        m_handleCallsThreads.start(task);
+        REQUIRE(QTest::qWaitFor([&finished ]() {return finished == true; }, timeout));
+        // CHECK EFFECTS OF YOUR METHOD HERE
+
+
+    }
+    SECTION("Test method {{.Name}} async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = client{{$class}}->{{camel .Name}}Async(
+    {{- range $idx, $p := .Params -}}
+            {{- if $idx }}, {{end -}}
+            {{ qtDefault $namespacePrefix .}}
+    {{- end -}}
+        );
+        resultFuture.then([&finished]({{if (not .Return.IsVoid) }}{{qtReturn $namespacePrefix .Return}} /*res*/{{ end }}){finished = true;});
+        REQUIRE(QTest::qWaitFor([&finished ](){ return finished == true; }, timeout));
+        {{- if (not .Return.IsVoid) }}
+        auto return_value = resultFuture.result();
+        REQUIRE(return_value == {{ qtDefault $namespacePrefix .Return }});
+        {{- end }}
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    {{- end }}
+
+    client{{$class}}.reset();
+    service{{$class}}.reset();
+    client.disconnect();
+    service.disconnect();
+}

--- a/templates/mqtt/tests/test_main.cpp
+++ b/templates/mqtt/tests/test_main.cpp
@@ -1,0 +1,12 @@
+#define CATCH_CONFIG_RUNNER
+
+#include <QCoreApplication>
+#include <catch2/catch.hpp>
+
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv); // -platform offscreen
+    int result = Catch::Session().run(argc, argv); // --break
+    return result;
+}


### PR DESCRIPTION
Introduces generated tests for mqtt interfaces.
CI tests it only on linux, locally it was also tested on windows.
Fixes an mqtt implementation:
- adds isReady function and ready() singal for the interface adapters - which mean all the subscriptions for topic are finished
- fixes asynchronous version of remote calling methods

A ticket #96 was open while implementing tests for synchronous method. The tests are using thread for synchronous version call which uses asynchronous method version inside. This is caused because waiting for future result blocks thread in which the mqtt client would like to send a message.

Closes #89

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->